### PR TITLE
PAB: More consistent slot configs

### DIFF
--- a/plutus-chain-index/src/Plutus/ChainIndex/Config.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Config.hs
@@ -58,7 +58,7 @@ defaultConfig = ChainIndexConfig
   , cicSecurityParam = 2160
   , cicSlotConfig =
       SlotConfig
-        { scSlotZeroTime = 1591566291000
+        { scSlotZeroTime = 1596059091000
         , scSlotLength   = 1000
         }
   }

--- a/plutus-contract/src/Wallet/Emulator/Types.hs
+++ b/plutus-contract/src/Wallet/Emulator/Types.hs
@@ -106,6 +106,6 @@ processEmulated slotCfg feeCfg act =
         & reinterpret2 @ChainEffect @(State ChainState) @(LogMsg ChainEvent) (handleChain slotCfg)
         & interpret (Eff.handleZoomedState chainState)
         & interpret (mapLog (review chainEvent))
-        & reinterpret2 @ChainControlEffect @(State ChainState) @(LogMsg ChainEvent) handleControlChain
+        & reinterpret2 @ChainControlEffect @(State ChainState) @(LogMsg ChainEvent) (handleControlChain slotCfg)
         & interpret (Eff.handleZoomedState chainState)
         & interpret (mapLog (review chainEvent))

--- a/plutus-contract/src/Wallet/Emulator/Wallet.hs
+++ b/plutus-contract/src/Wallet/Emulator/Wallet.hs
@@ -51,7 +51,7 @@ import Ledger.Constraints.OffChain (UnbalancedTx (..))
 import Ledger.Constraints.OffChain qualified as U
 import Ledger.Credential (Credential (..))
 import Ledger.Fee (FeeConfig (..), calcFees)
-import Ledger.TimeSlot (posixTimeRangeToContainedSlotRange)
+import Ledger.TimeSlot (SlotConfig, posixTimeRangeToContainedSlotRange)
 import Ledger.Tx qualified as Tx
 import Ledger.Value qualified as Value
 import Plutus.ChainIndex (PageQuery)
@@ -210,7 +210,7 @@ handleWallet feeCfg = \case
         slotConfig <- WAPI.getClientSlotConfig
         let validitySlotRange = posixTimeRangeToContainedSlotRange slotConfig (utx' ^. U.validityTimeRange)
         let utx = utx' & U.tx . validRange .~ validitySlotRange
-        utxWithFees <- validateTxAndAddFees feeCfg utxo utx
+        utxWithFees <- validateTxAndAddFees feeCfg slotConfig utxo utx
         -- balance to add fees
         tx' <- handleBalanceTx utxo (utx & U.tx . fee .~ (utxWithFees ^. U.tx . fee))
         tx'' <- handleAddSignature tx'
@@ -260,15 +260,16 @@ validateTxAndAddFees ::
     , Member (State WalletState) effs
     )
     => FeeConfig
+    -> SlotConfig
     -> Map.Map TxOutRef ChainIndexTxOut
     -> UnbalancedTx
     -> Eff effs UnbalancedTx
-validateTxAndAddFees feeCfg ownTxOuts utx = do
+validateTxAndAddFees feeCfg slotCfg ownTxOuts utx = do
     -- Balance and sign just for validation
     tx <- handleBalanceTx ownTxOuts utx
     signedTx <- handleAddSignature tx
     let utxoIndex        = Ledger.UtxoIndex $ unBalancedTxUtxoIndex utx <> (toTxOut <$> ownTxOuts)
-        ((e, _), events) = Ledger.runValidation (Ledger.validateTransactionOffChain signedTx) utxoIndex
+        ((e, _), events) = Ledger.runValidation (Ledger.validateTransactionOffChain signedTx) (Ledger.ValidationCtx utxoIndex slotCfg)
     for_ e $ \(phase, ve) -> do
         logWarn $ ValidationFailed phase (txId tx) tx ve events
         throwError $ WAPI.ValidationError ve

