### PR TITLE
SCP-3147: MkTx JSON logs

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-contract.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-contract.nix
@@ -94,6 +94,7 @@
           "Plutus/Contract/Request"
           "Plutus/Contract/Checkpoint"
           "Plutus/Contract/Constraints"
+          "Plutus/Contract/Logging"
           "Plutus/Contract/Oracle"
           "Plutus/Contract/State"
           "Plutus/Contract/Schema"

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-contract.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-contract.nix
@@ -94,6 +94,7 @@
           "Plutus/Contract/Request"
           "Plutus/Contract/Checkpoint"
           "Plutus/Contract/Constraints"
+          "Plutus/Contract/Logging"
           "Plutus/Contract/Oracle"
           "Plutus/Contract/State"
           "Plutus/Contract/Schema"

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-contract.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-contract.nix
@@ -94,6 +94,7 @@
           "Plutus/Contract/Request"
           "Plutus/Contract/Checkpoint"
           "Plutus/Contract/Constraints"
+          "Plutus/Contract/Logging"
           "Plutus/Contract/Oracle"
           "Plutus/Contract/State"
           "Plutus/Contract/Schema"

--- a/plutus-contract/plutus-contract.cabal
+++ b/plutus-contract/plutus-contract.cabal
@@ -46,6 +46,7 @@ library
         Plutus.Contract.Request
         Plutus.Contract.Checkpoint
         Plutus.Contract.Constraints
+        Plutus.Contract.Logging
         Plutus.Contract.Oracle
         Plutus.Contract.State
         Plutus.Contract.Schema

