### PR TITLE
add plutus-doc to build

### DIFF
--- a/plutus-pab/test-node/README.md
+++ b/plutus-pab/test-node/README.md
@@ -24,7 +24,7 @@ You will need ~6 terminals to run all the different components.
 
   ```
   > cd $PLUTUS
-  > cabal build plutus-pab-examples plutus-chain-index cardano-node cardano-wallet
+  > cabal build plutus-pab-examples plutus-chain-index cardano-node cardano-wallet plutus-doc
   ```
 
 3. Start the testnet node locally:


### PR DESCRIPTION
plutus-doc is a dependency of step 4 of the test-node. Added to build step 1. Without this addition, several steps will ask for plutus-doc:doctest and refuse to run. Perhaps there is a smaller build step to use, but this one works.

This is a single-word commit that does not affect code.

unrelated: when finally able to run step 4, I get a lot of:
```
[cardano-wallet.pools-engine:Warning:27] [2021-11-25 21:20:34.21 UTC] {"string":"Still not syncing. Applied 0 blocks, 0 rollbacks in the last 30.00195666s. Currently at slot 0. (not applying blocks)"}
[cardano-wallet.network:Warning:16] [2021-11-25 21:20:34.65 UTC] {"string":"Couldn't connect to node (x277). Retrying in a bit..."}
```