### PR TITLE
SCP-2669: Delete beAddressMap from BlockchainEnv in plutus-pab.

### DIFF
--- a/plutus-contract/src/Wallet/Emulator/Wallet.hs
+++ b/plutus-contract/src/Wallet/Emulator/Wallet.hs
@@ -130,7 +130,11 @@ walletMockWallet (Wallet wid) = find ((==) wid . WalletId . CW.mwWalletId) CW.kn
 
 -- | The public key hash of a mock wallet.  (Fails if the wallet is not a mock wallet).
 walletPubKeyHash :: Wallet -> PubKeyHash
-walletPubKeyHash = CW.pubKeyHash . fromMaybe (error "walletPubKeyHash: Wallet is not a mock wallet") . walletMockWallet
+walletPubKeyHash w = CW.pubKeyHash
+                 $ fromMaybe (error $ "Wallet.Emulator.Wallet.walletPubKeyHash: Wallet "
+                                   <> show w
+                                   <> " is not a mock wallet")
+                 $ walletMockWallet w
 
 -- | Get the address of a mock wallet. (Fails if the wallet is not a mock wallet).
 walletAddress :: Wallet -> Address

--- a/plutus-ledger/src/Ledger/CardanoWallet.hs
+++ b/plutus-ledger/src/Ledger/CardanoWallet.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE TypeApplications   #-}
 {-# LANGUAGE TypeFamilies       #-}
 
 {- Cardano wallet implementation for the emulator.
@@ -76,7 +75,7 @@ fromSeed bs = MockWallet{mwWalletId, mwKey} where
     missing = max 0 (32 - BS.length bs)
     bs' = bs <> BS.replicate missing 0
     mwWalletId = CW.WalletId
-        $ fromMaybe (error "CardanoWallet: fromSeed: digestFromByteString")
+        $ fromMaybe (error "Ledger.CardanoWallet.fromSeed: digestFromByteString")
         $ Crypto.digestFromByteString
         $ Crypto.hashWith Crypto.Blake2b_160
         $ getLedgerBytes
@@ -86,7 +85,10 @@ fromSeed bs = MockWallet{mwWalletId, mwKey} where
     mwKey = MockPrivateKey k
 
 toWalletNumber :: MockWallet -> WalletNumber
-toWalletNumber MockWallet{mwWalletId=w} = maybe (error "toWalletNumber: not a known wallet") (WalletNumber . toInteger . succ) $ findIndex ((==) w . mwWalletId) knownWallets
+toWalletNumber MockWallet{mwWalletId=w} =
+    maybe (error "Ledger.CardanoWallet.toWalletNumber: not a known wallet")
+          (WalletNumber . toInteger . succ)
+          $ findIndex ((==) w . mwWalletId) knownWallets
 
 -- | The wallets used in mockchain simulations by default. There are
 --   ten wallets by default.

--- a/plutus-pab/src/Plutus/PAB/Webserver/Types.hs
+++ b/plutus-pab/src/Plutus/PAB/Webserver/Types.hs
@@ -19,7 +19,6 @@ import           GHC.Generics                            (Generic)
 import           Ledger                                  (PubKeyHash, Tx, TxId)
 import           Ledger.Index                            (UtxoIndex)
 import           Ledger.Slot                             (Slot)
-import           Ledger.Value                            (Value)
 import           Playground.Types                        (FunctionSchema)
 import           Plutus.Contract.Effects                 (ActiveEndpoint, PABReq)
 import           Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse)
@@ -108,7 +107,6 @@ data InstanceStatusToClient
 data CombinedWSStreamToClient
     = InstanceUpdate ContractInstanceId InstanceStatusToClient
     | SlotChange Slot -- ^ New slot number
-    | PubKeyHashFundsChange PubKeyHash Value -- ^ The funds at the pubkeyhash address have changed
     deriving stock (Generic, Eq, Show)
     deriving anyclass (ToJSON, FromJSON)
 


### PR DESCRIPTION
* New PAB action `valueAt` where we can query the value at a specific wallet which replaces the beAddressMap field in BlockchainEnv.

* Deleted PubKeyHashFundsChange in Webserver stream. Upstream code which uses that should now use the new `valueAt` PAB action.

* Added plutus-pab testing for `valueAt`.

* More precise error message in cardano wallet code.

@nau Redoing this PR in plutus-apps following the repo split. This PR will affect `marlowe-dashboard` from what I remember.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
