### PR TITLE
Update pab-config.yml to work with latest wallet config

### DIFF
--- a/plutus-pab/test-node/testnet/pab-config.yml
+++ b/plutus-pab/test-node/testnet/pab-config.yml
@@ -12,9 +12,9 @@ pabWebserverConfig:
   endpointTimeout: 5
 
 walletServerConfig:
-  baseUrl: http://localhost:8090
-  wallet:
-    getWallet: 1
+  tag: LocalWalletConfig
+  walletSettings:
+    baseUrl: http://localhost:8090
 
 nodeServerConfig:
   mscSocketPath: testnet/node.sock


### PR DESCRIPTION
The current pab-config.yml uses an outdated wallet config that will throw an error, this can be especially confusing to users trying to do the integration test example. This PR will update the config to be compliant with the current wallet configuration.