--- a/plutus-contract/src/Plutus/Contract.hs
+++ b/plutus-contract/src/Plutus/Contract.hs
@@ -95,10 +95,7 @@ module Plutus.Contract(
     , AsCheckpointError(..)
     , CheckpointError(..)
     -- * Logging
-    , logDebug
-    , logInfo
-    , logWarn
-    , logError
+    , module Logging
     -- * Row-related things
     , HasType
     , ContractRow
@@ -106,9 +103,9 @@ module Plutus.Contract(
     , type Empty
     ) where
 
-import Data.Aeson (ToJSON (toJSON))
 import Data.Row (Empty, HasType, type (.\/))
 
+import Plutus.Contract.Logging as Logging
 import Plutus.Contract.Request (ContractRow)
 import Plutus.Contract.Request qualified as Request
 import Plutus.Contract.Schema qualified as Schema
@@ -118,7 +115,6 @@ import Plutus.Contract.Types (AsCheckpointError (..), AsContractError (..), Chec
                               handleError, mapError, never, promiseBind, promiseMap, runError, select, selectEither,
                               selectList, throwError)
 
-import Control.Monad.Freer.Extras.Log qualified as L
 import Control.Monad.Freer.Writer qualified as W
 import Data.Functor.Apply (liftF2)
 import Wallet.API (WalletAPIError)
@@ -127,22 +123,6 @@ import Wallet.Types qualified
 -- | Execute both contracts in any order
 both :: Promise w s e a -> Promise w s e b -> Promise w s e (a, b)
 both a b = liftF2 (,) a b `select` liftF2 (flip (,)) b a
-
--- | Log a message at the 'Debug' level
-logDebug :: ToJSON a => a -> Contract w s e ()
-logDebug = Contract . L.logDebug . toJSON
-
--- | Log a message at the 'Info' level
-logInfo :: ToJSON a => a -> Contract w s e ()
-logInfo = Contract . L.logInfo . toJSON
-
--- | Log a message at the 'Warning' level
-logWarn :: ToJSON a => a -> Contract w s e ()
-logWarn = Contract . L.logWarn . toJSON
-
--- | Log a message at the 'Error' level
-logError :: ToJSON a => a -> Contract w s e ()
-logError = Contract . L.logError . toJSON
 
 -- | Update the contract's accumulating state @w@
 tell :: w -> Contract w s e ()

--- a/plutus-contract/src/Plutus/Contract/Logging.hs
+++ b/plutus-contract/src/Plutus/Contract/Logging.hs
@@ -1,0 +1,28 @@
+module Plutus.Contract.Logging(
+  logDebug
+  , logInfo
+  , logWarn
+  , logError
+) where
+
+
+import Data.Aeson (ToJSON (toJSON))
+import Plutus.Contract.Types (Contract (..))
+
+import Control.Monad.Freer.Extras.Log qualified as L
+
+-- | Log a message at the 'Debug' level
+logDebug :: ToJSON a => a -> Contract w s e ()
+logDebug = Contract . L.logDebug . toJSON
+
+-- | Log a message at the 'Info' level
+logInfo :: ToJSON a => a -> Contract w s e ()
+logInfo = Contract . L.logInfo . toJSON
+
+-- | Log a message at the 'Warning' level
+logWarn :: ToJSON a => a -> Contract w s e ()
+logWarn = Contract . L.logWarn . toJSON
+
+-- | Log a message at the 'Error' level
+logError :: ToJSON a => a -> Contract w s e ()
+logError = Contract . L.logError . toJSON

--- a/plutus-contract/src/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Plutus/Contract/Request.hs
@@ -857,6 +857,8 @@ mkTxContract lookups txc = do
         Left err -> throwError err
         Right r' -> return r'
 
+{-| Arguments and result of a call to 'mkTx'
+-}
 data MkTxLog =
     MkTxLog
         { mkTxLogLookups       :: ScriptLookups Any
@@ -864,7 +866,7 @@ data MkTxLog =
         , mkTxLogResult        :: Either Constraints.MkTxError UnbalancedTx
         }
         deriving stock (Show, Generic)
-        deriving anyclass (ToJSON)
+        deriving anyclass (ToJSON, FromJSON)
 
 -- | Build a transaction that satisfies the constraints
 mkTxConstraints :: forall a w s e.

--- a/plutus-contract/src/Plutus/Contract/StateMachine.hs
+++ b/plutus-contract/src/Plutus/Contract/StateMachine.hs
@@ -79,12 +79,12 @@ import Ledger.Typed.Scripts qualified as Scripts
 import Ledger.Typed.Tx (TypedScriptTxOut (TypedScriptTxOut, tyTxOutData, tyTxOutTxOut))
 import Ledger.Typed.Tx qualified as Typed
 import Ledger.Value qualified as Value
-import Plutus.Contract.Request (mkTxContract)
 import Plutus.ChainIndex (ChainIndexTx (_citxInputs))
 import Plutus.Contract (AsContractError (_ConstraintResolutionError, _ContractError), Contract, ContractError, Promise,
                         awaitPromise, isSlot, isTime, logWarn, mapError, never, ownPaymentPubKeyHash, promiseBind,
                         select, submitTxConfirmed, utxoIsProduced, utxoIsSpent, utxosAt, utxosTxOutTxAt,
                         utxosTxOutTxFromTx)
+import Plutus.Contract.Request (mkTxContract)
 import Plutus.Contract.StateMachine.MintingPolarity (MintingPolarity (Burn, Mint))
 import Plutus.Contract.StateMachine.OnChain (State (State, stateData, stateValue),
                                              StateMachine (StateMachine, smFinal, smThreadToken, smTransition),

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -19,6 +19,7 @@ module Ledger.Constraints.OffChain(
     -- * Lookups
     ScriptLookups(..)
     , typedValidatorLookups
+    , generalise
     , unspentOutputs
     , mintingPolicy
     , otherScript
@@ -84,7 +85,7 @@ import Ledger.Scripts (Datum (Datum), DatumHash, MintingPolicy, MintingPolicyHas
 import Ledger.Tx (ChainIndexTxOut, RedeemerPtr (RedeemerPtr), ScriptTag (Mint), Tx,
                   TxOut (txOutAddress, txOutDatumHash, txOutValue), TxOutRef)
 import Ledger.Tx qualified as Tx
-import Ledger.Typed.Scripts (TypedValidator, ValidatorTypes (DatumType, RedeemerType))
+import Ledger.Typed.Scripts (Any, TypedValidator, ValidatorTypes (DatumType, RedeemerType))
 import Ledger.Typed.Scripts qualified as Scripts
 import Ledger.Typed.Tx (ConnectionError)
 import Ledger.Typed.Tx qualified as Typed
@@ -113,6 +114,11 @@ data ScriptLookups a =
         -- ^ The contract's stake public key hash (optional)
         } deriving stock (Show, Generic)
           deriving anyclass (ToJSON, FromJSON)
+
+generalise :: ScriptLookups a -> ScriptLookups Any
+generalise sl =
+    let validator = fmap Scripts.generalise (slTypedValidator sl)
+    in sl{slTypedValidator = validator}
 
 instance Semigroup (ScriptLookups a) where
     l <> r =

--- a/plutus-ledger/src/Ledger/Typed/TypeUtils.hs
+++ b/plutus-ledger/src/Ledger/Typed/TypeUtils.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE EmptyDataDeriving     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds             #-}
@@ -7,11 +10,19 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
-module Ledger.Typed.TypeUtils where
+module Ledger.Typed.TypeUtils(
+    Any
+    , HListF(..)
+    , hfOut
+    ) where
 
+import Data.Aeson (ToJSON)
 import Data.Kind
+import GHC.Generics (Generic)
 
 data Any
+    deriving stock (Eq, Show, Generic)
+    deriving anyclass (ToJSON)
 
 -- | A heterogeneous list where every element is wrapped with the given functor.
 data HListF (f :: Type -> Type) (l :: [Type]) where

--- a/plutus-use-cases/scripts/Main.hs
+++ b/plutus-use-cases/scripts/Main.hs
@@ -35,6 +35,7 @@ writeWhat :: Command -> String
 writeWhat (Scripts FullyAppliedValidators) = "scripts (fully applied)"
 writeWhat (Scripts UnappliedValidators)    = "scripts (unapplied)"
 writeWhat Transactions{}                   = "transactions"
+writeWhat MkTxLogs                         = "mkTx logs"
 
 pathParser :: Parser FilePath
 pathParser = strArgument (metavar "SCRIPT_PATH" <> help "output path")
@@ -48,7 +49,7 @@ networkIdParser =
     in p <|> pure C.Mainnet
 
 commandParser :: Parser Command
-commandParser = hsubparser $ mconcat [scriptsParser, transactionsParser]
+commandParser = hsubparser $ mconcat [scriptsParser, transactionsParser, mkTxParser]
 
 scriptsParser :: Mod CommandFields Command
 scriptsParser =
@@ -63,6 +64,13 @@ transactionsParser =
     info
         (Transactions <$> networkIdParser <*> protocolParamsParser)
         (fullDesc <> progDesc "Write partial transactions")
+
+mkTxParser :: Mod CommandFields Command
+mkTxParser =
+    command "mktx" $
+    info
+        (pure MkTxLogs)
+        (fullDesc <> progDesc "Write logs for 'mkTx' calls")
 
 progParser :: ParserInfo ScriptsConfig
 progParser =


### PR DESCRIPTION
Add some logging to extract the arguments and results of all calls to `mkTx`. 

```haskell
{-| Arguments and result of a call to 'mkTx'
-}
data MkTxLog =
    MkTxLog
        { mkTxLogLookups       :: ScriptLookups Any
        , mkTxLogTxConstraints :: TxConstraints PlutusTx.BuiltinData PlutusTx.BuiltinData
        , mkTxLogResult        :: Either Constraints.MkTxError UnbalancedTx
        }
        deriving stock (Show, Generic)
        deriving anyclass (ToJSON, FromJSON)

```

The JSON objects are values of the `MkTxLog` type. To get the results, run `mkdir tmp && cabal run plutus-use-cases-scripts -- ./tmp mktx`.

[Example](https://gist.github.com/j-mueller/352798e4004cef94298037e2869b0f2b)

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
