### PR TITLE
Make z3 available for static analysis in the Marlowe playground.

### DIFF
--- a/bitte/plutus-playground-server.nix
+++ b/bitte/plutus-playground-server.nix
@@ -1,7 +1,7 @@
-{ writeShellScriptBin, pkg, variant, symlinkJoin, lib, cacert }:
+{ writeShellScriptBin, pkg, variant, symlinkJoin, lib, cacert, z3 }:
 
 let
-  deps = [ pkg ];
+  deps = [ pkg z3 ];
   entrypoint = writeShellScriptBin "entrypoint" ''
     export PATH=${lib.makeBinPath deps}
     export SYSTEM_CERTIFICATE_PATH=${cacert}/etc/ssl/certs/ca-bundle.crt


### PR DESCRIPTION
This is already deployed, somehow slipped through getting merged into master prior to the split.