### PR TITLE
Chain Index app: query the tip of the node for first response before start

### DIFF
--- a/plutus-chain-index/app/Main.hs
+++ b/plutus-chain-index/app/Main.hs
@@ -34,8 +34,10 @@ import qualified Cardano.BM.Configuration.Model  as CM
 import           Cardano.BM.Setup                (setupTrace_)
 import           Cardano.BM.Trace                (Trace, logDebug, logError)
 
-import           Cardano.Api                     (ChainPoint)
+import           Cardano.Api                     (ChainPoint, ChainTip (..), ConsensusModeParams (..),
+                                                  LocalNodeConnectInfo (..), getLocalChainTip)
 import           Cardano.Protocol.Socket.Client  (ChainSyncEvent (..), runChainSync)
+import           Cardano.Protocol.Socket.Type    (epochSlots)
 import           CommandLine                     (AppConfig (..), Command (..), applyOverrides, cmdWithHelpParser)
 import qualified Config
 import           Ledger                          (Slot (..))
@@ -134,6 +136,17 @@ main = do
 
       putStrLn "\nChain Index config:"
       print (pretty config)
+
+      -- The printed slot number is only half helpful.
+      -- The primary purpose of this query is to get the first response of the node for potential errors before opening the DB and starting the chain index.
+      -- See #69.
+      putStrLn "\nQuery the tip of the local node:"
+      ChainTip slotNo _ _ <- getLocalChainTip $ LocalNodeConnectInfo
+        { localConsensusModeParams = CardanoModeParams epochSlots
+        , localNodeNetworkId = Config.cicNetworkId config
+        , localNodeSocketPath = Config.cicSocketPath config
+        }
+      print slotNo
 
       Sqlite.withConnection (Config.cicDbPath config) $ \conn -> do
 

--- a/plutus-chain-index/app/Main.hs
+++ b/plutus-chain-index/app/Main.hs
@@ -140,7 +140,7 @@ main = do
       -- The printed slot number is only half helpful.
       -- The primary purpose of this query is to get the first response of the node for potential errors before opening the DB and starting the chain index.
       -- See #69.
-      putStrLn "\nQuery the tip of the local node:"
+      putStr "\nThe tip of the local node: "
       ChainTip slotNo _ _ <- getLocalChainTip $ LocalNodeConnectInfo
         { localConsensusModeParams = CardanoModeParams epochSlots
         , localNodeNetworkId = Config.cicNetworkId config


### PR DESCRIPTION
This work is part of #69.

The printed slot number is only half helpful. The primary purpose of this query is to get the first response of the node for potential errors before opening the DB and starting the chain index.

When the socket does not exist:
```
Query the tip of the local node: 
plutus-chain-index: Network.Socket.connect: <socket: 78>: does not exist (No such file or directory)
```

When the network magics do not match:
```
Query the tip of the local node: 
plutus-chain-index: HandshakeError (Refused NodeToClientV_9 "version data mismatch: NodeToClientVersionData {networkMagic = NetworkMagic {unNetworkMagic = 1097911063}} /= NodeToClientVersionData {networkMagic = NetworkMagic {unNetworkMagic = 1097911062}}")
```

When it works:
```
Query the tip of the local node:
SlotNo 41320486
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
