### PR TITLE
Write arbitrary instance for data that uses sized

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
@@ -445,11 +445,13 @@
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
             (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError "quickcheck-instances"))
             (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             (hsPkgs."smallcheck" or (errorHandler.buildDepError "smallcheck"))
+            (hsPkgs."hedgehog-quickcheck" or (errorHandler.buildDepError "hedgehog-quickcheck"))
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
             (hsPkgs."tasty-smallcheck" or (errorHandler.buildDepError "tasty-smallcheck"))
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
@@ -465,6 +467,7 @@
             "Cardano/Wallet/RemoteClientSpec"
             "Cardano/Wallet/ServerSpec"
             "Control/Concurrent/STM/ExtrasSpec"
+            "Plutus/PAB/ArbitrarySpec"
             ];
           hsSourceDirs = [ "test/light" ];
           mainPath = [ "Spec.hs" ];

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
@@ -445,11 +445,13 @@
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
             (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError "quickcheck-instances"))
             (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             (hsPkgs."smallcheck" or (errorHandler.buildDepError "smallcheck"))
+            (hsPkgs."hedgehog-quickcheck" or (errorHandler.buildDepError "hedgehog-quickcheck"))
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
             (hsPkgs."tasty-smallcheck" or (errorHandler.buildDepError "tasty-smallcheck"))
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
@@ -465,6 +467,7 @@
             "Cardano/Wallet/RemoteClientSpec"
             "Cardano/Wallet/ServerSpec"
             "Control/Concurrent/STM/ExtrasSpec"
+            "Plutus/PAB/ArbitrarySpec"
             ];
           hsSourceDirs = [ "test/light" ];
           mainPath = [ "Spec.hs" ];

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab.nix
@@ -445,11 +445,13 @@
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
             (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError "quickcheck-instances"))
             (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             (hsPkgs."smallcheck" or (errorHandler.buildDepError "smallcheck"))
+            (hsPkgs."hedgehog-quickcheck" or (errorHandler.buildDepError "hedgehog-quickcheck"))
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
             (hsPkgs."tasty-smallcheck" or (errorHandler.buildDepError "tasty-smallcheck"))
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
@@ -465,6 +467,7 @@
             "Cardano/Wallet/RemoteClientSpec"
             "Cardano/Wallet/ServerSpec"
             "Control/Concurrent/STM/ExtrasSpec"
+            "Plutus/PAB/ArbitrarySpec"
             ];
           hsSourceDirs = [ "test/light" ];
           mainPath = [ "Spec.hs" ];

--- a/plutus-pab/plutus-pab.cabal
+++ b/plutus-pab/plutus-pab.cabal
@@ -432,6 +432,7 @@ test-suite plutus-pab-test-light
         Cardano.Wallet.RemoteClientSpec
         Cardano.Wallet.ServerSpec
         Control.Concurrent.STM.ExtrasSpec
+        Plutus.PAB.ArbitrarySpec
 
     build-depends:
         QuickCheck -any,
@@ -455,11 +456,13 @@ test-suite plutus-pab-test-light
         plutus-pab,
         plutus-ledger -any,
         plutus-ledger-constraints -any,
+        plutus-tx -any,
         quickcheck-instances -any,
         servant-client -any,
         tasty -any,
         tasty-hunit -any,
         smallcheck -any,
+        hedgehog-quickcheck -any,
         tasty-hedgehog -any,
         tasty-smallcheck -any,
         tasty-quickcheck -any,

--- a/plutus-pab/test/light/Plutus/PAB/ArbitrarySpec.hs
+++ b/plutus-pab/test/light/Plutus/PAB/ArbitrarySpec.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Plutus.PAB.ArbitrarySpec where
+
+import Hedgehog (MonadGen, Property, forAll, property)
+import Hedgehog qualified
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Gen.QuickCheck qualified as Gen
+import Hedgehog.Range qualified as Range
+import Plutus.PAB.Arbitrary ()
+import PlutusTx (Data (..))
+import PlutusTx qualified
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+tests :: TestTree
+tests = testGroup "Plutus.PAB.ArbitrarySpec"
+  [ testProperty "arbitrary data is bounded by size parameter" dataBoundedBySizeProp ]
+
+dataBoundedBySizeProp :: Property
+dataBoundedBySizeProp = property $ do
+  maxNodes <- forAll $ Gen.integral_ $ Range.linear 0 10000
+  d <- forAll $ Gen.resize (fromInteger maxNodes) Gen.arbitrary
+  Hedgehog.assert $ countDataNodes d <= maxNodes + 1
+
+countDataNodes :: Data -> Integer
+countDataNodes = \case
+  Constr _ ds -> 1 + foldr ((+) . countDataNodes) 0 ds
+  Map pairs   -> 1 + foldr ((+) . (\(a, b) -> countDataNodes a + countDataNodes b)) 0 pairs
+  List ds     -> 1 + foldr ((+) . countDataNodes) 0 ds
+  I _         -> 1
+  B _         -> 1

--- a/plutus-pab/test/light/Spec.hs
+++ b/plutus-pab/test/light/Spec.hs
@@ -6,6 +6,7 @@ import Cardano.Api.NetworkId.ExtraSpec qualified
 import Cardano.Wallet.RemoteClientSpec qualified
 import Cardano.Wallet.ServerSpec qualified
 import Control.Concurrent.STM.ExtrasSpec qualified
+import Plutus.PAB.ArbitrarySpec qualified
 import Test.Tasty (defaultMain, testGroup)
 
 main :: IO ()
@@ -17,4 +18,5 @@ main =
         , Cardano.Wallet.RemoteClientSpec.tests
         , Cardano.Wallet.ServerSpec.tests
         , Control.Concurrent.STM.ExtrasSpec.tests
+        , Plutus.PAB.ArbitrarySpec.tests
         ]


### PR DESCRIPTION
By using sized we can have an arbitrary instance that actually
terminates and is configurable via standard QuickCheck
methods (e.g. generate, resize). This will allow testing with Datums and
will prevent users unintentionally stalling their tests when generating
Datums, BuiltinData, and Data. Fixes #172.