--- a/plutus-contract/test/Spec/Emulator.hs
+++ b/plutus-contract/test/Spec/Emulator.hs
@@ -116,7 +116,7 @@ pubKey3 = walletPubKeyHash wallet3
 
 utxo :: Property
 utxo = property $ do
-    Mockchain txPool o <- forAll Gen.genMockchain
+    Mockchain txPool o _ <- forAll Gen.genMockchain
     Hedgehog.assert (unspentOutputs [map Valid txPool] == o)
 
 txnValid :: Property
@@ -153,7 +153,7 @@ selectCoinProp = property $ do
 
 txnUpdateUtxo :: Property
 txnUpdateUtxo = property $ do
-    (Mockchain m _, txn) <- forAll genChainTxn
+    (Mockchain m _ _, txn) <- forAll genChainTxn
     let options = defaultCheckOptions & emulatorConfig . Trace.initialChainState .~ Right m
 
         -- submit the same txn twice, so it should be accepted the first time
@@ -173,14 +173,14 @@ txnUpdateUtxo = property $ do
 
 validTrace :: Property
 validTrace = property $ do
-    (Mockchain m _, txn) <- forAll genChainTxn
+    (Mockchain m _ _, txn) <- forAll genChainTxn
     let options = defaultCheckOptions & emulatorConfig . Trace.initialChainState .~ Right m
         trace = Trace.liftWallet wallet1 (submitTxn $ Right txn)
     checkPredicateInner options assertNoFailedTransactions trace Hedgehog.annotate Hedgehog.assert
 
 validTrace2 :: Property
 validTrace2 = property $ do
-    (Mockchain m _, txn) <- forAll genChainTxn
+    (Mockchain m _ _, txn) <- forAll genChainTxn
     let options = defaultCheckOptions & emulatorConfig . Trace.initialChainState .~ Right m
         trace = do
             Trace.liftWallet wallet1 (submitTxn $ Right txn)
@@ -190,7 +190,7 @@ validTrace2 = property $ do
 
 invalidTrace :: Property
 invalidTrace = property $ do
-    (Mockchain m _, txn) <- forAll genChainTxn
+    (Mockchain m _ _, txn) <- forAll genChainTxn
     let invalidTxn = txn { txMint = Ada.adaValueOf 1 }
         options = defaultCheckOptions & emulatorConfig . Trace.initialChainState .~ Right m
         trace = Trace.liftWallet wallet1 (submitTxn $ Right invalidTxn)
@@ -205,7 +205,7 @@ invalidTrace = property $ do
 
 invalidScript :: Property
 invalidScript = property $ do
-    (Mockchain m _, txn1) <- forAll genChainTxn
+    (Mockchain m _ _, txn1) <- forAll genChainTxn
 
     -- modify one of the outputs to be a script output
     index <- forAll $ Gen.int (Range.linear 0 ((length $ txOutputs txn1) -1))

--- a/plutus-pab/plutus-pab.yaml.sample
+++ b/plutus-pab/plutus-pab.yaml.sample
@@ -22,7 +22,7 @@ nodeServerConfig:
   mscKeptBlocks: 100
   mscNetworkId: "1097911063" # Testnet network ID (main net = empty string)
   mscSlotConfig:
-    scSlotZeroTime: 1591566291000 # Wednesday, July 29, 2020 21:44:51 - shelley launch time in milliseconds
+    scSlotZeroTime: 1596059091000 # Wednesday, July 29, 2020 21:44:51 - shelley launch time in milliseconds
     scSlotLength: 1000 # In milliseconds
   mscFeeConfig:
     fcConstantFee:

--- a/plutus-pab/src/Cardano/Chain.hs
+++ b/plutus-pab/src/Cardano/Chain.hs
@@ -83,15 +83,15 @@ handleControlChain ::
      , Member (LogMsg EC.ChainEvent) effs
      , LastMember m effs
      , MonadIO m )
