### PR TITLE
Add raiseMUnderN to freer-extras

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Types.hs
+++ b/plutus-contract/src/Plutus/Contract/Types.hs
@@ -74,7 +74,7 @@ import Control.Monad.Freer
 import Control.Monad.Freer.Error (Error)
 import Control.Monad.Freer.Error qualified as E
 import Control.Monad.Freer.Extras.Log (LogMessage, LogMsg, handleLogIgnore, handleLogWriter)
-import Control.Monad.Freer.Extras.Modify (raiseEnd, raiseUnderN, writeIntoState)
+import Control.Monad.Freer.Extras.Modify (raiseEnd, raiseUnder, writeIntoState)
 import Control.Monad.Freer.State
 import Control.Monad.Freer.Writer (Writer)
 import Control.Monad.Freer.Writer qualified as W
@@ -282,7 +282,7 @@ runError ::
   forall w s e e0 a.
   Contract w s e a
   -> Contract w s e0 (Either e a)
-runError (Contract r) = Contract (E.runError $ raiseUnderN @'[E.Error e0] r)
+runError (Contract r) = Contract (E.runError $ raiseUnder r)
 
 -- | Handle errors, potentially throwing new errors.
 handleError ::
@@ -291,7 +291,7 @@ handleError ::
   -> Contract w s e a
   -> Contract w s e' a
 handleError f (Contract c) = Contract c' where
-  c' = E.handleError @e (raiseUnderN @'[E.Error e'] c) (fmap unContract f)
+  c' = E.handleError @e (raiseUnder c) (fmap unContract f)
 
 type SuspendedContractEffects w e =
   Error e


### PR DESCRIPTION
This may seem silly, but I needed this for `M = 6` and `N = 3`.

The `mapEffs` function seems generally useful, so I suggested to add it to `freer-simple`: https://github.com/lexi-lambda/freer-simple/issues/37

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
