### PR TITLE
Change path for chain-index.db

### DIFF
--- a/plutus-pab/test-node/testnet/chain-index-config.json
+++ b/plutus-pab/test-node/testnet/chain-index-config.json
@@ -6,7 +6,7 @@
   "cicPort": 9083,
   "cicSecurityParam": 2160,
   "cicSocketPath": "testnet/node.sock",
-  "cicDbPath": "/tmp/chain-index.db",
+  "cicDbPath": "testnet/chain-index.db",
   "cicNetworkId": {
     "contents": {
       "unNetworkMagic": 1097911063


### PR DESCRIPTION
Currently, chain-index db is saved under /tmp. Since /tmp is periodically cleaned up by OS, chain-index will then start syncing again from genesis. 

This commit updates 'cicDbPath' to relocate 'chain-index.db' to "$PLUTUS/plutus-pab/test-node/testnet" directory, similar to that of db for cardano-node.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