-  => EC.ChainControlEffect ~> Eff effs
-handleControlChain = \case
+  => SlotConfig -> EC.ChainControlEffect ~> Eff effs
+handleControlChain slotCfg = \case
     EC.ProcessBlock -> do
         st <- get
         let pool  = st ^. txPool
             slot  = st ^. currentSlot
             idx   = st ^. index
             EC.ValidatedBlock block events rest =
-                EC.validateBlock slot idx pool
+                EC.validateBlock slotCfg slot idx pool
 
         let st' = st & txPool .~ rest
                      & tip    ?~ block

--- a/plutus-pab/src/Cardano/Node/Mock.hs
+++ b/plutus-pab/src/Cardano/Node/Mock.hs
@@ -88,7 +88,7 @@ runChainEffects trace slotCfg clientHandler stateVar eff = do
             runChain = interpret (mapLog ProcessingChainEvent)
                      . reinterpret (handleChain slotCfg)
                      . interpret (mapLog ProcessingChainEvent)
-                     . reinterpret handleControlChain
+                     . reinterpret (handleControlChain slotCfg)
 
             mergeState = interpret (handleZoomedState chainState)
 

--- a/plutus-pab/src/Cardano/Node/Server.hs
+++ b/plutus-pab/src/Cardano/Node/Server.hs
@@ -67,7 +67,7 @@ main trace MockServerConfig { mscBaseUrl
             { _chainState = initialState
             , _eventHistory = mempty
             }
-    serverHandler <- liftIO $ Server.runServerNode trace mscSocketPath mscKeptBlocks (_chainState appState)
+    serverHandler <- liftIO $ Server.runServerNode trace mscSocketPath mscKeptBlocks (_chainState appState) mscSlotConfig
     serverState   <- liftIO $ newMVar appState
     handleDelayEffect $ delayThread (2 :: Second)
     clientHandler <- liftIO $ Client.runTxSender mscSocketPath

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -485,7 +485,7 @@ runChainEffects slotCfg action = do
                                 $ runWriter @[LogMessage Chain.ChainEvent]
                                 $ reinterpret @(LogMsg Chain.ChainEvent) @(Writer [LogMessage Chain.ChainEvent]) (handleLogWriter _singleton)
                                 $ runState oldState
-                                $ interpret Chain.handleControlChain
+                                $ interpret (Chain.handleControlChain slotCfg)
                                 $ interpret (Chain.handleChain slotCfg) action
                         STM.writeTVar _chainState newState
                         pure (a, logs)

--- a/plutus-pab/sync-client/Main.hs
+++ b/plutus-pab/sync-client/Main.hs
@@ -32,7 +32,7 @@ data Configuration = Configuration
 slotConfig :: SlotConfig
 slotConfig =
   SlotConfig
-    { scSlotZeroTime = 1591566291000
+    { scSlotZeroTime = 1596059091000
     , scSlotLength   = 1000
     }
 

--- a/plutus-pab/test-node/testnet/chain-index-config.json
+++ b/plutus-pab/test-node/testnet/chain-index-config.json
@@ -1,7 +1,7 @@
 {
   "cicSlotConfig": {
     "scSlotLength": 1000,
-    "scSlotZeroTime": 1591566291000
+    "scSlotZeroTime": 1596059091000
   },
   "cicPort": 9083,
   "cicSecurityParam": 2160,

--- a/plutus-pab/test-node/testnet/pab-config.yml
+++ b/plutus-pab/test-node/testnet/pab-config.yml
@@ -22,7 +22,7 @@ nodeServerConfig:
   mscKeptBlocks: 2160
   mscNetworkId: "1097911063" # Testnet network ID (main net = empty string)
   mscSlotConfig:
-    scSlotZeroTime: 1591566291000 # Wednesday, July 29, 2020 21:44:51 - shelley launch time in milliseconds
+    scSlotZeroTime: 1596059091000 # Wednesday, July 29, 2020 21:44:51 - shelley launch time in milliseconds
     scSlotLength: 1000 # In milliseconds
   mscFeeConfig:
     fcConstantFee:

--- a/plutus-pab/tx-inject/TxInject/RandomTx.hs
+++ b/plutus-pab/tx-inject/TxInject/RandomTx.hs
@@ -24,7 +24,7 @@ import Ledger.Address qualified as Address
 import Ledger.CardanoWallet qualified as CW
 import Ledger.Crypto (PrivateKey, PubKey)
 import Ledger.Generators qualified as Generators
-import Ledger.Index (UtxoIndex (..), runValidation, validateTransaction)
+import Ledger.Index (UtxoIndex (..), ValidationCtx (..), runValidation, validateTransaction)
 import Ledger.Slot (Slot (..))
 import Ledger.Tx (Tx, TxOut (..))
 import Ledger.Tx qualified as Tx
@@ -88,8 +88,9 @@ generateTx gen slot (UtxoIndex utxo) = do
         sourceTxIns = Set.fromList $ fmap (Tx.pubKeyTxIn . fst) inputs
     tx <- Gen.sample $
       Generators.genValidTransactionSpending sourceTxIns sourceAda
+    slotCfg <- Gen.sample Generators.genSlotConfig
     let ((validationResult, _), _) =
-          runValidation (validateTransaction slot tx) (UtxoIndex utxo)
+          runValidation (validateTransaction slot tx) (ValidationCtx (UtxoIndex utxo) slotCfg)
     case validationResult of
       Nothing -> pure tx
       Just  _ -> generateTx gen slot (UtxoIndex utxo)

--- a/plutus-pab/tx-inject/config.yaml
+++ b/plutus-pab/tx-inject/config.yaml
@@ -18,7 +18,7 @@ nodeServerConfig:
   mscKeptBlocks: 100000
   mscNetworkId: "1097911063"
   mscSlotConfig:
-    scSlotZeroTime: 1591566291000 # Wednesday, July 29, 2020 21:44:51 - shelley launch time in milliseconds
+    scSlotZeroTime: 1596059091000 # Wednesday, July 29, 2020 21:44:51 - shelley launch time in milliseconds
     scSlotLength: 1000 # In milliseconds
   mscFeeConfig:
     fcConstantFee:


### PR DESCRIPTION
This PR attempts to fix a misconfigured slot config issue we found while working with PAB. It started with a wrong Shelley launch time in `plutus-pab/plutus-pab.yaml.sample`, which leads to weird off-chain validation errors when we use `mustValidateIn` constraints.

The quick fix was to update the config file with the "correct" Shelley launch date, but this PR provides the general fix that removes the bug for good.

The flow starts with `mustValidateIn`, which adds the validity range to the `UnbalancedTx`:
https://github.com/input-output-hk/plutus-apps/blob/942bd8c6de6a2d5981d91c704b0258bddd9d9d7c/plutus-ledger/src/Ledger/Constraints/OffChain.hs#L505-L506

Which is eventually balanced here:
https://github.com/input-output-hk/plutus-apps/blob/942bd8c6de6a2d5981d91c704b0258bddd9d9d7c/plutus-contract/src/Wallet/Emulator/Wallet.hs#L202-L208

We can see that the original validity interval is translated to a slot range using the PAB's slot config before being set to `UnbalancedTx`'s internal `tx`'s validity range.

Fast forward through `validateTxAndAddFees`, then `validateTransactionOffChain`, then `checkMintingScripts`, then `mkTxInfo` we end up re-converting the slot range, but with the default slot config!
https://github.com/input-output-hk/plutus-apps/blob/ecc528ec38f42dee056ccb072abd41a64b640425/plutus-ledger/src/Ledger/Index.hs#L396

When the PAB's slot config does not match the default, this mismatch modifies the intended validity interval, and off-chain validates the transaction with it, which effectively makes the config not configurable.
https://github.com/input-output-hk/plutus-apps/blob/f4893f8713d299020d9e6d059dd956f30c11dca1/plutus-ledger/src/Ledger/TimeSlot.hs#L54-L56

Luckily the addition of `SlotConfig` to the existing API is pretty natural and matches previous works.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
