### PR TITLE
SCP-3064: Fixed failing test case in the Crowdfunding plutus use case

### DIFF
--- a/plutus-use-cases/test/Spec/Auction.hs
+++ b/plutus-use-cases/test/Spec/Auction.hs
@@ -209,11 +209,16 @@ instance ContractModel AuctionModel where
         case cmd of
             WaitUntil slot -> slot > s ^. currentSlot
 
-            -- In order to place a bid, we need to satifsy the constraint where
+            -- In order to place a bid, we need to satisfy the constraint where
             -- each tx output must have at least N Ada.
+            --
             -- When we bid, we must make sure that we don't bid too high such
-            -- that we can't pay to fees anymore and have a tx output of less
-            -- than N Ada.
+            -- that:
+            --     - we can't pay for fees anymore
+            --     - we have a tx output of less than N Ada.
+            --
+            -- We suppose the initial balance is 100 Ada. Needs to be changed if
+            -- the emulator initialises the wallets with a different value.
             Bid w bid      -> let currentWalletBalance = Ada.adaOf 100 + Ada.fromValue (s ^. balanceChange w)
                                   current = s ^. contractState . currentBid
                                in    bid > current


### PR DESCRIPTION
The failing test case can be run using:

```
cabal test plutus-use-cases --test-options="-p \"crowdfunding.QuickCheck ContractModel\" --quickcheck-replay=714845"
```

This corrects a bug resulting from the PR #76 

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
