### PR TITLE
SCP-2368: expose partial transactions that need to be balanced, signed and submitted by a remote wallet

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-contract.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-contract.nix
@@ -10,7 +10,7 @@
   {
     flags = { defer-plugin-errors = false; };
     package = {
-      specVersion = "2.2";
+      specVersion = "3.0";
       identifier = { name = "plutus-contract"; version = "0.1.0.0"; };
       license = "Apache-2.0";
       copyright = "";
@@ -124,6 +124,7 @@
           "Wallet"
           "Wallet/API"
           "Wallet/Effects"
+          "Wallet/Error"
           "Wallet/Graph"
           "Wallet/Types"
           "Plutus/Trace"
@@ -154,6 +155,7 @@
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."cardano-api".components.sublibs.gen or (errorHandler.buildDepError "cardano-api:gen"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
             (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
@@ -189,6 +191,7 @@
             "Spec/State"
             "Spec/ThreadToken"
             "Spec/Secrets"
+            "Spec/Plutus/Contract/Wallet"
             ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Spec.hs" ];

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
@@ -10,7 +10,7 @@
   {
     flags = { defer-plugin-errors = false; };
     package = {
-      specVersion = "2.2";
+      specVersion = "3.0";
       identifier = { name = "plutus-pab"; version = "0.1.0.0"; };
       license = "Apache-2.0";
       copyright = "";
@@ -123,7 +123,9 @@
           "Cardano/Node/Types"
           "Cardano/Protocol/Socket/Mock/Client"
           "Cardano/Protocol/Socket/Mock/Server"
-          "Cardano/Wallet/Client"
+          "Cardano/Wallet/LocalClient"
+          "Cardano/Wallet/RemoteClient"
+          "Cardano/Wallet/Types"
           "Cardano/Wallet/Mock/API"
           "Cardano/Wallet/Mock/Client"
           "Cardano/Wallet/Mock/Handlers"
@@ -424,7 +426,9 @@
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."cardano-api".components.sublibs.gen or (errorHandler.buildDepError "cardano-api:gen"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
             (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
             (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
             (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
@@ -453,6 +457,7 @@
           buildable = true;
           modules = [
             "Cardano/Api/NetworkId/ExtraSpec"
+            "Cardano/Wallet/RemoteClientSpec"
             "Cardano/Wallet/ServerSpec"
             "Control/Concurrent/STM/ExtrasSpec"
             ];

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-contract.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-contract.nix
@@ -10,7 +10,7 @@
   {
     flags = { defer-plugin-errors = false; };
     package = {
-      specVersion = "2.2";
+      specVersion = "3.0";
       identifier = { name = "plutus-contract"; version = "0.1.0.0"; };
       license = "Apache-2.0";
       copyright = "";
@@ -124,6 +124,7 @@
           "Wallet"
           "Wallet/API"
           "Wallet/Effects"
+          "Wallet/Error"
           "Wallet/Graph"
           "Wallet/Types"
           "Plutus/Trace"
@@ -154,6 +155,7 @@
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."cardano-api".components.sublibs.gen or (errorHandler.buildDepError "cardano-api:gen"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
             (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
@@ -189,6 +191,7 @@
             "Spec/State"
             "Spec/ThreadToken"
             "Spec/Secrets"
+            "Spec/Plutus/Contract/Wallet"
             ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Spec.hs" ];

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
@@ -10,7 +10,7 @@
   {
     flags = { defer-plugin-errors = false; };
     package = {
-      specVersion = "2.2";
+      specVersion = "3.0";
       identifier = { name = "plutus-pab"; version = "0.1.0.0"; };
       license = "Apache-2.0";
       copyright = "";
@@ -123,7 +123,9 @@
           "Cardano/Node/Types"
           "Cardano/Protocol/Socket/Mock/Client"
           "Cardano/Protocol/Socket/Mock/Server"
-          "Cardano/Wallet/Client"
+          "Cardano/Wallet/LocalClient"
+          "Cardano/Wallet/RemoteClient"
+          "Cardano/Wallet/Types"
           "Cardano/Wallet/Mock/API"
           "Cardano/Wallet/Mock/Client"
           "Cardano/Wallet/Mock/Handlers"
@@ -424,7 +426,9 @@
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."cardano-api".components.sublibs.gen or (errorHandler.buildDepError "cardano-api:gen"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
             (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
             (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
             (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
@@ -453,6 +457,7 @@
           buildable = true;
           modules = [
             "Cardano/Api/NetworkId/ExtraSpec"
+            "Cardano/Wallet/RemoteClientSpec"
             "Cardano/Wallet/ServerSpec"
             "Control/Concurrent/STM/ExtrasSpec"
             ];

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-contract.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-contract.nix
@@ -10,7 +10,7 @@
   {
     flags = { defer-plugin-errors = false; };
     package = {
-      specVersion = "2.2";
+      specVersion = "3.0";
       identifier = { name = "plutus-contract"; version = "0.1.0.0"; };
       license = "Apache-2.0";
       copyright = "";
@@ -124,6 +124,7 @@
           "Wallet"
           "Wallet/API"
           "Wallet/Effects"
+          "Wallet/Error"
           "Wallet/Graph"
           "Wallet/Types"
           "Plutus/Trace"
@@ -154,6 +155,7 @@
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."cardano-api".components.sublibs.gen or (errorHandler.buildDepError "cardano-api:gen"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
             (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
@@ -189,6 +191,7 @@
             "Spec/State"
             "Spec/ThreadToken"
             "Spec/Secrets"
+            "Spec/Plutus/Contract/Wallet"
             ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Spec.hs" ];

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab.nix
@@ -10,7 +10,7 @@
   {
     flags = { defer-plugin-errors = false; };
     package = {
-      specVersion = "2.2";
+      specVersion = "3.0";
       identifier = { name = "plutus-pab"; version = "0.1.0.0"; };
       license = "Apache-2.0";
       copyright = "";
@@ -123,7 +123,9 @@
           "Cardano/Node/Types"
           "Cardano/Protocol/Socket/Mock/Client"
           "Cardano/Protocol/Socket/Mock/Server"
-          "Cardano/Wallet/Client"
+          "Cardano/Wallet/LocalClient"
+          "Cardano/Wallet/RemoteClient"
+          "Cardano/Wallet/Types"
           "Cardano/Wallet/Mock/API"
           "Cardano/Wallet/Mock/Client"
           "Cardano/Wallet/Mock/Handlers"
@@ -424,7 +426,9 @@
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."cardano-api".components.sublibs.gen or (errorHandler.buildDepError "cardano-api:gen"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
             (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
             (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
             (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
@@ -453,6 +457,7 @@
           buildable = true;
           modules = [
             "Cardano/Api/NetworkId/ExtraSpec"
+            "Cardano/Wallet/RemoteClientSpec"
             "Cardano/Wallet/ServerSpec"
             "Control/Concurrent/STM/ExtrasSpec"
             ];

--- a/plutus-contract/plutus-contract.cabal
+++ b/plutus-contract/plutus-contract.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.2
+cabal-version: 3.0
 name: plutus-contract
 version: 0.1.0.0
 license: Apache-2.0
@@ -77,6 +77,7 @@ library
         Wallet
         Wallet.API
         Wallet.Effects
+        Wallet.Error
         Wallet.Graph
         Wallet.Types
         Plutus.Trace
@@ -181,10 +182,12 @@ test-suite plutus-contract-test
         Spec.State
         Spec.ThreadToken
         Spec.Secrets
+        Spec.Plutus.Contract.Wallet
     build-depends:
         base >=4.9 && <5,
         bytestring -any,
         cardano-api -any,
+        cardano-api:gen -any,
         containers -any,
         data-default -any,
         freer-extras -any,

--- a/plutus-contract/src/Plutus/Contract.hs
+++ b/plutus-contract/src/Plutus/Contract.hs
@@ -80,6 +80,7 @@ module Plutus.Contract(
     , Request.submitBalancedTx
     , Request.balanceTx
     , Request.mkTxConstraints
+    , Request.yieldUnbalancedTx
     -- ** Creating transactions
     , module Tx
     -- ** Tx confirmation
@@ -106,12 +107,12 @@ module Plutus.Contract(
     ) where
 
 import Data.Aeson (ToJSON (toJSON))
-import Data.Row
+import Data.Row (Empty, HasType, type (.\/))
 
 import Plutus.Contract.Request (ContractRow)
 import Plutus.Contract.Request qualified as Request
 import Plutus.Contract.Schema qualified as Schema
-import Plutus.Contract.Typed.Tx as Tx
+import Plutus.Contract.Typed.Tx as Tx (collectFromScript, collectFromScriptFilter)
 import Plutus.Contract.Types (AsCheckpointError (..), AsContractError (..), CheckpointError (..), Contract (..),
                               ContractError (..), IsContract (..), Promise (..), checkpoint, checkpointLoop,
                               handleError, mapError, never, promiseBind, promiseMap, runError, select, selectEither,

--- a/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
@@ -34,43 +34,51 @@ module Plutus.Trace.Emulator.ContractInstance(
     , addResponse
     ) where
 
-import Control.Lens
+import Control.Lens (at, preview, view, (?~))
 import Control.Monad (guard, join, unless, void, when)
-import Control.Monad.Freer
+import Control.Monad.Freer (Eff, Member, Members, interpret, send, subsume)
 import Control.Monad.Freer.Error (Error, throwError)
-import Control.Monad.Freer.Extras.Log (LogMessage, LogMsg (..), LogObserve, logDebug, logError, logInfo, logWarn,
+import Control.Monad.Freer.Extras.Log (LogMessage, LogMsg (LMessage), LogObserve, logDebug, logError, logInfo, logWarn,
                                        mapLog)
 import Control.Monad.Freer.Extras.Modify (raiseEnd)
 import Control.Monad.Freer.Reader (Reader, ask, runReader)
 import Control.Monad.Freer.State (State, evalState, get, gets, modify, put)
 import Data.Aeson qualified as JSON
 import Data.Foldable (traverse_)
-import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (listToMaybe, mapMaybe)
 import Data.Set qualified as Set
 import Data.Text qualified as T
-import Ledger.Blockchain (OnChainTx (..))
-import Ledger.Tx (Address, TxIn (..), TxOut (..), TxOutRef, txId)
+import Ledger.Blockchain (OnChainTx (Invalid, Valid))
+import Ledger.Tx (Address, TxIn (txInRef), TxOut (TxOut, txOutAddress), TxOutRef, txId)
 import Plutus.ChainIndex (ChainIndexQueryEffect, ChainIndexTx (ChainIndexTx, _citxOutputs, _citxTxId),
-                          ChainIndexTxOutputs (InvalidTx, ValidTx), RollbackState (..), TxOutState (..),
-                          TxValidity (..), _ValidTx, citxInputs, citxOutputs, fromOnChainTx, txOutRefs)
-import Plutus.Contract (Contract (..))
+                          ChainIndexTxOutputs (InvalidTx, ValidTx), RollbackState (Committed),
+                          TxOutState (Spent, Unspent), TxValidity (TxInvalid, TxValid), _ValidTx, citxInputs,
+                          citxOutputs, fromOnChainTx, txOutRefs)
+import Plutus.Contract (Contract)
 import Plutus.Contract.Effects (PABReq, PABResp (AwaitTxStatusChangeResp), matches)
 import Plutus.Contract.Effects qualified as E
-import Plutus.Contract.Resumable (Request (..), Response (..))
+import Plutus.Contract.Resumable (Request (Request, rqID, rqRequest),
+                                  Response (Response, rspItID, rspResponse, rspRqID), itID)
 import Plutus.Contract.Resumable qualified as State
-import Plutus.Contract.Trace (handleBlockchainQueries)
-import Plutus.Contract.Trace.RequestHandler (RequestHandler (..), RequestHandlerLogMsg, tryHandler, wrapHandler)
-import Plutus.Contract.Types (ResumableResult (..), lastLogs, requests, resumableResult)
-import Plutus.Trace.Emulator.Types (ContractConstraints, ContractHandle (..), ContractInstanceLog (..),
-                                    ContractInstanceMsg (..), ContractInstanceState (..),
-                                    ContractInstanceStateInternal (..), EmulatedWalletEffects, EmulatedWalletEffects',
-                                    EmulatorAgentThreadEffs, EmulatorMessage (..), EmulatorRuntimeError (..),
-                                    EmulatorThreads, addEventInstanceState, emptyInstanceState, instanceIdThreads,
-                                    toInstanceState)
-import Plutus.Trace.Scheduler (MessageCall (..), Priority (..), ThreadId, mkAgentSysCall)
+import Plutus.Contract.Trace qualified as RequestHandler
+import Plutus.Contract.Trace.RequestHandler (RequestHandler (RequestHandler), RequestHandlerLogMsg, tryHandler,
+                                             wrapHandler)
+import Plutus.Contract.Types (ResumableResult (ResumableResult, _finalState), lastLogs, requests, resumableResult)
+import Plutus.Trace.Emulator.Types (ContractConstraints,
+                                    ContractHandle (ContractHandle, chContract, chInstanceId, chInstanceTag),
+                                    ContractInstanceLog (ContractInstanceLog),
+                                    ContractInstanceMsg (ContractLog, CurrentRequests, Freezing, HandledRequest, InstErr, NoRequestsHandled, ReceiveEndpointCall, SendingContractState, Started, StoppedNoError, StoppedWithError),
+                                    ContractInstanceState (ContractInstanceState, instContractState, instEvents, instHandlersHistory),
+                                    ContractInstanceStateInternal (cisiSuspState), EmulatedWalletEffects,
+                                    EmulatedWalletEffects', EmulatorAgentThreadEffs,
+                                    EmulatorMessage (ContractInstanceStateRequest, ContractInstanceStateResponse, EndpointCall, Freeze, NewSlot),
+                                    EmulatorRuntimeError (EmulatorJSONDecodingError, ThreadIdNotFound), EmulatorThreads,
+                                    addEventInstanceState, emptyInstanceState, instanceIdThreads, toInstanceState)
+import Plutus.Trace.Scheduler (MessageCall (Message, WaitForMessage), Priority (Frozen, Normal, Sleeping), ThreadId,
+                               mkAgentSysCall)
 import Wallet.API qualified as WAPI
 import Wallet.Effects (NodeClientEffect, WalletEffect)
 import Wallet.Emulator.LogMessages (TxBalanceMsg)
@@ -232,6 +240,25 @@ waitForNextMessage isLogShowed = do
                 (const Normal)
                 response
     mkAgentSysCall prio WaitForMessage
+
+handleBlockchainQueries ::
+    RequestHandler
+        (Reader ContractInstanceId ': EmulatedWalletEffects)
+        PABReq
+        PABResp
+handleBlockchainQueries =
+    RequestHandler.handleUnbalancedTransactions
+    <> RequestHandler.handlePendingTransactions
+    <> RequestHandler.handleChainIndexQueries
+    <> RequestHandler.handleOwnPubKeyHashQueries
+    <> RequestHandler.handleOwnInstanceIdQueries
+    <> RequestHandler.handleSlotNotifications
+    <> RequestHandler.handleCurrentSlotQueries
+    <> RequestHandler.handleTimeNotifications
+    <> RequestHandler.handleCurrentTimeQueries
+    <> RequestHandler.handleTimeToSlotConversions
+    <> RequestHandler.handleYieldedUnbalancedTx
+
 
 decodeEvent ::
     forall effs.

--- a/plutus-contract/src/Wallet/Effects.hs
+++ b/plutus-contract/src/Wallet/Effects.hs
@@ -17,6 +17,7 @@ module Wallet.Effects(
     , balanceTx
     , totalFunds
     , walletAddSignature
+    , yieldUnbalancedTx
     -- * Node client
     , NodeClientEffect(..)
     , publishTx
@@ -28,7 +29,7 @@ import Control.Monad.Freer.TH (makeEffect)
 import Ledger (CardanoTx, PubKeyHash, Slot, Tx, Value)
 import Ledger.Constraints.OffChain (UnbalancedTx)
 import Ledger.TimeSlot (SlotConfig)
-import Wallet.Emulator.Error (WalletAPIError)
+import Wallet.Error (WalletAPIError)
 
 data WalletEffect r where
     SubmitTxn :: CardanoTx -> WalletEffect ()
@@ -36,6 +37,8 @@ data WalletEffect r where
     BalanceTx :: UnbalancedTx -> WalletEffect (Either WalletAPIError CardanoTx)
     TotalFunds :: WalletEffect Value -- ^ Total of all funds that are in the wallet (incl. tokens)
     WalletAddSignature :: CardanoTx -> WalletEffect CardanoTx
+    -- | Sends an unbalanced tx to be balanced, signed and submitted.
+    YieldUnbalancedTx :: UnbalancedTx -> WalletEffect ()
 makeEffect ''WalletEffect
 
 data NodeClientEffect r where

--- a/plutus-contract/src/Wallet/Emulator/Error.hs
+++ b/plutus-contract/src/Wallet/Emulator/Error.hs
@@ -33,6 +33,8 @@ data WalletAPIError =
     -- ^ There was an error while converting to Cardano.API format.
     | PaymentMkTxError Constraints.MkTxError
     -- ^ There was an error while creating a payment transaction
+    | RemoteClientFunctionNotYetSupported Text
+    -- ^ The called wallet effect is not yet supported in a remote wallet client scenario.
     | OtherError Text
     -- ^ Some other error occurred.
     deriving stock (Show, Eq, Generic)
@@ -51,6 +53,8 @@ instance Pretty WalletAPIError where
             "Error during conversion to a Cardano.Api format:" <+> pretty t
         PaymentMkTxError e ->
             "Payment transaction error:" <+> pretty e
+        RemoteClientFunctionNotYetSupported e ->
+            "Remote client function not yet supported:" <+> pretty e
         OtherError t ->
             "Other error:" <+> pretty t
 

--- a/plutus-contract/src/Wallet/Error.hs
+++ b/plutus-contract/src/Wallet/Error.hs
@@ -1,0 +1,6 @@
+module Wallet.Error(
+    module Error
+    ) where
+
+import Wallet.Emulator.Error as Error
+

--- a/plutus-contract/src/Wallet/Types.hs
+++ b/plutus-contract/src/Wallet/Types.hs
@@ -45,7 +45,7 @@ import Prettyprinter (Pretty (..), colon, hang, viaShow, vsep, (<+>))
 import Ledger.Constraints.OffChain (MkTxError)
 import Plutus.Contract.Checkpoint (AsCheckpointError (..), CheckpointError)
 import Prettyprinter.Extras (PrettyShow (..), Tagged (..))
-import Wallet.Emulator.Error (WalletAPIError)
+import Wallet.Error (WalletAPIError)
 
 import Data.OpenApi.Schema qualified as OpenApi
 

--- a/plutus-contract/test/Spec.hs
+++ b/plutus-contract/test/Spec.hs
@@ -4,11 +4,12 @@ module Main(main) where
 import Spec.Contract qualified
 import Spec.Emulator qualified
 import Spec.ErrorChecking qualified
+import Spec.Plutus.Contract.Wallet qualified
 import Spec.Rows qualified
 import Spec.Secrets qualified
 import Spec.State qualified
 import Spec.ThreadToken qualified
-import Test.Tasty
+import Test.Tasty (TestTree, defaultMain, testGroup)
 
 main :: IO ()
 main = defaultMain tests
@@ -21,5 +22,6 @@ tests = testGroup "plutus-contract" [
     Spec.Rows.tests,
     Spec.ThreadToken.tests,
     Spec.Secrets.tests,
-    Spec.ErrorChecking.tests
+    Spec.ErrorChecking.tests,
+    Spec.Plutus.Contract.Wallet.tests
     ]

--- a/plutus-contract/test/Spec/Plutus/Contract/Wallet.hs
+++ b/plutus-contract/test/Spec/Plutus/Contract/Wallet.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE GADTs          #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Spec.Plutus.Contract.Wallet
+    ( tests
+    ) where
+
+import Cardano.Api qualified as C
+import Data.Aeson (decode, encode)
+import Data.Functor.Identity (Identity)
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Maybe (mapMaybe)
+import Gen.Cardano.Api.Typed qualified as Gen
+import Hedgehog (MonadGen, Property)
+import Hedgehog qualified
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Ledger (MintingPolicyHash, TxOutRef (TxOutRef))
+import Ledger.Scripts qualified as Script
+import Ledger.Tx.CardanoAPI (fromCardanoPolicyId, fromCardanoTxId)
+import Plutus.Contract.Wallet (ExportTx (ExportTx), ExportTxInput (ExportTxInput, etxiAssets, etxiId, etxiTxIx),
+                               ExportTxRedeemer (MintingRedeemer, SpendingRedeemer))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+tests :: TestTree
+tests =
+    testGroup
+        "Plutus.Cardano.Wallet"
+        [ testProperty "ExportTx FromJSON and ToJSON inverse property" jsonInvProp
+        ]
+
+jsonInvProp :: Property
+jsonInvProp = Hedgehog.property $ do
+    exportTx <- Hedgehog.forAll exportTxGen
+    Hedgehog.tripping exportTx encode decode
+
+exportTxGen :: (Hedgehog.GenBase m ~ Identity, MonadFail m, MonadGen m) => m ExportTx
+exportTxGen = do
+    exportTxInputs <- Gen.list (Range.linear 0 5) exportTxInputGen
+    ExportTx
+        <$> Hedgehog.fromGenT (Gen.genTx C.AlonzoEra)
+        <*> pure exportTxInputs
+        <*> exportTxRedeemersGen exportTxInputs
+
+exportTxInputGen :: (Hedgehog.GenBase m ~ Identity, MonadFail m, MonadGen m) => m ExportTxInput
+exportTxInputGen = do
+    C.TxIn txId txIx <- Hedgehog.fromGenT Gen.genTxIn
+    C.TxOut addressInEra txOutValue txOutDatum <- Hedgehog.fromGenT (Gen.genTxOut C.AlonzoEra)
+    let datumToScriptDataHash C.TxOutDatumNone       = Nothing
+        datumToScriptDataHash (C.TxOutDatumHash _ h) = Just h
+        datumToScriptDataHash (C.TxOutDatum _ d)     = Just $ C.hashScriptData d
+    pure $ ExportTxInput
+        txId
+        txIx
+        addressInEra
+        (C.txOutValueToLovelace txOutValue)
+        (datumToScriptDataHash txOutDatum)
+        (currenciesFromTxOutValue txOutValue)
+
+currenciesFromTxOutValue :: C.TxOutValue C.AlonzoEra -> [(C.PolicyId, C.AssetName, C.Quantity)]
+currenciesFromTxOutValue txOutValue =
+    mapMaybe currencyFromValue $ C.valueToList $ C.txOutValueToValue txOutValue
+  where
+    currencyFromValue :: (C.AssetId, C.Quantity) -> Maybe (C.PolicyId, C.AssetName, C.Quantity)
+    currencyFromValue (C.AdaAssetId, _)                   = Nothing
+    currencyFromValue (C.AssetId policyId assetName, qty) = Just (policyId, assetName, qty)
+
+exportTxRedeemersGen :: MonadGen m => [ExportTxInput] -> m [ExportTxRedeemer]
+exportTxRedeemersGen [] = pure []
+exportTxRedeemersGen inputs = do
+    let spendingGenM = fmap exportTxSpendingRedeemerGen $ NonEmpty.nonEmpty $ fmap getTxOutRef inputs
+        mintingGenM = fmap exportTxMintingRedeemerGen $ NonEmpty.nonEmpty $ concatMap getMintingPolicyHashes inputs
+    case (spendingGenM, mintingGenM) of
+      (Just spendingGen, Just mintingGen) ->
+          Gen.list (Range.linear 0 (length inputs)) $ Gen.choice [mintingGen, spendingGen]
+      (Just spendingGen, Nothing) ->
+          Gen.list (Range.linear 0 (length inputs)) spendingGen
+      (Nothing, Just mintingGen) ->
+          Gen.list (Range.linear 0 (length inputs)) mintingGen
+      (Nothing, Nothing) -> pure []
+  where
+    getTxOutRef :: ExportTxInput -> TxOutRef
+    getTxOutRef ExportTxInput { etxiId, etxiTxIx = (C.TxIx txIx) } =
+        TxOutRef (fromCardanoTxId etxiId) (toInteger txIx)
+
+    getMintingPolicyHashes :: ExportTxInput -> [MintingPolicyHash]
+    getMintingPolicyHashes ExportTxInput { etxiAssets } =
+        fmap (\(policyId, _, _) -> fromCardanoPolicyId policyId) etxiAssets
+
+exportTxSpendingRedeemerGen :: MonadGen m => NonEmpty TxOutRef -> m ExportTxRedeemer
+exportTxSpendingRedeemerGen txOutRefs = do
+    txOutRef <- Gen.element (NonEmpty.toList txOutRefs)
+    pure $ SpendingRedeemer Script.unitRedeemer txOutRef
+
+exportTxMintingRedeemerGen :: MonadGen m => NonEmpty MintingPolicyHash -> m ExportTxRedeemer
+exportTxMintingRedeemerGen policyHashes = do
+    policyHash <- Gen.element (NonEmpty.toList policyHashes)
+    pure $ MintingRedeemer Script.unitRedeemer policyHash

--- a/plutus-ledger/src/Ledger/Orphans.hs
+++ b/plutus-ledger/src/Ledger/Orphans.hs
@@ -7,7 +7,12 @@
 
 module Ledger.Orphans where
 
+import Cardano.Api qualified as C
+import Cardano.Crypto.Hash qualified as Hash
 import Cardano.Crypto.Wallet qualified as Crypto
+import Cardano.Ledger.Crypto qualified as C
+import Cardano.Ledger.Hashes qualified as Hashes
+import Cardano.Ledger.SafeHash qualified as C
 import Control.Lens ((&), (.~), (?~))
 import Control.Monad.Freer.Extras.Log (LogLevel, LogMessage)
 import Crypto.Hash qualified as Crypto
@@ -16,20 +21,26 @@ import Data.Aeson.Extras qualified as JSON
 import Data.Bifunctor (bimap)
 import Data.OpenApi qualified as OpenApi
 import Data.Text qualified as Text
-import Data.Typeable
-import GHC.Exts (IsList (..))
-import Plutus.V1.Ledger.Ada
-import Plutus.V1.Ledger.Api
+import Data.Typeable (Proxy (Proxy), Typeable)
+import GHC.Exts (IsList (fromList))
+import GHC.Generics (Generic)
+import Plutus.V1.Ledger.Ada (Ada (Lovelace))
+import Plutus.V1.Ledger.Api (Address, BuiltinByteString, BuiltinData (BuiltinData), Credential,
+                             CurrencySymbol (CurrencySymbol), Data, Datum (Datum), DatumHash (DatumHash), Extended,
+                             Interval, LedgerBytes (LedgerBytes), LowerBound, MintingPolicy (MintingPolicy),
+                             MintingPolicyHash (MintingPolicyHash), POSIXTime (POSIXTime), PubKeyHash (PubKeyHash),
+                             Redeemer (Redeemer), RedeemerHash (RedeemerHash), Script,
+                             StakeValidatorHash (StakeValidatorHash), StakingCredential, TokenName (TokenName),
+                             TxId (TxId), TxOut, TxOutRef, UpperBound, Validator (Validator),
+                             ValidatorHash (ValidatorHash), Value (Value), fromBytes)
 import Plutus.V1.Ledger.Bytes (bytes)
-import Plutus.V1.Ledger.Crypto (PrivateKey (PrivateKey, getPrivateKey), PubKey (..), Signature (..))
-import Plutus.V1.Ledger.Slot (Slot (..))
-import Plutus.V1.Ledger.Tx
-import Plutus.V1.Ledger.Value
-import PlutusCore
+import Plutus.V1.Ledger.Crypto (PrivateKey (PrivateKey, getPrivateKey), PubKey (PubKey), Signature (Signature))
+import Plutus.V1.Ledger.Slot (Slot (Slot))
+import Plutus.V1.Ledger.Tx (RedeemerPtr, ScriptTag, Tx, TxIn, TxInType)
+import Plutus.V1.Ledger.Value (AssetClass (AssetClass))
+import PlutusCore (Kind, Some, Term, Type, ValueOf, Version)
 import PlutusTx.AssocMap qualified as AssocMap
-import Prelude as Haskell
-import Web.HttpApiData (FromHttpApiData (..), ToHttpApiData (..))
-
+import Web.HttpApiData (FromHttpApiData (parseUrlPiece), ToHttpApiData (toUrlPiece))
 
 instance ToHttpApiData PrivateKey where
     toUrlPiece = toUrlPiece . getPrivateKey
@@ -45,6 +56,31 @@ instance FromHttpApiData LedgerBytes where
 
 -- | OpenApi instances for swagger support
 
+instance OpenApi.ToSchema C.ScriptHash where
+    declareNamedSchema _ = pure $ OpenApi.NamedSchema (Just "ScriptHash") mempty
+instance OpenApi.ToSchema (C.AddressInEra C.AlonzoEra) where
+    declareNamedSchema _ = pure $ OpenApi.NamedSchema (Just "AddressInAlonzoEra") mempty
+deriving instance Generic C.ScriptData
+instance OpenApi.ToSchema C.ScriptData where
+    declareNamedSchema _ =
+        pure $ OpenApi.NamedSchema (Just "ScriptData") OpenApi.byteSchema
+instance OpenApi.ToSchema (C.Hash C.ScriptData) where
+    declareNamedSchema _ =
+        pure $ OpenApi.NamedSchema (Just "HashScriptData") OpenApi.byteSchema
+deriving instance Generic C.TxId
+deriving anyclass instance OpenApi.ToSchema C.TxId
+deriving instance Generic C.TxIx
+deriving anyclass instance OpenApi.ToSchema C.TxIx
+deriving instance Generic C.Lovelace
+deriving anyclass instance OpenApi.ToSchema C.Lovelace
+deriving instance Generic C.PolicyId
+deriving anyclass instance OpenApi.ToSchema C.PolicyId
+instance OpenApi.ToSchema C.AssetName where
+    declareNamedSchema _ =
+        pure $ OpenApi.NamedSchema (Just "AssetName") OpenApi.byteSchema
+deriving instance Generic C.Quantity
+deriving anyclass instance OpenApi.ToSchema C.Quantity
+
 deriving anyclass instance (OpenApi.ToSchema k, OpenApi.ToSchema v) => OpenApi.ToSchema (AssocMap.Map k v)
 instance OpenApi.ToSchema BuiltinByteString where
     declareNamedSchema _ = pure $ OpenApi.NamedSchema (Just "Bytes") mempty
@@ -53,6 +89,10 @@ instance OpenApi.ToSchema Crypto.XPub where
 instance OpenApi.ToSchema Crypto.XPrv where
     declareNamedSchema _ = pure $ OpenApi.NamedSchema (Just "PrvKey") mempty
 instance OpenApi.ToSchema (Crypto.Digest Crypto.Blake2b_160) where
+    declareNamedSchema _ = pure $ OpenApi.NamedSchema (Just "Digest") mempty
+instance OpenApi.ToSchema (Hash.Hash Hash.Blake2b_256 Hashes.EraIndependentTxBody) where
+    declareNamedSchema _ = pure $ OpenApi.NamedSchema (Just "Hash") mempty
+instance OpenApi.ToSchema (C.SafeHash C.StandardCrypto Hashes.EraIndependentData) where
     declareNamedSchema _ = pure $ OpenApi.NamedSchema (Just "Hash") mempty
 deriving instance OpenApi.ToSchema (LogMessage JSON.Value)
 deriving instance OpenApi.ToSchema LogLevel
@@ -125,4 +165,4 @@ deriving instance
 deriving instance OpenApi.ToSchema ann => OpenApi.ToSchema (Version ann)
 instance OpenApi.ToSchema Script where
     declareNamedSchema _ =
-        Haskell.pure $ OpenApi.NamedSchema (Just "Script") (OpenApi.toSchema (Proxy :: Proxy String))
+        pure $ OpenApi.NamedSchema (Just "Script") (OpenApi.toSchema (Proxy :: Proxy String))

--- a/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
+++ b/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
@@ -23,9 +23,11 @@ module Ledger.Tx.CardanoAPI(
   , fromCardanoTxInsCollateral
   , fromCardanoTxInWitness
   , fromCardanoTxOut
+  , fromCardanoTxOutDatumHash
   , fromCardanoAddress
   , fromCardanoMintValue
   , fromCardanoValue
+  , fromCardanoPolicyId
   , fromCardanoFee
   , fromCardanoValidityRange
   , fromCardanoScriptInEra
@@ -55,7 +57,7 @@ module Ledger.Tx.CardanoAPI(
 import Cardano.Api qualified as C
 import Cardano.Api.Byron qualified as C
 import Cardano.Api.Shelley qualified as C
-import Cardano.BM.Data.Tracer (ToObject (..))
+import Cardano.BM.Data.Tracer (ToObject)
 import Cardano.Chain.Common (addrToBase58)
 import Cardano.Ledger.Alonzo.Scripts qualified as Alonzo
 import Cardano.Ledger.Alonzo.TxWitness qualified as C
@@ -63,9 +65,9 @@ import Cardano.Ledger.Core qualified as Ledger
 import Codec.Serialise (Serialise, deserialiseOrFail)
 import Codec.Serialise qualified as Codec
 import Codec.Serialise.Decoding (Decoder, decodeBytes, decodeSimple)
-import Codec.Serialise.Encoding (Encoding (..), Tokens (..))
+import Codec.Serialise.Encoding (Encoding (Encoding), Tokens (TkBytes, TkSimple))
 import Control.Applicative ((<|>))
-import Control.Lens hiding ((.=))
+import Control.Lens ((&), (.~), (?~))
 import Control.Monad (when)
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), object, (.:), (.=))
 import Data.Aeson qualified as Aeson
@@ -78,8 +80,8 @@ import Data.ByteString.Short qualified as SBS
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (mapMaybe)
-import Data.OpenApi (NamedSchema (..), OpenApiType (..), byteSchema, declareSchemaRef, properties, required,
-                     sketchSchema, type_)
+import Data.OpenApi (NamedSchema (NamedSchema), OpenApiType (OpenApiObject), byteSchema, declareSchemaRef, properties,
+                     required, sketchSchema, type_)
 import Data.OpenApi qualified as OpenApi
 import Data.Proxy (Proxy (Proxy))
 import Data.Set qualified as Set
@@ -96,7 +98,7 @@ import Plutus.V1.Ledger.Slot qualified as P
 import Plutus.V1.Ledger.Tx qualified as P
 import Plutus.V1.Ledger.Value qualified as Value
 import PlutusTx.Prelude qualified as PlutusTx
-import Prettyprinter (Pretty (..), colon, viaShow, (<+>))
+import Prettyprinter (Pretty (pretty), colon, viaShow, (<+>))
 
 instance (Typeable era, Typeable mode) => OpenApi.ToSchema (C.EraInMode era mode) where
   declareNamedSchema _ = do

--- a/plutus-pab/plutus-pab.cabal
+++ b/plutus-pab/plutus-pab.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.2
+cabal-version: 3.0
 name:          plutus-pab
 version:       0.1.0.0
 license:       Apache-2.0
@@ -72,7 +72,9 @@ library
         Cardano.Node.Types
         Cardano.Protocol.Socket.Mock.Client
         Cardano.Protocol.Socket.Mock.Server
-        Cardano.Wallet.Client
+        Cardano.Wallet.LocalClient
+        Cardano.Wallet.RemoteClient
+        Cardano.Wallet.Types
         Cardano.Wallet.Mock.API
         Cardano.Wallet.Mock.Client
         Cardano.Wallet.Mock.Handlers
@@ -423,6 +425,7 @@ test-suite plutus-pab-test-light
     main-is:          Spec.hs
     other-modules:
         Cardano.Api.NetworkId.ExtraSpec
+        Cardano.Wallet.RemoteClientSpec
         Cardano.Wallet.ServerSpec
         Control.Concurrent.STM.ExtrasSpec
 
@@ -433,7 +436,9 @@ test-suite plutus-pab-test-light
         base >=4.9 && <5,
         bytestring -any,
         cardano-api -any,
+        cardano-api:gen -any,
         containers -any,
+        data-default -any,
         freer-extras -any,
         freer-simple -any,
         hedgehog -any,

--- a/plutus-pab/plutus-pab.yaml.sample
+++ b/plutus-pab/plutus-pab.yaml.sample
@@ -12,9 +12,9 @@ pabWebserverConfig:
   endpointTimeout: 5
 
 walletServerConfig:
-  baseUrl: http://localhost:9081
-  wallet:
-    getWallet: 1
+  tag: LocalWalletConfig
+  walletSettings:
+    baseUrl: http://localhost:9081
 
 nodeServerConfig:
   mscBaseUrl: http://localhost:9082
@@ -36,7 +36,6 @@ nodeServerConfig:
 
 chainIndexConfig:
   ciBaseUrl: http://localhost:9083
-  ciWatchedAddresses: []
 
 requestProcessingConfig:
   requestProcessingInterval: 1

--- a/plutus-pab/src/Cardano/Wallet/LocalClient.hs
+++ b/plutus-pab/src/Cardano/Wallet/LocalClient.hs
@@ -1,24 +1,21 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE GADTs             #-}
-{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE NamedFieldPuns    #-}
-{-# LANGUAGE OverloadedLabels  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE TypeOperators     #-}
-{-# LANGUAGE ViewPatterns      #-}
 
-module Cardano.Wallet.Client where
+module Cardano.Wallet.LocalClient where
 
 import Cardano.Api qualified
-import Cardano.Api.NetworkId.Extra (NetworkIdWrapper (..))
+import Cardano.Api.NetworkId.Extra (NetworkIdWrapper (NetworkIdWrapper))
 import Cardano.Api.Shelley qualified as Cardano.Api
-import Cardano.Node.Types (MockServerConfig (..))
+import Cardano.Node.Types (MockServerConfig (mscNetworkId, mscPassphrase))
 import Cardano.Wallet.Api qualified as C
 import Cardano.Wallet.Api.Client qualified as C
-import Cardano.Wallet.Api.Types (ApiVerificationKeyShelley (..), ApiWallet (..))
+import Cardano.Wallet.Api.Types (ApiVerificationKeyShelley (getApiVerificationKey), ApiWallet (assets, balance))
 import Cardano.Wallet.Api.Types qualified as C
 import Cardano.Wallet.Primitive.AddressDerivation qualified as C
 import Cardano.Wallet.Primitive.Types qualified as C
@@ -31,31 +28,32 @@ import Control.Monad.Freer (Eff, LastMember, Member, sendM, type (~>))
 import Control.Monad.Freer.Error (Error, throwError)
 import Control.Monad.Freer.Extras.Log (LogMsg, logWarn)
 import Control.Monad.Freer.Reader (Reader, ask)
-import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Aeson (toJSON)
 import Data.Bifunctor (bimap)
 import Data.Coerce (coerce)
 import Data.Foldable (toList)
 import Data.Functor (void)
 import Data.Proxy (Proxy (Proxy))
-import Data.Quantity (Quantity (..))
+import Data.Quantity (Quantity (Quantity))
 import Data.Text (pack)
 import Data.Text.Class (fromText)
 import Ledger (CardanoTx)
 import Ledger.Ada qualified as Ada
-import Ledger.Tx.CardanoAPI (SomeCardanoApiTx (..), ToCardanoError, toCardanoTxBody)
-import Ledger.Value (CurrencySymbol (..), TokenName (..), Value (..))
+import Ledger.Constraints.OffChain (UnbalancedTx)
+import Ledger.Tx.CardanoAPI (SomeCardanoApiTx (SomeTx), ToCardanoError, toCardanoTxBody)
+import Ledger.Value (CurrencySymbol (CurrencySymbol), TokenName (TokenName), Value (Value))
 import Plutus.Contract.Wallet (export)
-import Plutus.PAB.Monitoring.PABLogMsg (WalletClientMsg (..))
-import Plutus.V1.Ledger.Crypto (PubKeyHash (..))
+import Plutus.PAB.Monitoring.PABLogMsg (WalletClientMsg (BalanceTxError, WalletClientError))
+import Plutus.V1.Ledger.Crypto (PubKeyHash (PubKeyHash))
 import PlutusTx.AssocMap qualified as Map
-import PlutusTx.Builtins.Internal (BuiltinByteString (..))
-import Prettyprinter (Pretty (..))
-import Servant ((:<|>) (..), (:>))
+import PlutusTx.Builtins.Internal (BuiltinByteString (BuiltinByteString))
+import Prettyprinter (Pretty (pretty))
+import Servant ((:<|>) ((:<|>)), (:>))
 import Servant.Client (ClientEnv, ClientError, ClientM, client, runClientM)
-import Wallet.Effects (WalletEffect (..))
-import Wallet.Emulator.Error (WalletAPIError (..))
-import Wallet.Emulator.Wallet (Wallet (..), WalletId (..))
+import Wallet.Effects (WalletEffect (BalanceTx, OwnPubKeyHash, SubmitTxn, TotalFunds, WalletAddSignature, YieldUnbalancedTx))
+import Wallet.Emulator.Error (WalletAPIError (OtherError, ToCardanoError))
+import Wallet.Emulator.Wallet (Wallet (Wallet), WalletId (WalletId))
 
 getWalletKey :: C.ApiT C.WalletId -> C.ApiT C.Role -> C.ApiT C.DerivationIndex -> Maybe Bool -> ClientM ApiVerificationKeyShelley
 getWalletKey :<|> _ :<|> _ :<|> _ = client (Proxy @("v2" :> C.WalletKeys))
@@ -70,7 +68,7 @@ handleWalletClient
     , Member (Reader Cardano.Api.ProtocolParameters) effs
     , Member (LogMsg WalletClientMsg) effs
     )
-    => MockServerConfig
+    => MockServerConfig -- TODO: Rename. Not mock
     -> Wallet
     -> WalletEffect
     ~> Eff effs
@@ -96,19 +94,25 @@ handleWalletClient config (Wallet (WalletId walletId)) event = do
                     logWarn (WalletClientError $ show err)
                     throwError err
                 Right _ -> pure result
-    case event of
-        SubmitTxn tx -> do
+
+        submitTxnH :: CardanoTx -> Eff effs ()
+        submitTxnH tx = do
             sealedTx <- either (throwError . ToCardanoError) pure $ toSealedTx protocolParams networkId tx
             void . runClient $ C.postExternalTransaction C.transactionClient (C.ApiBytesT (C.SerialisedTx $ C.serialisedTx sealedTx))
 
-        OwnPubKeyHash -> do
+        ownPubKeyHashH :: Eff effs PubKeyHash
+        ownPubKeyHashH =
             fmap (PubKeyHash . BuiltinByteString . fst . getApiVerificationKey) . runClient $
-                getWalletKey (C.ApiT walletId) (C.ApiT C.UtxoExternal) (C.ApiT (C.DerivationIndex 0)) (Just True)
+                getWalletKey (C.ApiT walletId)
+                             (C.ApiT C.UtxoExternal)
+                             (C.ApiT (C.DerivationIndex 0))
+                             (Just True)
 
-        BalanceTx utx -> do
+        balanceTxH :: UnbalancedTx -> Eff effs (Either WalletAPIError CardanoTx)
+        balanceTxH utx = do
             case export protocolParams networkId utx of
                 Left err -> do
-                    logWarn $ BalanceTxError $ show $ pretty $ err
+                    logWarn $ BalanceTxError $ show $ pretty err
                     throwOtherError $ pretty err
                 Right ex -> do
                     res <- runClient' $ C.balanceTransaction C.transactionClient (C.ApiT walletId) (toJSON ex)
@@ -118,18 +122,35 @@ handleWalletClient config (Wallet (WalletId walletId)) event = do
                         Right r  -> do
                             pure (Right $ fromApiSerialisedTransaction r)
 
-        WalletAddSignature tx -> do
+        walletAddSignatureH :: CardanoTx -> Eff effs CardanoTx
+        walletAddSignatureH tx = do
             sealedTx <- either (throwError . ToCardanoError) pure $ toSealedTx protocolParams networkId tx
             passphrase <- maybe (throwError $ OtherError "Wallet passphrase required") pure mpassphrase
             lenientPP <- either throwOtherError pure $ fromText passphrase
             let postData = C.ApiSignTransactionPostData (C.ApiT sealedTx) (C.ApiT lenientPP)
             fmap fromApiSerialisedTransaction . runClient $ C.signTransaction C.transactionClient (C.ApiT walletId) postData
 
-        TotalFunds -> do
+        totalFundsH :: Eff effs Value
+        totalFundsH = do
             C.ApiWallet{balance, assets} <- runClient $ C.getWallet C.walletClient (C.ApiT walletId)
             let C.ApiWalletBalance (Quantity avAda) _ _ = balance
                 C.ApiWalletAssetsBalance (C.ApiT avAssets) _ = assets
             pure $ Ada.lovelaceValueOf (fromIntegral avAda) <> tokenMapToValue avAssets
+
+        yieldUnbalancedTxH :: UnbalancedTx -> Eff effs ()
+        yieldUnbalancedTxH utx = do
+            balancedTxM <- balanceTxH utx
+            case balancedTxM of
+                Left err         -> throwError err
+                Right balancedTx -> walletAddSignatureH balancedTx >>= submitTxnH
+
+    case event of
+        SubmitTxn tx          -> submitTxnH tx
+        OwnPubKeyHash         -> ownPubKeyHashH
+        BalanceTx utx         -> balanceTxH utx
+        WalletAddSignature tx -> walletAddSignatureH tx
+        TotalFunds            -> totalFundsH
+        YieldUnbalancedTx utx -> yieldUnbalancedTxH utx
 
 tokenMapToValue :: C.TokenMap -> Value
 tokenMapToValue = Value . Map.fromList . fmap (bimap coerce (Map.fromList . fmap (bimap coerce (fromIntegral . C.unTokenQuantity)) . toList)) . C.toNestedList

--- a/plutus-pab/src/Cardano/Wallet/Mock/Handlers.hs
+++ b/plutus-pab/src/Cardano/Wallet/Mock/Handlers.hs
@@ -218,5 +218,7 @@ fromWalletAPIError e@ChangeHasLessThanNAda {} =
     err500 {errBody = BSL8.pack $ show $ pretty e}
 fromWalletAPIError e@PaymentMkTxError {} =
     err500 {errBody = BSL8.pack $ show $ pretty e}
+fromWalletAPIError e@(RemoteClientFunctionNotYetSupported _) =
+    err500 {errBody = BSL8.pack $ show $ pretty e}
 fromWalletAPIError (OtherError text) =
     err500 {errBody = BSL.fromStrict $ encodeUtf8 text}

--- a/plutus-pab/src/Cardano/Wallet/Mock/Server.hs
+++ b/plutus-pab/src/Cardano/Wallet/Mock/Server.hs
@@ -13,13 +13,14 @@ module Cardano.Wallet.Mock.Server
     ) where
 
 import Cardano.BM.Data.Trace (Trace)
-import Cardano.ChainIndex.Types (ChainIndexUrl (..))
-import Cardano.Node.Client as NodeClient
+import Cardano.ChainIndex.Types (ChainIndexUrl (ChainIndexUrl))
+import Cardano.Node.Client qualified as NodeClient
 import Cardano.Protocol.Socket.Mock.Client qualified as MockClient
 import Cardano.Wallet.Mock.API (API)
-import Cardano.Wallet.Mock.Handlers
-import Cardano.Wallet.Mock.Types (Port (..), WalletConfig (..), WalletMsg (..), WalletUrl (..), Wallets, createWallet,
-                                  getWalletInfo, multiWallet)
+import Cardano.Wallet.Mock.Handlers (processWalletEffects)
+import Cardano.Wallet.Mock.Types (Port (Port), WalletMsg (StartingWallet), Wallets, createWallet, getWalletInfo,
+                                  multiWallet)
+import Cardano.Wallet.Types (LocalWalletSettings (LocalWalletSettings, baseUrl), WalletUrl (WalletUrl))
 import Control.Concurrent.Availability (Availability, available)
 import Control.Concurrent.MVar (MVar, newMVar)
 import Control.Monad ((>=>))
@@ -38,10 +39,10 @@ import Network.HTTP.Client (defaultManagerSettings, newManager)
 import Network.Wai.Handler.Warp qualified as Warp
 import Plutus.PAB.Arbitrary ()
 import Plutus.PAB.Monitoring.Monitoring qualified as LM
-import Servant (Application, NoContent (..), err404, hoistServer, serve, (:<|>) ((:<|>)))
+import Servant (Application, NoContent (NoContent), err404, hoistServer, serve, (:<|>) ((:<|>)))
 import Servant.Client (BaseUrl (baseUrlPort), ClientEnv, mkClientEnv)
 import Wallet.Effects (balanceTx, submitTxn, totalFunds, walletAddSignature)
-import Wallet.Emulator.Wallet (Wallet (..), WalletId)
+import Wallet.Emulator.Wallet (Wallet (Wallet), WalletId)
 import Wallet.Emulator.Wallet qualified as Wallet
 
 app :: Trace IO WalletMsg
@@ -66,8 +67,8 @@ app trace txSendHandle chainSyncHandle chainIndexEnv mVarState feeCfg slotCfg =
             (\w tx -> fmap (fromRight (error "Cardano.Wallet.Mock.Server: Expecting a mock tx, not an Alonzo tx when adding a signature."))
                     $ multiWallet (Wallet w) (walletAddSignature $ Right tx))
 
-main :: Trace IO WalletMsg -> WalletConfig -> FeeConfig -> FilePath -> SlotConfig -> ChainIndexUrl -> Availability -> IO ()
-main trace WalletConfig { baseUrl } feeCfg serverSocket slotCfg (ChainIndexUrl chainUrl) availability = LM.runLogEffects trace $ do
+main :: Trace IO WalletMsg -> LocalWalletSettings -> FeeConfig -> FilePath -> SlotConfig -> ChainIndexUrl -> Availability -> IO ()
+main trace LocalWalletSettings { baseUrl } feeCfg serverSocket slotCfg (ChainIndexUrl chainUrl) availability = LM.runLogEffects trace $ do
     chainIndexEnv <- buildEnv chainUrl defaultManagerSettings
     let knownWallets = Map.fromList $ zip Wallet.knownWallets (Wallet.fromMockWallet <$> CW.knownWallets)
     mVarState <- liftIO $ newMVar knownWallets

--- a/plutus-pab/src/Cardano/Wallet/RemoteClient.hs
+++ b/plutus-pab/src/Cardano/Wallet/RemoteClient.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeOperators     #-}
+
+module Cardano.Wallet.RemoteClient
+    ( handleWalletClient
+    ) where
+
+import Cardano.Api.NetworkId.Extra (NetworkIdWrapper (NetworkIdWrapper))
+import Cardano.Api.Shelley qualified as Cardano.Api
+import Cardano.Node.Types (MockServerConfig (mscNetworkId))
+import Control.Concurrent.STM qualified as STM
+import Control.Monad.Freer (Eff, LastMember, Member, type (~>))
+import Control.Monad.Freer.Error (Error, throwError)
+import Control.Monad.Freer.Reader (Reader, ask)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.Text qualified as Text
+import Plutus.Contract.Wallet (export)
+import Plutus.PAB.Core.ContractInstance.STM (InstancesState)
+import Plutus.PAB.Core.ContractInstance.STM qualified as Instances
+import Wallet.Effects (WalletEffect (BalanceTx, OwnPubKeyHash, SubmitTxn, TotalFunds, WalletAddSignature, YieldUnbalancedTx))
+import Wallet.Error (WalletAPIError (RemoteClientFunctionNotYetSupported), throwOtherError)
+import Wallet.Types (ContractInstanceId)
+
+-- | Wallet effect handler to remote client scenario.
+--
+-- Useful for browser-based wallets (Nami, Yoroi, etc.) where the PAB doesn't
+-- have direct access.
+--
+-- TODO: All wallet effects, except 'YieldUnbalancedTx' need to be implemented. See SCP-3094.
+handleWalletClient
+    :: forall m effs.
+    ( LastMember m effs
+    , MonadIO m
+    , Member (Error WalletAPIError) effs
+    , Member (Reader Cardano.Api.ProtocolParameters) effs
+    , Member (Reader InstancesState) effs
+    )
+    => MockServerConfig
+    -> Maybe ContractInstanceId
+    -> WalletEffect
+    ~> Eff effs
+handleWalletClient config cidM event = do
+    let NetworkIdWrapper networkId = mscNetworkId config
+    protocolParams <- ask @Cardano.Api.ProtocolParameters
+    case event of
+        OwnPubKeyHash -> do
+            throwError $ RemoteClientFunctionNotYetSupported "Cardano.Wallet.RemoteClient.OwnPubKeyHash"
+
+        WalletAddSignature _ -> do
+            throwError $ RemoteClientFunctionNotYetSupported "Cardano.Wallet.RemoteClient.WalletAddSignature"
+
+        TotalFunds -> do
+            throwError $ RemoteClientFunctionNotYetSupported "Cardano.Wallet.RemoteClient.TotalFunds"
+
+        SubmitTxn _ -> do
+            throwError $ RemoteClientFunctionNotYetSupported "Cardano.Wallet.RemoteClient.SubmitTxn"
+
+        BalanceTx _ ->
+            throwError $ RemoteClientFunctionNotYetSupported "Cardano.Wallet.RemoteClient.BalanceTx"
+
+        YieldUnbalancedTx utx -> do
+            case export protocolParams networkId utx of
+                Left err -> throwOtherError $ Text.pack $ show err
+                Right ex -> do
+                  case cidM of
+                    Nothing -> throwOtherError "RemoteWalletClient: No contract instance id"
+                    Just cid -> do
+                        iss <- ask @InstancesState
+                        liftIO $ STM.atomically $ do
+                            is <- Instances.instanceState cid iss
+                            STM.modifyTVar (Instances.issYieldedExportTxs is) (\txs -> txs ++ [ex])

--- a/plutus-pab/src/Cardano/Wallet/Types.hs
+++ b/plutus-pab/src/Cardano/Wallet/Types.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE DeriveAnyClass  #-}
+{-# LANGUAGE DerivingVia     #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Cardano.Wallet.Types
+    ( -- * Wallet configuration
+      WalletConfig (..)
+    , LocalWalletSettings (..)
+    , WalletUrl (..)
+    , defaultWalletConfig
+      -- * Lens and Prisms
+    , walletSettingsL
+    , baseUrlL
+    , _LocalWalletConfig
+    , _RemoteWalletConfig
+    ) where
+
+import Control.Lens (Lens', Traversal', lens, makePrisms)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Default (Default (def))
+import GHC.Generics (Generic)
+import Servant.Client (BaseUrl (BaseUrl), Scheme (Http))
+
+data WalletConfig =
+      LocalWalletConfig { walletSettings :: LocalWalletSettings }
+    | RemoteWalletConfig
+    deriving (Show, Eq, Generic)
+    deriving anyclass (FromJSON, ToJSON)
+
+instance Default WalletConfig where
+  def = defaultWalletConfig
+
+defaultWalletConfig :: WalletConfig
+defaultWalletConfig =
+  LocalWalletConfig $ LocalWalletSettings
+    -- See Note [pab-ports] in "test/full/Plutus/PAB/CliSpec.hs".
+    { baseUrl = WalletUrl $ BaseUrl Http "localhost" 9081 ""
+    }
+
+walletSettingsL :: Traversal' WalletConfig LocalWalletSettings
+walletSettingsL f (LocalWalletConfig settings) =
+    (\settings' -> LocalWalletConfig settings') <$> f settings
+walletSettingsL _ c@RemoteWalletConfig {} = pure c
+
+newtype LocalWalletSettings = LocalWalletSettings { baseUrl :: WalletUrl }
+    deriving (Show, Eq, Generic)
+    deriving anyclass (FromJSON, ToJSON)
+
+newtype WalletUrl = WalletUrl BaseUrl
+    deriving (Eq, Show, ToJSON, FromJSON) via BaseUrl
+
+baseUrlL :: Lens' LocalWalletSettings WalletUrl
+baseUrlL = lens g s where
+    g = baseUrl
+    s settings url = settings { baseUrl = url }
+
+makePrisms ''WalletConfig

--- a/plutus-pab/src/Plutus/PAB/Core.hs
+++ b/plutus-pab/src/Plutus/PAB/Core.hs
@@ -60,6 +60,7 @@ module Plutus.PAB.Core
     , waitForTxOutStatusChange
     , activeEndpoints
     , waitForEndpoint
+    , yieldedExportTxs
     , currentSlot
     , waitUntilSlot
     , waitNSlots
@@ -83,54 +84,57 @@ module Plutus.PAB.Core
     , timed
     ) where
 
-import Control.Applicative (Alternative (..))
+import Control.Applicative (Alternative ((<|>)))
 import Control.Concurrent.STM (STM)
 import Control.Concurrent.STM qualified as STM
 import Control.Lens (view)
 import Control.Monad (forM, guard, void)
 import Control.Monad.Freer (Eff, LastMember, Member, interpret, reinterpret, runM, send, subsume, type (~>))
 import Control.Monad.Freer.Error (Error, runError, throwError)
-import Control.Monad.Freer.Extras.Log (LogMessage, LogMsg (..), LogObserve, handleObserveLog, mapLog)
+import Control.Monad.Freer.Extras.Log (LogMessage, LogMsg (LMessage), LogObserve, handleObserveLog, mapLog)
 import Control.Monad.Freer.Extras.Modify qualified as Modify
-import Control.Monad.Freer.Reader (Reader (..), ask, asks, runReader)
-import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Freer.Reader (Reader (Ask), ask, asks, runReader)
+import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Aeson qualified as JSON
 import Data.Default (Default (def))
 import Data.Foldable (traverse_)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (catMaybes)
-import Data.Proxy (Proxy (..))
+import Data.Proxy (Proxy (Proxy))
 import Data.Set (Set)
 import Data.Text (Text)
 import Ledger (Address (addressCredential), TxOutRef)
 import Ledger.Tx (CardanoTx, ciTxOutValue)
 import Ledger.TxId (TxId)
 import Ledger.Value (Value)
-import Plutus.ChainIndex (ChainIndexQueryEffect, RollbackState (..), TxOutStatus, TxStatus)
+import Plutus.ChainIndex (ChainIndexQueryEffect, RollbackState (Unknown), TxOutStatus, TxStatus)
 import Plutus.ChainIndex qualified as ChainIndex
-import Plutus.Contract.Effects (ActiveEndpoint (..), PABReq)
+import Plutus.Contract.Effects (ActiveEndpoint (ActiveEndpoint, aeDescription), PABReq)
+import Plutus.Contract.Wallet (ExportTx)
 import Plutus.PAB.Core.ContractInstance (ContractInstanceMsg, ContractInstanceState)
 import Plutus.PAB.Core.ContractInstance qualified as ContractInstance
-import Plutus.PAB.Core.ContractInstance.STM (Activity (Active), BlockchainEnv, InstancesState, OpenEndpoint (..))
+import Plutus.PAB.Core.ContractInstance.STM (Activity (Active), BlockchainEnv, InstancesState, OpenEndpoint)
 import Plutus.PAB.Core.ContractInstance.STM qualified as Instances
-import Plutus.PAB.Effects.Contract (ContractDefinition, ContractEffect, ContractStore, PABContract (..), getState)
+import Plutus.PAB.Effects.Contract (ContractDefinition, ContractEffect, ContractStore, PABContract (ContractDef),
+                                    getState)
 import Plutus.PAB.Effects.Contract qualified as Contract
-import Plutus.PAB.Effects.TimeEffect (TimeEffect (..), systemTime)
+import Plutus.PAB.Effects.TimeEffect (TimeEffect (SystemTime), systemTime)
 import Plutus.PAB.Effects.UUID (UUIDEffect, handleUUIDEffect)
 import Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse, fromResp)
-import Plutus.PAB.Monitoring.PABLogMsg (PABMultiAgentMsg (..))
+import Plutus.PAB.Monitoring.PABLogMsg (PABMultiAgentMsg (ContractInstanceLog, EmulatorMsg))
 import Plutus.PAB.Timeout (Timeout)
 import Plutus.PAB.Timeout qualified as Timeout
 import Plutus.PAB.Types (PABError (ContractInstanceNotFound, InstanceAlreadyStopped, WalletError))
-import Plutus.PAB.Webserver.Types (ContractActivationArgs (..))
+import Plutus.PAB.Webserver.Types (ContractActivationArgs (ContractActivationArgs, caID, caWallet))
 import Wallet.API (PubKeyHash, Slot)
 import Wallet.API qualified as WAPI
 import Wallet.Effects (NodeClientEffect, WalletEffect)
 import Wallet.Emulator.LogMessages (RequestHandlerLogMsg, TxBalanceMsg)
-import Wallet.Emulator.MultiAgent (EmulatorEvent' (..), EmulatorTimeEvent (..))
-import Wallet.Emulator.Wallet (Wallet, WalletEvent (..), walletAddress)
-import Wallet.Types (ContractActivityStatus, ContractInstanceId, EndpointDescription (..), NotificationError)
+import Wallet.Emulator.MultiAgent (EmulatorEvent' (WalletEvent), EmulatorTimeEvent (EmulatorTimeEvent))
+import Wallet.Emulator.Wallet (Wallet, WalletEvent (GenericLog, RequestHandlerLog, TxBalanceLog), walletAddress)
+import Wallet.Types (ContractActivityStatus, ContractInstanceId, EndpointDescription (EndpointDescription),
+                     NotificationError)
 
 -- | Effects that are available in 'PABAction's.
 type PABEffects t env =
@@ -250,11 +254,11 @@ activateContract' ::
 activateContract' state cid w contractDef = do
     PABRunner{runPABAction} <- pabRunner
 
-    let handler :: forall a. Eff (ContractInstanceEffects t env '[IO]) a -> IO a
-        handler x = fmap (either (error . show) id) (runPABAction $ handleAgentThread w x)
+    let handler :: forall a. ContractInstanceId -> Eff (ContractInstanceEffects t env '[IO]) a -> IO a
+        handler _ x = fmap (either (error . show) id) (runPABAction $ handleAgentThread w (Just cid) x)
         args :: ContractActivationArgs (ContractDef t)
         args = ContractActivationArgs{caWallet = Just w, caID = contractDef}
-    handleAgentThread w
+    handleAgentThread w (Just cid)
         $ ContractInstance.startContractInstanceThread' @t @IO @(ContractInstanceEffects t env '[IO]) state cid handler args
 
 -- | Start a new instance of a contract
@@ -262,11 +266,11 @@ activateContract :: forall t env. PABContract t => Wallet -> ContractDef t -> PA
 activateContract w contractDef = do
     PABRunner{runPABAction} <- pabRunner
 
-    let handler :: forall a. Eff (ContractInstanceEffects t env '[IO]) a -> IO a
-        handler x = fmap (either (error . show) id) (runPABAction $ handleAgentThread w x)
+    let handler :: forall a. ContractInstanceId -> Eff (ContractInstanceEffects t env '[IO]) a -> IO a
+        handler cid x = fmap (either (error . show) id) (runPABAction $ handleAgentThread w (Just cid) x)
         args :: ContractActivationArgs (ContractDef t)
         args = ContractActivationArgs{caWallet = Just w, caID = contractDef}
-    handleAgentThread w
+    handleAgentThread w Nothing
         $ ContractInstance.activateContractSTM @t @IO @(ContractInstanceEffects t env '[IO]) handler args
 
 -- | Call a named endpoint on a contract instance. Waits if the endpoint is not
@@ -329,10 +333,10 @@ callEndpointOnInstance' instanceID ep value = do
         $ STM.atomically
         $ Instances.callEndpointOnInstance state (EndpointDescription ep) (JSON.toJSON value) instanceID
 
--- | Make a payment to a public key
-payToPublicKey :: Wallet -> PubKeyHash -> Value -> PABAction t env CardanoTx
-payToPublicKey source target amount =
-    handleAgentThread source
+-- | Make a payment to a public key.
+payToPublicKey :: ContractInstanceId -> Wallet -> PubKeyHash -> Value -> PABAction t env CardanoTx
+payToPublicKey cid source target amount =
+    handleAgentThread source (Just cid)
         $ Modify.wrapError WalletError
         $ WAPI.payToPublicKeyHash WAPI.defaultSlotRange amount target
 
@@ -361,9 +365,10 @@ type ContractInstanceEffects t env effs =
 handleAgentThread ::
     forall t env a.
     Wallet
+    -> Maybe ContractInstanceId
     -> Eff (ContractInstanceEffects t env '[IO]) a
     -> PABAction t env a
-handleAgentThread wallet action = do
+handleAgentThread wallet cidM action = do
     PABEnvironment{effectHandlers, blockchainEnv, instancesState} <- ask @(PABEnvironment t env)
     let EffectHandlers{handleContractStoreEffect, handleContractEffect, handleServicesEffects} = effectHandlers
     let action' :: Eff (ContractInstanceEffects t env (IO ': PABEffects t env)) a = Modify.raiseEnd action
@@ -381,7 +386,7 @@ handleAgentThread wallet action = do
         $ (interpret (mapLog @_ @(PABMultiAgentMsg t) EmulatorMsg) . reinterpret (timed @EmulatorEvent') . reinterpret (mapLog (WalletEvent wallet)) . reinterpret (mapLog RequestHandlerLog))
         $ (interpret (mapLog @_ @(PABMultiAgentMsg t) EmulatorMsg) . reinterpret (timed @EmulatorEvent') . reinterpret (mapLog (WalletEvent wallet)) . reinterpret (mapLog TxBalanceLog))
         $ handleUUIDEffect
-        $ handleServicesEffects wallet
+        $ handleServicesEffects wallet cidM
         $ handleContractStoreEffect
         $ handleContractEffect action'
 
@@ -449,6 +454,7 @@ data EffectHandlers t env =
             , LastMember IO effs
             )
             => Wallet
+            -> Maybe ContractInstanceId
             -> Eff (WalletEffect ': ChainIndexQueryEffect ': NodeClientEffect ': effs)
             ~> Eff effs
 
@@ -486,7 +492,7 @@ timed = \case
 
 -- | Get the current state of the contract instance.
 instanceState :: forall t env. Wallet -> ContractInstanceId -> PABAction t env (Contract.State t)
-instanceState wallet instanceId = handleAgentThread wallet (Contract.getState @t instanceId)
+instanceState wallet instanceId = handleAgentThread wallet (Just instanceId) (Contract.getState @t instanceId)
 
 -- | An STM transaction that returns the observable state of the contract instance.
 observableState :: forall t env. ContractInstanceId -> PABAction t env (STM JSON.Value)
@@ -530,6 +536,15 @@ waitForEndpoint instanceId endpointName = do
         eps <- tx
         guard $ any (\Instances.OpenEndpoint{Instances.oepName=ActiveEndpoint{aeDescription=EndpointDescription nm}} -> nm == endpointName) eps
 
+-- | Get exported transactions waiting to be balanced, signed and submitted by
+-- an external client.
+yieldedExportTxs :: forall t env. ContractInstanceId -> PABAction t env [ExportTx]
+yieldedExportTxs instanceId = do
+    instancesState <- asks @(PABEnvironment t env) instancesState
+    liftIO $ STM.atomically $ do
+        is <- Instances.instanceState instanceId instancesState
+        Instances.yieldedExportTxs is
+
 currentSlot :: forall t env. PABAction t env (STM Slot)
 currentSlot = do
     Instances.BlockchainEnv{Instances.beCurrentSlot} <- asks @(PABEnvironment t env) blockchainEnv
@@ -565,7 +580,7 @@ finalResult instanceId = do
 -- TODO: Change from 'Wallet' to 'Address' (see SCP-2208).
 valueAt :: Wallet -> PABAction t env Value
 valueAt wallet = do
-  handleAgentThread wallet $ do
+  handleAgentThread wallet Nothing $ do
     utxoRefs <- getAllUtxoRefs def
     txOutsM <- traverse ChainIndex.txOutFromRef utxoRefs
     pure $ foldMap (view ciTxOutValue) $ catMaybes txOutsM

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
@@ -17,7 +17,7 @@ Start the threads for contract instances
 
 -}
 module Plutus.PAB.Core.ContractInstance(
-    ContractInstanceMsg(..)
+    RequestHandlers.ContractInstanceMsg(..)
     , activateContractSTM
     , activateContractSTM'
     , initContractInstanceState
@@ -32,46 +32,50 @@ module Plutus.PAB.Core.ContractInstance(
     -- * Indexed block
     ) where
 
-import Control.Applicative (Alternative (..))
+import Control.Applicative (Alternative (empty, (<|>)))
 import Control.Arrow ((>>>))
 import Control.Concurrent (forkIO)
 import Control.Concurrent.STM (STM)
 import Control.Concurrent.STM qualified as STM
 import Control.Lens (preview)
 import Control.Monad (forM_, void)
-import Control.Monad.Freer
+import Control.Monad.Freer (Eff, LastMember, Member, type (~>))
 import Control.Monad.Freer.Error (Error)
 import Control.Monad.Freer.Extras.Log (LogMessage, LogMsg, LogObserve, logDebug, logInfo)
 import Control.Monad.Freer.Reader (Reader, ask, runReader)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Aeson (Value)
 import Data.Maybe (fromMaybe)
-import Data.Proxy (Proxy (..))
+import Data.Proxy (Proxy (Proxy))
 import Data.Text qualified as Text
 
-import Plutus.Contract.Effects (ActiveEndpoint (..), PABReq (..), PABResp (..))
+import Plutus.Contract.Effects (ActiveEndpoint (aeDescription),
+                                PABReq (AwaitUtxoProducedReq, AwaitUtxoSpentReq, ExposeEndpointReq),
+                                PABResp (AwaitSlotResp, AwaitTimeResp, AwaitTxOutStatusChangeResp, AwaitTxStatusChangeResp, AwaitUtxoProducedResp, AwaitUtxoSpentResp, ExposeEndpointResp))
 import Plutus.Contract.Effects qualified as Contract.Effects
-import Plutus.Contract.Resumable (Request (..), Response (..))
-import Plutus.Contract.State (ContractResponse (..), State (..))
+import Plutus.Contract.Resumable (Request (Request, itID, rqID, rqRequest), Response (Response))
+import Plutus.Contract.State (ContractResponse (ContractResponse, err, hooks, newState), State (State, observableState))
 import Plutus.Contract.Trace qualified as RequestHandler
-import Plutus.Contract.Trace.RequestHandler (RequestHandler (..), RequestHandlerLogMsg, extract, maybeToHandler,
-                                             tryHandler', wrapHandler)
-import Plutus.PAB.Core.ContractInstance.RequestHandlers (ContractInstanceMsg (..))
+import Plutus.Contract.Trace.RequestHandler (RequestHandler (RequestHandler), RequestHandlerLogMsg, extract,
+                                             maybeToHandler, tryHandler', wrapHandler)
+import Plutus.PAB.Core.ContractInstance.RequestHandlers (ContractInstanceMsg (ActivatedContractInstance, HandlingRequests, InitialisingContract))
+import Plutus.PAB.Core.ContractInstance.RequestHandlers qualified as RequestHandlers
 
 import Wallet.Effects (NodeClientEffect, WalletEffect)
 import Wallet.Emulator.LogMessages (TxBalanceMsg)
 import Wallet.Emulator.Wallet qualified as Wallet
 
 import Plutus.ChainIndex (ChainIndexQueryEffect, RollbackState (Unknown))
-import Plutus.PAB.Core.ContractInstance.STM (Activity (Done, Stopped), BlockchainEnv (..), InstanceState (..),
-                                             InstancesState, callEndpointOnInstance, emptyInstanceState)
+import Plutus.PAB.Core.ContractInstance.STM (Activity (Done, Stopped), BlockchainEnv,
+                                             InstanceState (InstanceState, issStop), InstancesState,
+                                             callEndpointOnInstance, emptyInstanceState)
 import Plutus.PAB.Core.ContractInstance.STM qualified as InstanceState
-import Plutus.PAB.Effects.Contract (ContractEffect, ContractStore, PABContract (..))
+import Plutus.PAB.Effects.Contract (ContractEffect, ContractStore, PABContract (ContractDef, serialisableState))
 import Plutus.PAB.Effects.Contract qualified as Contract
 import Plutus.PAB.Effects.UUID (UUIDEffect, uuidNextRandom)
-import Plutus.PAB.Events.Contract (ContractInstanceId (..))
-import Plutus.PAB.Types (PABError (..))
-import Plutus.PAB.Webserver.Types (ContractActivationArgs (..))
+import Plutus.PAB.Events.Contract (ContractInstanceId (ContractInstanceId))
+import Plutus.PAB.Types (PABError)
+import Plutus.PAB.Webserver.Types (ContractActivationArgs (ContractActivationArgs, caID, caWallet))
 
 -- | Container for holding a few bits of state related to the contract
 -- instance that we may want to pass in.
@@ -95,7 +99,7 @@ activateContractSTM' ::
     )
     => ContractInstanceState t
     -> ContractInstanceId
-    -> (Eff appBackend ~> IO)
+    -> (ContractInstanceId -> Eff appBackend ~> IO)
     -> ContractActivationArgs (ContractDef t)
     -> Eff effs ContractInstanceId
 activateContractSTM' c@ContractInstanceState{contractState} activeContractInstanceId runAppBackend a@ContractActivationArgs{caID, caWallet} = do
@@ -119,11 +123,12 @@ startContractInstanceThread' ::
     )
     => ContractInstanceState t
     -> ContractInstanceId
-    -> (Eff appBackend ~> IO)
+    -> (ContractInstanceId -> Eff appBackend ~> IO)
     -> ContractActivationArgs (ContractDef t)
     -> Eff effs ContractInstanceId
 startContractInstanceThread' ContractInstanceState{stmState} activeContractInstanceId runAppBackend a = do
-  s <- startSTMInstanceThread' @t @m stmState runAppBackend a activeContractInstanceId
+  s <- startSTMInstanceThread'
+    @t @m stmState runAppBackend a activeContractInstanceId
   ask >>= void . liftIO . STM.atomically . InstanceState.insertInstance activeContractInstanceId s
   pure activeContractInstanceId
 
@@ -140,7 +145,7 @@ activateContractSTM ::
     , LastMember m (Reader ContractInstanceId ': appBackend)
     , LastMember m effs
     )
-    => (Eff appBackend ~> IO)
+    => (ContractInstanceId -> Eff appBackend ~> IO)
     -> ContractActivationArgs (ContractDef t)
     -> Eff effs ContractInstanceId
 activateContractSTM runAppBackend a = do
@@ -263,6 +268,7 @@ stmRequestHandler = fmap sequence (wrapHandler (fmap pure nonBlockingRequests) <
         <> RequestHandler.handleOwnInstanceIdQueries @effs
         <> RequestHandler.handleCurrentSlotQueries @effs
         <> RequestHandler.handleCurrentTimeQueries @effs
+        <> RequestHandler.handleYieldedUnbalancedTx @effs
 
     -- requests that wait for changes to happen
     blockingRequests =
@@ -283,7 +289,7 @@ startSTMInstanceThread' ::
     , LastMember m (Reader InstanceState ': Reader ContractInstanceId ': appBackend)
     )
     => STM InstanceState
-    -> (Eff appBackend ~> IO)
+    -> (ContractInstanceId -> Eff appBackend ~> IO)
     -> ContractActivationArgs (ContractDef t)
     -> ContractInstanceId
     -> Eff effs InstanceState
@@ -291,7 +297,7 @@ startSTMInstanceThread' stmState runAppBackend def instanceID =  do
     state <- liftIO $ STM.atomically stmState
     _ <- liftIO
         $ forkIO
-        $ runAppBackend
+        $ runAppBackend instanceID
         $ runReader instanceID
         $ runReader state
         $ stmInstanceLoop @t @m @(Reader InstanceState ': Reader ContractInstanceId ': appBackend) def instanceID
@@ -305,7 +311,7 @@ startSTMInstanceThread ::
     , AppBackendConstraints t m appBackend
     , LastMember m (Reader InstanceState ': Reader ContractInstanceId ': appBackend)
     )
-    => (Eff appBackend ~> IO)
+    => (ContractInstanceId -> Eff appBackend ~> IO)
     -> ContractActivationArgs (ContractDef t)
     -> ContractInstanceId
     -> Eff effs InstanceState

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/STM.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/STM.hs
@@ -41,6 +41,7 @@ module Plutus.PAB.Core.ContractInstance.STM(
     , callEndpointOnInstance
     , callEndpointOnInstanceTimeout
     , observableContractState
+    , yieldedExportTxs
     , instanceState
     , instanceIDs
     , instancesWithStatuses
@@ -48,7 +49,7 @@ module Plutus.PAB.Core.ContractInstance.STM(
     , InstanceClientEnv(..)
     ) where
 
-import Control.Applicative (Alternative (..))
+import Control.Applicative (Alternative (empty))
 import Control.Concurrent.STM (STM, TMVar, TVar)
 import Control.Concurrent.STM qualified as STM
 import Control.Monad (guard, (<=<))
@@ -60,16 +61,18 @@ import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Set (Set)
 import Ledger (Address, Slot, TxId, TxOutRef)
-import Ledger.Time (POSIXTime (..))
+import Ledger.Time (POSIXTime)
 import Ledger.TimeSlot qualified as TimeSlot
-import Plutus.ChainIndex (BlockNumber (..), ChainIndexTx, TxIdState (..), TxOutBalance, TxOutStatus, TxStatus,
+import Plutus.ChainIndex (BlockNumber (BlockNumber), ChainIndexTx, TxIdState, TxOutBalance, TxOutStatus, TxStatus,
                           transactionStatus)
 import Plutus.ChainIndex.TxOutBalance (transactionOutputStatus)
-import Plutus.ChainIndex.UtxoState (UtxoIndex, UtxoState (..), utxoState)
-import Plutus.Contract.Effects (ActiveEndpoint (..))
-import Plutus.Contract.Resumable (IterationID, Request (..), RequestID)
-import Wallet.Types (ContractInstanceId, EndpointDescription, EndpointValue (..), NotificationError (..))
-import Wallet.Types qualified as Wallet (ContractActivityStatus (..))
+import Plutus.ChainIndex.UtxoState (UtxoIndex, UtxoState (_usTxUtxoData), utxoState)
+import Plutus.Contract.Effects (ActiveEndpoint (ActiveEndpoint, aeDescription))
+import Plutus.Contract.Resumable (IterationID, Request (Request, itID, rqID, rqRequest), RequestID)
+import Plutus.Contract.Wallet (ExportTx)
+import Wallet.Types (ContractInstanceId, EndpointDescription, EndpointValue (EndpointValue),
+                     NotificationError (EndpointNotAvailable, InstanceDoesNotExist, MoreThanOneEndpointAvailable))
+import Wallet.Types qualified as Wallet (ContractActivityStatus (Active, Done, Stopped))
 
 {- Note [Contract instance thread model]
 
@@ -195,12 +198,13 @@ data Activity =
 -- | The state of an active contract instance.
 data InstanceState =
     InstanceState
-        { issEndpoints       :: TVar (Map (RequestID, IterationID) OpenEndpoint) -- ^ Open endpoints that can be responded to.
-        , issStatus          :: TVar Activity -- ^ Whether the instance is still running.
-        , issObservableState :: TVar (Maybe Value) -- ^ Serialised observable state of the contract instance (if available)
-        , issStop            :: TMVar () -- ^ Stop the instance if a value is written into the TMVar.
-        , issTxOutRefs       :: TVar (Map (RequestID, IterationID) OpenTxOutSpentRequest)
-        , issAddressRefs     :: TVar (Map (RequestID, IterationID) OpenTxOutProducedRequest)
+        { issEndpoints        :: TVar (Map (RequestID, IterationID) OpenEndpoint) -- ^ Open endpoints that can be responded to.
+        , issStatus           :: TVar Activity -- ^ Whether the instance is still running.
+        , issObservableState  :: TVar (Maybe Value) -- ^ Serialised observable state of the contract instance (if available)
+        , issStop             :: TMVar () -- ^ Stop the instance if a value is written into the TMVar.
+        , issTxOutRefs        :: TVar (Map (RequestID, IterationID) OpenTxOutSpentRequest)
+        , issAddressRefs      :: TVar (Map (RequestID, IterationID) OpenTxOutProducedRequest)
+        , issYieldedExportTxs :: TVar [ExportTx] -- ^ Partial tx that needs to be balanced, signed and submitted by an external agent.
         }
 
 -- | An 'InstanceState' value with empty fields
@@ -211,6 +215,7 @@ emptyInstanceState =
         <*> STM.newTVar Active
         <*> STM.newTVar Nothing
         <*> STM.newEmptyTMVar
+        <*> STM.newTVar mempty
         <*> STM.newTVar mempty
         <*> STM.newTVar mempty
 
@@ -336,6 +341,10 @@ callEndpointOnInstance' notAvailable (InstancesState m) endpointDescription valu
                 []   -> notAvailable
                 [ep] -> callEndpoint ep (EndpointValue value) >> pure Nothing
                 _    -> pure $ Just $ MoreThanOneEndpointAvailable instanceID endpointDescription
+
+-- | The list of all partial txs that need to be balanced on the instance.
+yieldedExportTxs :: InstanceState -> STM [ExportTx]
+yieldedExportTxs = STM.readTVar . issYieldedExportTxs
 
 -- | State of all contract instances that are currently running
 newtype InstancesState = InstancesState { getInstancesState :: TVar (Map ContractInstanceId InstanceState) }

--- a/plutus-pab/src/Plutus/PAB/Types.hs
+++ b/plutus-pab/src/Plutus/PAB/Types.hs
@@ -12,11 +12,11 @@
 module Plutus.PAB.Types where
 
 import Cardano.ChainIndex.Types qualified as ChainIndex
-import Cardano.Node.Types (MockServerConfig (..))
-import Cardano.Wallet.Mock.Types qualified as Wallet
+import Cardano.Node.Types (MockServerConfig)
+import Cardano.Wallet.Types qualified as Wallet
 import Control.Lens.TH (makePrisms)
 import Control.Monad.Freer.Extras.Beam (BeamError)
-import Data.Aeson (FromJSON, ToJSON (..))
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Default (Default, def)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -26,14 +26,15 @@ import Data.UUID (UUID)
 import Data.UUID.Extras qualified as UUID
 import GHC.Generics (Generic)
 import Ledger (Block, Blockchain, Tx, TxId, eitherTx, txId)
-import Ledger.Index as UtxoIndex
+import Ledger.Index (UtxoIndex (UtxoIndex))
+import Ledger.Index qualified as UtxoIndex
 import Plutus.Contract.Types (ContractError)
 import Plutus.PAB.Instances ()
 import Prettyprinter (Pretty, line, pretty, viaShow, (<+>))
-import Servant.Client (BaseUrl (..), ClientError, Scheme (Http))
+import Servant.Client (BaseUrl (BaseUrl), ClientError, Scheme (Http))
 import Wallet.API (WalletAPIError)
 import Wallet.Emulator.Wallet (Wallet)
-import Wallet.Types (ContractInstanceId (..), NotificationError)
+import Wallet.Types (ContractInstanceId (ContractInstanceId), NotificationError)
 
 data PABError
     = FileNotFound FilePath
@@ -56,6 +57,7 @@ data PABError
     | ContractStateNotFound ContractInstanceId
     | AesonDecodingError Text Text
     | MigrationNotDoneError Text
+    | RemoteWalletWithMockNodeError
     deriving stock (Show, Eq, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
@@ -84,6 +86,7 @@ instance Pretty PABError where
                                    <> line
                                    <> "Did you forget to run the 'migrate' command ?"
                                    <+> "(ex. 'plutus-pab-migrate' or 'plutus-pab-examples --config <CONFIG_FILE> migrate')"
+        RemoteWalletWithMockNodeError   -> "The remote wallet can't be used with the mock node."
 
 data DbConfig =
     DbConfig

--- a/plutus-pab/src/Plutus/PAB/Webserver/API.hs
+++ b/plutus-pab/src/Plutus/PAB/Webserver/API.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds          #-}
-{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE TypeFamilies       #-}
 {-# LANGUAGE TypeOperators      #-}
@@ -21,7 +20,8 @@ import Servant.API.WebSocket (WebSocketPending)
 import Servant.Swagger.UI (SwaggerSchemaUI)
 import Wallet.Types (ContractInstanceId)
 
-type WalletProxy walletId = "wallet" :> (Wallet.API walletId)
+-- TODO: This wallet proxy will be eventually removed. See SCP-3096.
+type WalletProxy walletId = "wallet" :> Wallet.API walletId
 
 type WSAPI =
     "ws" :>

--- a/plutus-pab/src/Plutus/PAB/Webserver/Handler.hs
+++ b/plutus-pab/src/Plutus/PAB/Webserver/Handler.hs
@@ -25,31 +25,36 @@ module Plutus.PAB.Webserver.Handler
     ) where
 
 import Cardano.Wallet.Mock.Client qualified as Wallet.Client
-import Cardano.Wallet.Mock.Types (WalletInfo (..))
+import Cardano.Wallet.Mock.Types (WalletInfo (WalletInfo, wiPubKeyHash, wiWallet))
 import Control.Lens (preview)
 import Control.Monad (join)
 import Control.Monad.Freer (sendM)
 import Control.Monad.Freer.Error (throwError)
-import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Aeson qualified as JSON
 import Data.Either (fromRight)
 import Data.Foldable (traverse_)
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.OpenApi.Schema (ToSchema)
-import Data.Proxy (Proxy (..))
+import Data.Proxy (Proxy (Proxy))
 import Data.Text (Text)
 import Ledger (Value)
 import Ledger.Constraints.OffChain (UnbalancedTx)
 import Ledger.Tx (Tx)
 import Plutus.Contract.Effects (PABReq, _ExposeEndpointReq)
+import Plutus.Contract.Wallet (ExportTx)
 import Plutus.PAB.Core (PABAction)
 import Plutus.PAB.Core qualified as Core
 import Plutus.PAB.Effects.Contract qualified as Contract
-import Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse (..), fromResp)
-import Plutus.PAB.Types
+import Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse (hooks), fromResp)
+import Plutus.PAB.Types (PABError (ContractInstanceNotFound, EndpointCallError, WalletClientError))
 import Plutus.PAB.Webserver.API (API)
-import Plutus.PAB.Webserver.Types
+import Plutus.PAB.Webserver.Types (ContractActivationArgs (ContractActivationArgs, caID, caWallet),
+                                   ContractInstanceClientState (ContractInstanceClientState, cicContract, cicCurrentState, cicDefinition, cicStatus, cicWallet, cicYieldedExportTxs),
+                                   ContractReport (ContractReport, crActiveContractStates, crAvailableContracts),
+                                   ContractSignatureResponse (ContractSignatureResponse),
+                                   FullReport (FullReport, chainReport, contractReport), emptyChainReport)
 import Servant (NoContent (NoContent), (:<|>) ((:<|>)))
 import Servant.Client (ClientEnv, ClientM, runClientM)
 import Servant.OpenApi (toOpenApi)
@@ -57,8 +62,8 @@ import Servant.Server qualified as Servant
 import Servant.Swagger.UI (SwaggerSchemaUI', swaggerSchemaUIServer)
 import Wallet.Effects qualified
 import Wallet.Emulator.Error (WalletAPIError)
-import Wallet.Emulator.Wallet (Wallet (..), WalletId, knownWallet)
-import Wallet.Types (ContractActivityStatus, ContractInstanceId (..), parseContractActivityStatus)
+import Wallet.Emulator.Wallet (Wallet (Wallet), WalletId, knownWallet)
+import Wallet.Types (ContractActivityStatus, ContractInstanceId, parseContractActivityStatus)
 
 healthcheck :: forall t env. PABAction t env ()
 healthcheck = pure ()
@@ -114,22 +119,24 @@ apiHandler =
 swagger :: forall t api dir. (Servant.Server api ~ Servant.Handler JSON.Value, ToSchema (Contract.ContractDef t)) => Servant.Server (SwaggerSchemaUI' dir api)
 swagger = swaggerSchemaUIServer $ toOpenApi (Proxy @(API (Contract.ContractDef t) Integer))
 
-fromInternalState ::
-    t
+fromInternalState
+    :: t
     -> ContractInstanceId
     -> ContractActivityStatus
-    -> Maybe Wallet
+    -> Wallet
+    -> [ExportTx]
     -> PartiallyDecodedResponse PABReq
     -> ContractInstanceClientState t
-fromInternalState t i s wallet resp =
+fromInternalState t i s wallet yieldedExportTxs resp =
     ContractInstanceClientState
         { cicContract = i
         , cicCurrentState =
             let hks' = mapMaybe (traverse (preview _ExposeEndpointReq)) (hooks resp)
             in resp { hooks = hks' }
-        , cicWallet = fromMaybe (knownWallet 1) wallet
+        , cicWallet = wallet
         , cicDefinition = t
         , cicStatus = s
+        , cicYieldedExportTxs = yieldedExportTxs
         }
 
 -- HANDLERS
@@ -138,13 +145,21 @@ activateContract :: forall t env. Contract.PABContract t => ContractActivationAr
 activateContract ContractActivationArgs{caID, caWallet} = do
     Core.activateContract (fromMaybe (knownWallet 1) caWallet) caID
 
-contractInstanceState :: forall t env. Contract.PABContract t => ContractInstanceId -> PABAction t env (ContractInstanceClientState (Contract.ContractDef t))
+contractInstanceState
+    :: forall t env. Contract.PABContract t
+    => ContractInstanceId
+    -> PABAction t env (ContractInstanceClientState (Contract.ContractDef t))
 contractInstanceState i = do
     definition <- Contract.getDefinition @t i
     instWithStatuses <- Core.instancesWithStatuses
     case (definition, Map.lookup i instWithStatuses) of
-        (Just ContractActivationArgs{caWallet, caID}, Just s) ->
-            fromInternalState caID i s caWallet . fromResp . Contract.serialisableState (Proxy @t) <$> Contract.getState @t i
+        (Just ContractActivationArgs{caWallet, caID}, Just s) -> do
+            let wallet = fromMaybe (knownWallet 1) caWallet
+            yieldedExportedTxs <- Core.yieldedExportTxs i
+            fmap ( fromInternalState caID i s wallet yieldedExportedTxs
+                 . fromResp
+                 . Contract.serialisableState (Proxy @t)
+                 ) $ Contract.getState @t i
         _ -> throwError @PABError (ContractInstanceNotFound i)
 
 callEndpoint :: forall t env. ContractInstanceId -> String -> JSON.Value -> PABAction t env ()
@@ -155,13 +170,21 @@ instancesForWallets wallet mStatus = filter ((==) (Wallet wallet) . cicWallet) <
 
 allInstanceStates :: forall t env. Contract.PABContract t => Maybe Text -> PABAction t env [ContractInstanceClientState (Contract.ContractDef t)]
 allInstanceStates mStatus = do
-    let mActivityStatus = join $ parseContractActivityStatus <$> mStatus
-    mp <- Contract.getContracts @t mActivityStatus
     instWithStatuses <- Core.instancesWithStatuses
-    let isInstanceStatusMatch s = maybe True ((==) s) mActivityStatus
-    let getStatus (i, args) = (i, args,) <$> Map.lookup i instWithStatuses
-    let get (i, ContractActivationArgs{caWallet, caID}, s) = fromInternalState caID i s caWallet . fromResp . Contract.serialisableState (Proxy @t) <$> Contract.getState @t i
-    filter (isInstanceStatusMatch . cicStatus) <$> traverse get (mapMaybe getStatus $ Map.toList mp)
+    let mActivityStatus = join $ parseContractActivityStatus <$> mStatus
+        isInstanceStatusMatch s = maybe True ((==) s) mActivityStatus
+        getStatus (i, args) = (i, args,) <$> Map.lookup i instWithStatuses
+        get (i, ContractActivationArgs{caWallet, caID}, s) =
+            let wallet = fromMaybe (knownWallet 1) caWallet
+             in do
+                yieldedExportedTxs <- Core.yieldedExportTxs i
+                fmap ( fromInternalState caID i s wallet yieldedExportedTxs
+                     . fromResp
+                     . Contract.serialisableState (Proxy @t)
+                     ) $ Contract.getState @t i
+    mp <- Contract.getContracts @t mActivityStatus
+    filter (isInstanceStatusMatch . cicStatus)
+        <$> traverse get (mapMaybe getStatus $ Map.toList mp)
 
 availableContracts :: forall t env. Contract.PABContract t => PABAction t env [ContractSignatureResponse (Contract.ContractDef t)]
 availableContracts = do
@@ -206,13 +229,13 @@ walletProxy ::
     :<|> (WalletId -> Tx -> PABAction t env Tx))
 walletProxy createNewWallet =
     createNewWallet
-    :<|> (\w tx -> fmap (const NoContent) (Core.handleAgentThread (Wallet w) $ Wallet.Effects.submitTxn $ Right tx))
+    :<|> (\w tx -> fmap (const NoContent) (Core.handleAgentThread (Wallet w) Nothing $ Wallet.Effects.submitTxn $ Right tx))
     :<|> (\w -> (\pkh -> WalletInfo{wiWallet=Wallet w, wiPubKeyHash = pkh })
-            <$> Core.handleAgentThread (Wallet w) Wallet.Effects.ownPubKeyHash)
+            <$> Core.handleAgentThread (Wallet w) Nothing Wallet.Effects.ownPubKeyHash)
     :<|> (\w -> fmap (fmap (fromRight (error "Plutus.PAB.Webserver.Handler: Expecting a mock tx, not an Alonzo tx when submitting it.")))
-              . Core.handleAgentThread (Wallet w) . Wallet.Effects.balanceTx)
-    :<|> (\w -> Core.handleAgentThread (Wallet w) Wallet.Effects.totalFunds)
+              . Core.handleAgentThread (Wallet w) Nothing . Wallet.Effects.balanceTx)
+    :<|> (\w -> Core.handleAgentThread (Wallet w) Nothing Wallet.Effects.totalFunds)
     :<|> (\w tx -> fmap (fromRight (error "Plutus.PAB.Webserver.Handler: Expecting a mock tx, not an Alonzo tx when adding a signature."))
-                 $ Core.handleAgentThread (Wallet w)
+                 $ Core.handleAgentThread (Wallet w) Nothing
                  $ Wallet.Effects.walletAddSignature
                  $ Right tx)

--- a/plutus-pab/src/Plutus/PAB/Webserver/Types.hs
+++ b/plutus-pab/src/Plutus/PAB/Webserver/Types.hs
@@ -20,6 +20,7 @@ import Ledger.Index (UtxoIndex)
 import Ledger.Slot (Slot)
 import Playground.Types (FunctionSchema)
 import Plutus.Contract.Effects (ActiveEndpoint, PABReq)
+import Plutus.Contract.Wallet (ExportTx)
 import Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse)
 import Prettyprinter (Pretty, pretty, (<+>))
 import Schema (FormSchema)
@@ -84,11 +85,12 @@ instance Pretty t => Pretty (ContractActivationArgs t) where
 --   (to be sent to external clients)
 data ContractInstanceClientState t =
     ContractInstanceClientState
-        { cicContract     :: ContractInstanceId
-        , cicCurrentState :: PartiallyDecodedResponse ActiveEndpoint
-        , cicWallet       :: Wallet
-        , cicDefinition   :: t
-        , cicStatus       :: ContractActivityStatus
+        { cicContract         :: ContractInstanceId
+        , cicCurrentState     :: PartiallyDecodedResponse ActiveEndpoint
+        , cicWallet           :: Wallet
+        , cicDefinition       :: t
+        , cicStatus           :: ContractActivityStatus
+        , cicYieldedExportTxs :: [ExportTx]
         }
         deriving stock (Eq, Show, Generic)
         deriving anyclass (ToJSON, FromJSON)
@@ -99,6 +101,7 @@ deriving instance OpenApi.ToSchema t => OpenApi.ToSchema (ContractInstanceClient
 data InstanceStatusToClient
     = NewObservableState JSON.Value -- ^ The observable state of the contract has changed.
     | NewActiveEndpoints [ActiveEndpoint] -- ^ The set of active endpoints has changed.
+    | NewYieldedExportTxs [ExportTx] -- ^ Partial txs that need to be balanced, signed and submitted by an external client.
     | ContractFinished (Maybe JSON.Value) -- ^ Contract instance is done with an optional error message.
     deriving stock (Generic, Eq, Show)
     deriving anyclass (ToJSON, FromJSON)

--- a/plutus-pab/src/Plutus/PAB/Webserver/WebSocket.hs
+++ b/plutus-pab/src/Plutus/PAB/Webserver/WebSocket.hs
@@ -34,10 +34,10 @@ import Control.Monad.Freer.Error (throwError)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (ToJSON)
 import Data.Aeson qualified as JSON
-import Data.Bifunctor (Bifunctor (..))
+import Data.Bifunctor (Bifunctor (first))
 import Data.Foldable (fold)
 import Data.Map qualified as Map
-import Data.Proxy (Proxy (..))
+import Data.Proxy (Proxy (Proxy))
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -46,19 +46,23 @@ import Ledger (PubKeyHash)
 import Ledger.Slot (Slot)
 import Network.WebSockets qualified as WS
 import Network.WebSockets.Connection (Connection, PendingConnection)
-import Plutus.Contract.Effects (ActiveEndpoint (..))
+import Plutus.Contract.Effects (ActiveEndpoint)
+import Plutus.Contract.Wallet (ExportTx)
 import Plutus.PAB.Core (PABAction)
 import Plutus.PAB.Core qualified as Core
-import Plutus.PAB.Core.ContractInstance.STM (BlockchainEnv, InstancesState, OpenEndpoint (..))
+import Plutus.PAB.Core.ContractInstance.STM (BlockchainEnv, InstancesState, OpenEndpoint (oepName))
 import Plutus.PAB.Core.ContractInstance.STM qualified as Instances
 import Plutus.PAB.Effects.Contract qualified as Contract
 import Plutus.PAB.Events.ContractInstanceState (fromResp)
 import Plutus.PAB.Types (PABError (OtherError))
 import Plutus.PAB.Webserver.API ()
-import Plutus.PAB.Webserver.Types (CombinedWSStreamToClient (..), CombinedWSStreamToServer (..), ContractReport (..),
-                                   ContractSignatureResponse (..), InstanceStatusToClient (..))
+import Plutus.PAB.Webserver.Types (CombinedWSStreamToClient (InstanceUpdate, SlotChange),
+                                   CombinedWSStreamToServer (Subscribe, Unsubscribe),
+                                   ContractReport (ContractReport, crActiveContractStates, crAvailableContracts),
+                                   ContractSignatureResponse (ContractSignatureResponse),
+                                   InstanceStatusToClient (ContractFinished, NewActiveEndpoints, NewObservableState, NewYieldedExportTxs))
 import Servant ((:<|>) ((:<|>)))
-import Wallet.Types (ContractInstanceId (..))
+import Wallet.Types (ContractInstanceId)
 
 getContractReport :: forall t env. Contract.PABContract t => PABAction t env (ContractReport (Contract.ContractDef t))
 getContractReport = do
@@ -108,6 +112,12 @@ openEndpoints contractInstanceId instancesState = do
       instanceState <- Instances.instanceState contractInstanceId instancesState
       fmap (oepName . snd) . Map.toList <$> Instances.openEndpoints instanceState
 
+yieldedExportTxsChange :: ContractInstanceId -> InstancesState -> STMStream [ExportTx]
+yieldedExportTxsChange contractInstanceId instancesState =
+    unfold $ do
+      instanceState <- Instances.instanceState contractInstanceId instancesState
+      Instances.yieldedExportTxs instanceState
+
 finalValue :: ContractInstanceId -> InstancesState -> STMStream (Maybe JSON.Value)
 finalValue contractInstanceId instancesState =
     singleton $ Instances.finalResult contractInstanceId instancesState
@@ -118,6 +128,7 @@ instanceUpdates instanceId instancesState =
     fold
         [ NewObservableState <$> observableStateChange instanceId instancesState
         , NewActiveEndpoints <$> openEndpoints instanceId instancesState
+        , NewYieldedExportTxs      <$> yieldedExportTxsChange instanceId instancesState
         , ContractFinished   <$> finalValue instanceId instancesState
         ]
 

--- a/plutus-pab/test/light/Cardano/Wallet/RemoteClientSpec.hs
+++ b/plutus-pab/test/light/Cardano/Wallet/RemoteClientSpec.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TupleSections    #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Wallet.RemoteClientSpec
+    ( tests
+    ) where
+
+import Cardano.Api.ProtocolParameters (ProtocolParameters)
+import Cardano.Wallet.RemoteClient (handleWalletClient)
+import Control.Concurrent.STM qualified as STM
+import Control.Monad.Freer (interpret, runM)
+import Control.Monad.Freer.Error (runError)
+import Control.Monad.Freer.Reader (runReader)
+import Control.Monad.IO.Class (liftIO)
+import Data.Default (Default (def))
+import Data.List qualified as List
+import Gen.Cardano.Api.Typed qualified as Gen
+import Hedgehog (Property, (===))
+import Hedgehog qualified
+import Ledger.Constraints.OffChain (emptyUnbalancedTx)
+import Plutus.Contract (WalletAPIError)
+import Plutus.PAB.Core.ContractInstance.STM (InstancesState, emptyInstanceState, emptyInstancesState, insertInstance,
+                                             instanceState, yieldedExportTxs)
+import Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+import Wallet.Effects (WalletEffect (YieldUnbalancedTx))
+import Wallet.Emulator.Error (WalletAPIError (OtherError))
+import Wallet.Types (ContractInstanceId, randomID)
+
+tests :: TestTree
+tests = testGroup "Cardano.Wallet.RemoteClient"
+    [ testGroup "yieldUnbalancedTx"
+        [ testProperty "should put partial tx in contract instance state" yieldToInstanceState
+        , testProperty "should throw error when no contract instance id is provided" yieldNoCid
+        ]
+    ]
+
+-- | Verify that a yielded unbalanced (partial) tx will appear in the contract's
+-- instance status.
+yieldToInstanceState :: Property
+yieldToInstanceState = Hedgehog.property $ do
+    pp <- Hedgehog.forAll Gen.genProtocolParameters
+    cid <- liftIO randomID
+
+    let utx = emptyUnbalancedTx
+    result <- liftIO $ do
+        iss <- STM.atomically $ do
+            iss <- emptyInstancesState
+            is <- emptyInstanceState
+            insertInstance cid is iss
+            pure iss
+        yieldedRes <- runRemoteWalletEffects pp iss (Just cid) (YieldUnbalancedTx utx)
+        pure $ fmap (,iss) yieldedRes
+
+    case result of
+      Left _ -> Hedgehog.assert False
+      Right ((), iss) -> do
+          txs <- liftIO $ STM.atomically $ instanceState cid iss >>= yieldedExportTxs
+          List.length txs === 1
+
+-- | An error should be thrown when no contract instance id is provided.
+yieldNoCid :: Property
+yieldNoCid = Hedgehog.property $ do
+    pp <- Hedgehog.forAll Gen.genProtocolParameters
+    result <- liftIO $ do
+        iss <- STM.atomically emptyInstancesState
+        runRemoteWalletEffects pp iss Nothing (YieldUnbalancedTx emptyUnbalancedTx)
+    case result of
+      Left (OtherError _) -> Hedgehog.assert True
+      _                   -> Hedgehog.assert False
+
+-- | Run the wallet effects in a remote wallet scenario.
+runRemoteWalletEffects
+    :: ProtocolParameters
+    -> InstancesState
+    -> Maybe ContractInstanceId
+    -> WalletEffect ()
+    -> IO (Either WalletAPIError ())
+runRemoteWalletEffects protocolParams is cidM action = do
+    runM
+        $ runError @WalletAPIError
+        $ runReader protocolParams
+        $ runReader is
+        $ handleWalletClient def cidM action

--- a/plutus-pab/test/light/Spec.hs
+++ b/plutus-pab/test/light/Spec.hs
@@ -3,6 +3,7 @@ module Main
     ) where
 
 import Cardano.Api.NetworkId.ExtraSpec qualified
+import Cardano.Wallet.RemoteClientSpec qualified
 import Cardano.Wallet.ServerSpec qualified
 import Control.Concurrent.STM.ExtrasSpec qualified
 import Test.Tasty (defaultMain, testGroup)
@@ -13,6 +14,7 @@ main =
     testGroup
         "all tests"
         [ Cardano.Api.NetworkId.ExtraSpec.tests
+        , Cardano.Wallet.RemoteClientSpec.tests
         , Cardano.Wallet.ServerSpec.tests
         , Control.Concurrent.STM.ExtrasSpec.tests
         ]


### PR DESCRIPTION
First part of the hosted PAB scenario for a remote wallet client.

We expose partial transactions that need to be balanced, signed and submitted by the remote wallet.

What was done:

* New WalletEffect, `yieldUnbalancedTx`, which makes available an unbalanced tx to be balanced, signed and then submitted to the blockchain.

* Added ToJSON and FromJSON instances to ExportTx (partial tx)

* Additionnal Generic and OpenAPI.ToSchema orphan instances for some cardano-api types.

* New wallet handler in the PAB: RemoteClient. The only implemented wallet effect for the moment is `YieldUnbalancedTx`. The rest of the effects will be implemented in the future.

* Changed the PAB wallet config settings which allows the user to specify if the wallet is available locally or remotely.

* In the PAB, partial txs (`ExportTx`) are now exposed in the contract instance status endpoint (additionnaly as a `NewYieldedPartialTx` message in the websocket) when calling `yieldUnbalancedTx`.

Here's a simple setup to test this functionality:

1- In the `plutus-pab.yaml` config file, set the following attributes:
```
...
walletServerConfig:
  tag: RemoteWalletConfig
...
nodeServerConfig:
  ...
  mscNodeMode: AlonzoNode
...
```
2- Open a terminal and run `cabal run plutus-pab:exe:plutus-pab-examples -- webserver --config plutus-pab/plutus-pab.yaml.sample`

3- Open another terminal and execute the following shell script:
```
#!/usr/bin/env sh

INSTANCE_ID=$(curl -s -H "Content-Type: application/json" \
  --request POST \
  --data '{"caID": {"tag": "PayToWallet"}, "caWallet":{"getWalletId": "ffffffffffffffffffffffffffffffffffffffff"}}' \
  http://localhost:9080/api/contract/activate | jq -r '.unContractInstanceId')

curl -s http://localhost:9080/api/contract/instance/"$INSTANCE_ID"/status | jq

curl -H "Content-Type: application/json" \
  --request POST \
  --data '{"amount": {"getValue": [[{"unCurrencySymbol": ""}, [[{"unTokenName": ""}, 10000000]]]]}, "pkh": {"getPubKeyHash": "a2c20c77887ace1cd986193e4e75babd8993cfd56995cd5cfce609c2"}}' \
  'http://localhost:9080/api/contract/instance/'"$INSTANCE_ID"'/endpoint/PayToWallet'

sleep 1

curl -s http://localhost:9080/api/contract/instance/"$INSTANCE_ID"/status | jq
```
You should see a yielded tx similar the to following:
```
  "cicYieldedExportTxs": [
    {
      "transaction": "84a500800d80018182581d60a2c20c77887ace1cd986193e4e75babd8993cfd56995cd5cfce609c21a0098968002000e80a0f5f6",
      "redeemers": [],
      "inputs": []
    }
  ],
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
