### PR TITLE
[plutus-chain-index]: fix utxo-at-adress beam query (#124).

### DIFF
--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
@@ -39,7 +39,7 @@ import Data.Proxy (Proxy (..))
 import Data.Set qualified as Set
 import Data.Word (Word64)
 import Database.Beam (Columnar, Identity, SqlSelect, TableEntity, aggregate_, all_, countAll_, delete, filter_, guard_,
-                      limit_, nub_, select, val_)
+                      limit_, not_, nub_, select, val_)
 import Database.Beam.Backend.SQL (BeamSqlBackendCanSerialize)
 import Database.Beam.Query (HasSqlEqualityCheck, asc_, desc_, exists_, orderBy_, update, (&&.), (<-.), (<.), (==.),
                             (>.))
@@ -198,12 +198,12 @@ getUtxoSetAtAddress pageQuery (toDbValue -> cred) = do
       tp           -> do
           let query =
                 fmap _addressRowOutRef
-                  $ filter_ (\row -> _addressRowCred row ==. val_ cred)
-                  $ do
-                    utxo <- all_ (unspentOutputRows db)
-                    a <- all_ (addressRows db)
-                    guard_ (_addressRowOutRef a ==. _unspentOutputRowOutRef utxo)
-                    pure a
+                  $ filter_ (\row ->
+                      (_addressRowCred row ==. val_ cred)
+                      &&. exists_ (filter_ (\utxo -> _addressRowOutRef row ==. _unspentOutputRowOutRef utxo) (all_ (unspentOutputRows db)))
+                      &&. not_ (exists_ (filter_ (\utxi -> _addressRowOutRef row ==. _unmatchedInputRowOutRef utxi) (all_ (unmatchedInputRows db))))
+                      )
+                  $ all_ (addressRows db)
 
           outRefs <- selectPage (fmap toDbValue pageQuery) query
           let page = fmap fromDbValue outRefs


### PR DESCRIPTION
Fix #124, when `utxo-at-adress` returns the incorrect set of utxos including the spent ones.

---

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
