### PR TITLE
Don't use default slotConfig where this was easily fixable.

### DIFF
--- a/plutus-contract/src/Plutus/Contract/StateMachine.hs
+++ b/plutus-contract/src/Plutus/Contract/StateMachine.hs
@@ -55,7 +55,6 @@ module Plutus.Contract.StateMachine(
 import Control.Lens
 import Control.Monad.Error.Lens
 import Data.Aeson (FromJSON, ToJSON)
-import Data.Default (Default (def))
 import Data.Either (rights)
 import Data.Map (Map)
 import Data.Map qualified as Map
@@ -72,7 +71,6 @@ import Ledger.Constraints (ScriptLookups, TxConstraints (..), mintingPolicy, mus
 import Ledger.Constraints.OffChain (UnbalancedTx)
 import Ledger.Constraints.OffChain qualified as Constraints
 import Ledger.Constraints.TxConstraints (InputConstraint (..), OutputConstraint (..))
-import Ledger.TimeSlot qualified as TimeSlot
 import Ledger.Tx qualified as Tx
 import Ledger.Typed.Scripts qualified as Scripts
 import Ledger.Typed.Tx (TypedScriptTxOut (..))
@@ -265,8 +263,8 @@ waitForUpdateUntilTime ::
     )
     => StateMachineClient state i
     -> POSIXTime
-    -> Contract w schema e (WaitingResult Slot i state)
-waitForUpdateUntilTime sm timeoutTime = waitForUpdateUntilSlot sm (TimeSlot.posixTimeToEnclosingSlot def timeoutTime)
+    -> Contract w schema e (WaitingResult POSIXTime i state)
+waitForUpdateUntilTime client timeoutTime = waitForUpdateTimeout client (isTime timeoutTime) >>= fmap (fmap (tyTxOutData . ocsTxOut)) . awaitPromise
 
 -- | Wait until the on-chain state of the state machine instance has changed,
 --   and return the new state, or return 'Nothing' if the instance has been

--- a/plutus-contract/src/Plutus/Trace/Emulator.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator.hs
@@ -162,7 +162,7 @@ handleEmulatorTrace slotCfg action = do
             . flip handleError (throwError . EmulatedWalletError)
             . reinterpret handleEmulatedWalletAPI
             . interpret (handleEmulatorControl @_ @effs slotCfg)
-            . interpret (handleWaiting @_ @effs)
+            . interpret (handleWaiting @_ @effs slotCfg)
             . interpret (handleAssert @_ @effs)
             . interpret (handleRunContract @_ @effs)
             $ raiseEnd action


### PR DESCRIPTION
Triggered by the review of #77. 

The only remaining instance that we should get rid of is in `awaitTime` in `Plutus.PAB.Core.ContractInstance.STM`.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
