### PR TITLE
SCP-3127: Chain index as a library

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-chain-index-core.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-chain-index-core.nix
@@ -134,7 +134,6 @@
             (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
             (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
-            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
             ];

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-chain-index.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-chain-index.nix
@@ -59,6 +59,7 @@
           "Plutus/ChainIndex/App"
           "Plutus/ChainIndex/CommandLine"
           "Plutus/ChainIndex/Config"
+          "Plutus/ChainIndex/Lib"
           "Plutus/ChainIndex/Logging"
           ];
         hsSourceDirs = [ "src" ];

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-chain-index.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-chain-index.nix
@@ -44,6 +44,7 @@
           (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
           (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+          (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
           (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-chain-index-core.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-chain-index-core.nix
@@ -134,7 +134,6 @@
             (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
             (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
-            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
             ];

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-chain-index.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-chain-index.nix
@@ -59,6 +59,7 @@
           "Plutus/ChainIndex/App"
           "Plutus/ChainIndex/CommandLine"
           "Plutus/ChainIndex/Config"
+          "Plutus/ChainIndex/Lib"
           "Plutus/ChainIndex/Logging"
           ];
         hsSourceDirs = [ "src" ];

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-chain-index.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-chain-index.nix
@@ -44,6 +44,7 @@
           (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
           (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+          (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
           (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-chain-index-core.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-chain-index-core.nix
@@ -134,7 +134,6 @@
             (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
             (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
-            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
             ];

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-chain-index.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-chain-index.nix
@@ -59,6 +59,7 @@
           "Plutus/ChainIndex/App"
           "Plutus/ChainIndex/CommandLine"
           "Plutus/ChainIndex/Config"
+          "Plutus/ChainIndex/Lib"
           "Plutus/ChainIndex/Logging"
           ];
         hsSourceDirs = [ "src" ];

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-chain-index.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-chain-index.nix
@@ -44,6 +44,7 @@
           (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
           (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+          (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
           (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))

--- a/plutus-chain-index-core/plutus-chain-index-core.cabal
+++ b/plutus-chain-index-core/plutus-chain-index-core.cabal
@@ -139,6 +139,5 @@ test-suite plutus-chain-index-test
         lens -any,
         serialise -any,
         sqlite-simple -any,
-        stm -any,
         tasty -any,
         tasty-hedgehog -any,

--- a/plutus-chain-index-core/src/Plutus/ChainIndex.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex.hs
@@ -36,7 +36,7 @@ import Control.Monad.IO.Class (liftIO)
 import Database.SQLite.Simple qualified as Sqlite
 import Plutus.Monitoring.Util (convertLog, runLogEffects)
 
--- | The required arguments to run the chain-index effects.
+-- | The required arguments to run the chain index effects.
 data RunRequirements = RunRequirements
     { trace         :: Trace IO ChainIndexLog
     , stateTVar     :: TVar ChainIndexState
@@ -44,7 +44,7 @@ data RunRequirements = RunRequirements
     , securityParam :: Int
     }
 
--- | Run the chain-index effects.
+-- | Run the chain index effects.
 runChainIndexEffects
     :: RunRequirements
     -> Eff '[ChainIndexQueryEffect, ChainIndexControlEffect, BeamEffect] a
@@ -54,7 +54,7 @@ runChainIndexEffects runReq action =
         $ handleChainIndexEffects runReq
         $ raiseEnd action
 
--- | Handle the chain-index effects from the set of all effects.
+-- | Handle the chain index effects from the set of all effects.
 handleChainIndexEffects
     :: (LastMember IO effs, Member (LogMsg ChainIndexLog) effs)
     => RunRequirements

--- a/plutus-chain-index-core/src/Plutus/ChainIndex.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex.hs
@@ -71,6 +71,7 @@ handleChainIndexEffects RunRequirements{trace, stateTVar, conn, securityParam} a
         $ interpret (handleBeam (convertLog BeamLogItem trace))
         $ interpret handleControl
         $ interpret handleQuery
+        -- Insert the 5 effects needed by the handlers of the 3 chain index effects between those 3 effects and 'effs'.
         $ raiseMUnderN @[_,_,_,_,_] @[_,_,_] action
     liftIO $ STM.atomically $ STM.writeTVar stateTVar newState
     pure result

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Effects.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Effects.hs
@@ -34,7 +34,7 @@ import Ledger.Credential (Credential)
 import Ledger.Tx (ChainIndexTxOut, TxOutRef)
 import Plutus.ChainIndex.Api (IsUtxoResponse, UtxosResponse)
 import Plutus.ChainIndex.Tx (ChainIndexTx)
-import Plutus.ChainIndex.Types (BlockProcessOption, Diagnostics, Point, Tip)
+import Plutus.ChainIndex.Types (ChainSyncBlock, Diagnostics, Point, Tip)
 
 data ChainIndexQueryEffect r where
 
@@ -79,7 +79,7 @@ makeEffect ''ChainIndexQueryEffect
 data ChainIndexControlEffect r where
 
     -- | Add a new block to the chain index by giving a new tip and list of tx.
-    AppendBlock :: Tip -> [ChainIndexTx] -> BlockProcessOption -> ChainIndexControlEffect ()
+    AppendBlock :: ChainSyncBlock -> ChainIndexControlEffect ()
 
     -- | Roll back to a previous state (previous tip)
     Rollback    :: Point -> ChainIndexControlEffect ()

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Server.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Server.hs
@@ -42,7 +42,7 @@ runChainIndexQuery ::
     RunRequirements
     -> Eff '[Error ServerError, ChainIndexQueryEffect, ChainIndexControlEffect] ~> Handler
 runChainIndexQuery runReq action = do
-    (result, _) <- liftIO $ runChainIndexEffects runReq $ runError $ raiseEnd action
+    result <- liftIO $ runChainIndexEffects runReq $ runError $ raiseEnd action
     case result of
         Right (Right a) -> pure a
         Right (Left e) -> E.throwError e

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Types.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Types.hs
@@ -34,7 +34,8 @@ module Plutus.ChainIndex.Types(
     , TxOutBalance(..)
     , tobUnspentOutputs
     , tobSpentOutputs
-    , BlockProcessOption(..)
+    , ChainSyncBlock(..)
+    , TxProcessOption(..)
     ) where
 
 import Codec.Serialise (Serialise)
@@ -56,15 +57,18 @@ import Data.Set qualified as Set
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import Ledger (TxOutRef (..))
-import Ledger.Blockchain (Block, BlockId (..))
+import Ledger.Blockchain (BlockId (..))
+import Ledger.Blockchain qualified as Ledger
 import Ledger.Slot (Slot)
 import Ledger.TxId (TxId)
 import PlutusTx.Lattice (MeetSemiLattice (..))
 import Prettyprinter (Pretty (..), (<+>))
 import Prettyprinter.Extras (PrettyShow (..))
 
+import Plutus.ChainIndex.Tx (ChainIndexTx)
+
 -- | Compute a hash of the block's contents.
-blockId :: Block -> BlockId
+blockId :: Ledger.Block -> BlockId
 blockId = BlockId
         . BA.convert
         . hash @_ @SHA256
@@ -358,17 +362,23 @@ instance Monoid TxUtxoBalance where
     mappend = (<>)
     mempty = TxUtxoBalance mempty mempty
 
--- | User-customizable options to process a block.
+
+-- | User-customizable options to process a transaction.
 -- See #73 for more motivations.
-newtype BlockProcessOption =
-  BlockProcessOption
-    { bpoStoreTxs :: Bool
-    -- ^ Should the chain index store this batch of transactions or not.
-    -- If not, only handle the tip and UTXOs.
+newtype TxProcessOption = TxProcessOption
+    { tpoStoreTx :: Bool
+    -- ^ Should the chain index store this transaction or not.
+    -- If not, only handle the UTXOs.
     -- This, for example, allows applications to skip unwanted pre-Alonzo transactions.
     }
 
 -- We should think twice when setting the default option.
 -- For now, it should store all data to avoid weird non-backward-compatible bugs in the future.
-instance Default BlockProcessOption where
-  def = BlockProcessOption True
+instance Default TxProcessOption where
+    def = TxProcessOption { tpoStoreTx = True }
+
+-- | A block of transactions to be synced.
+data ChainSyncBlock = Block
+    { blockTip :: Tip
+    , blockTxs :: [(ChainIndexTx, TxProcessOption)]
+    }

--- a/plutus-chain-index-core/test/Plutus/ChainIndex/HandlersSpec.hs
+++ b/plutus-chain-index-core/test/Plutus/ChainIndex/HandlersSpec.hs
@@ -8,7 +8,7 @@
 
 module Plutus.ChainIndex.HandlersSpec (tests) where
 
-import Control.Concurrent.STM (newTVarIO)
+import Control.Concurrent.MVar (newMVar)
 import Control.Lens (view)
 import Control.Monad (forM)
 import Control.Monad.Freer (Eff)
@@ -154,8 +154,8 @@ runChainIndexTest
 runChainIndexTest action = do
   result <- liftIO $ Sqlite.withConnection ":memory:" $ \conn -> do
     Sqlite.runBeamSqlite conn $ autoMigrate Sqlite.migrationBackend checkedSqliteDb
-    stateTVar <- newTVarIO mempty
-    runChainIndexEffects (RunRequirements nullTracer stateTVar conn 10) action
+    stateMVar <- newMVar mempty
+    runChainIndexEffects (RunRequirements nullTracer stateMVar conn 10) action
 
   case result of
     Left _  -> Hedgehog.failure

--- a/plutus-chain-index-core/test/Plutus/ChainIndex/HandlersSpec.hs
+++ b/plutus-chain-index-core/test/Plutus/ChainIndex/HandlersSpec.hs
@@ -12,7 +12,7 @@ import Control.Lens (view)
 import Control.Monad (forM)
 import Control.Monad.Freer (Eff)
 import Control.Monad.Freer.Extras.Beam (BeamEffect)
-import Control.Monad.IO.Class (liftIO)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Tracer (nullTracer)
 import Data.Default (def)
 import Data.Set qualified as S
@@ -21,19 +21,18 @@ import Database.Beam.Sqlite qualified as Sqlite
 import Database.Beam.Sqlite.Migrate qualified as Sqlite
 import Database.SQLite.Simple qualified as Sqlite
 import Generators qualified as Gen
-import Hedgehog (Property, assert, forAll, property, (===))
+import Hedgehog (MonadTest, Property, assert, failure, forAll, property, (===))
 import Ledger (outValue)
 import Plutus.ChainIndex (Page (pageItems), PageQuery (PageQuery), RunRequirements (..), appendBlock, citxOutputs,
                           runChainIndexEffects, txFromTxId, utxoSetMembership, utxoSetWithCurrency)
 import Plutus.ChainIndex.Api (IsUtxoResponse (isUtxo), UtxosResponse (UtxosResponse))
-import Plutus.ChainIndex.ChainIndexError (ChainIndexError (..))
 import Plutus.ChainIndex.DbSchema (checkedSqliteDb)
 import Plutus.ChainIndex.Effects (ChainIndexControlEffect, ChainIndexQueryEffect)
 import Plutus.ChainIndex.Tx (_ValidTx, citxTxId)
 import Plutus.ChainIndex.Types (BlockProcessOption (..))
 import Plutus.V1.Ledger.Ada qualified as Ada
 import Plutus.V1.Ledger.Value (AssetClass (AssetClass), flattenValue)
-import Test.Tasty
+import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
 import Util (utxoSetFromBlockAddrs)
 
@@ -61,17 +60,15 @@ txFromTxIdSpec :: Property
 txFromTxIdSpec = property $ do
   (tip, block@(fstTx:_)) <- forAll $ Gen.evalTxGenState Gen.genNonEmptyBlock
   unknownTxId <- forAll Gen.genRandomTxId
-  txs <- liftIO $ Sqlite.withConnection ":memory:" $ \conn -> do
-    Sqlite.runBeamSqlite conn $ autoMigrate Sqlite.migrationBackend checkedSqliteDb
-    liftIO $ runChainIndex conn $ do
+  txs <- runChainIndexTest $ do
       appendBlock tip block def
       tx <- txFromTxId (view citxTxId fstTx)
       tx' <- txFromTxId unknownTxId
       pure (tx, tx')
 
   case txs of
-    Right (Just tx, Nothing) -> fstTx === tx
-    _                        -> Hedgehog.assert False
+    (Just tx, Nothing) -> fstTx === tx
+    _                  -> Hedgehog.assert False
 
 -- | After generating and appending a block in the chain index, verify that
 -- querying the chain index with each of the addresses in the block returns
@@ -80,16 +77,12 @@ eachTxOutRefAtAddressShouldBeUnspentSpec :: Property
 eachTxOutRefAtAddressShouldBeUnspentSpec = property $ do
   ((tip, block), state) <- forAll $ Gen.runTxGenState Gen.genNonEmptyBlock
 
-  result <- liftIO $ Sqlite.withConnection ":memory:" $ \conn -> do
-    Sqlite.runBeamSqlite conn $ autoMigrate Sqlite.migrationBackend checkedSqliteDb
-    liftIO $ runChainIndex conn $ do
+  utxoGroups <- runChainIndexTest $ do
       -- Append the generated block in the chain index
       appendBlock tip block def
       utxoSetFromBlockAddrs block
 
-  case result of
-    Left _           -> Hedgehog.assert False
-    Right utxoGroups -> S.fromList (concat utxoGroups) === view Gen.txgsUtxoSet state
+  S.fromList (concat utxoGroups) === view Gen.txgsUtxoSet state
 
 -- | After generating and appending a block in the chain index, verify that
 -- querying the chain index with each of the addresses in the block returns
@@ -104,9 +97,7 @@ eachTxOutRefWithCurrencyShouldBeUnspentSpec = property $ do
              $ flattenValue
              $ view (traverse . citxOutputs . _ValidTx . traverse . outValue) block
 
-  result <- liftIO $ Sqlite.withConnection ":memory:" $ \conn -> do
-    Sqlite.runBeamSqlite conn $ autoMigrate Sqlite.migrationBackend checkedSqliteDb
-    liftIO $ runChainIndex conn $ do
+  utxoGroups <- runChainIndexTest $ do
       -- Append the generated block in the chain index
       appendBlock tip block def
 
@@ -115,9 +106,7 @@ eachTxOutRefWithCurrencyShouldBeUnspentSpec = property $ do
         UtxosResponse _ utxoRefs <- utxoSetWithCurrency pq ac
         pure $ pageItems utxoRefs
 
-  case result of
-    Left _           -> Hedgehog.assert False
-    Right utxoGroups -> S.fromList (concat utxoGroups) === view Gen.txgsUtxoSet state
+  S.fromList (concat utxoGroups) === view Gen.txgsUtxoSet state
 
 -- | Requesting UTXOs containing Ada should not return anything because every
 -- transaction output must have a minimum of 1 ADA. So asking for UTXOs with ADA
@@ -126,9 +115,7 @@ cantRequestForTxOutRefsWithAdaSpec :: Property
 cantRequestForTxOutRefsWithAdaSpec = property $ do
   (tip, block) <- forAll $ Gen.evalTxGenState Gen.genNonEmptyBlock
 
-  result <- liftIO $ Sqlite.withConnection ":memory:" $ \conn -> do
-    Sqlite.runBeamSqlite conn $ autoMigrate Sqlite.migrationBackend checkedSqliteDb
-    liftIO $ runChainIndex conn $ do
+  utxoRefs <- runChainIndexTest $ do
       -- Append the generated block in the chain index
       appendBlock tip block def
 
@@ -136,9 +123,7 @@ cantRequestForTxOutRefsWithAdaSpec = property $ do
       UtxosResponse _ utxoRefs <- utxoSetWithCurrency pq (AssetClass (Ada.adaSymbol, Ada.adaToken))
       pure $ pageItems utxoRefs
 
-  case result of
-    Left _         -> Hedgehog.assert False
-    Right utxoRefs -> Hedgehog.assert $ null utxoRefs
+  Hedgehog.assert $ null utxoRefs
 
 -- | Do not store txs through BlockProcessOption.
 -- The UTxO set must still be stored.
@@ -146,27 +131,32 @@ cantRequestForTxOutRefsWithAdaSpec = property $ do
 doNotStoreTxs :: Property
 doNotStoreTxs = property $ do
   ((tip, block), state) <- forAll $ Gen.runTxGenState Gen.genNonEmptyBlock
-  result <- liftIO $ Sqlite.withConnection ":memory:" $ \conn -> do
-    Sqlite.runBeamSqlite conn $ autoMigrate Sqlite.migrationBackend checkedSqliteDb
-    liftIO $ runChainIndex conn $ do
+  result <- runChainIndexTest $ do
       appendBlock tip block BlockProcessOption{bpoStoreTxs=False}
       tx <- txFromTxId (view citxTxId (head block))
       utxosFromAddr <- utxoSetFromBlockAddrs block
       utxosStored <- traverse utxoSetMembership (S.toList (view Gen.txgsUtxoSet state))
       pure (tx, concat utxosFromAddr, utxosStored)
   case result of
-    Right (Nothing, [], utxosStored) -> Hedgehog.assert $ and (isUtxo <$> utxosStored)
-    _                                -> Hedgehog.assert False
+    (Nothing, [], utxosStored) -> Hedgehog.assert $ and (isUtxo <$> utxosStored)
+    _                          -> Hedgehog.assert False
 
--- | Run a chain index action against a SQLite connection.
-runChainIndex
-  :: Sqlite.Connection
-  -> Eff '[ ChainIndexQueryEffect
+-- | Run a chain index test against an in-memory SQLite database.
+runChainIndexTest
+  :: (MonadTest m
+      , MonadIO m)
+  => Eff '[ ChainIndexQueryEffect
           , ChainIndexControlEffect
           , BeamEffect
           ] a
-  -> IO (Either ChainIndexError a)
-runChainIndex conn action = do
-  stateTVar <- newTVarIO mempty
-  (r, _) <- runChainIndexEffects (RunRequirements nullTracer stateTVar conn 10) action
-  pure r
+  -> m a
+runChainIndexTest action = do
+  result <- liftIO $ Sqlite.withConnection ":memory:" $ \conn -> do
+    Sqlite.runBeamSqlite conn $ autoMigrate Sqlite.migrationBackend checkedSqliteDb
+    stateTVar <- newTVarIO mempty
+    runChainIndexEffects (RunRequirements nullTracer stateTVar conn 10) action
+
+  case result of
+    Left _  -> Hedgehog.failure
+    Right a -> pure a
+

--- a/plutus-chain-index/plutus-chain-index.cabal
+++ b/plutus-chain-index/plutus-chain-index.cabal
@@ -33,6 +33,7 @@ library
         Plutus.ChainIndex.App
         Plutus.ChainIndex.CommandLine
         Plutus.ChainIndex.Config
+        Plutus.ChainIndex.Lib
         Plutus.ChainIndex.Logging
     hs-source-dirs: src
     build-depends:

--- a/plutus-chain-index/plutus-chain-index.cabal
+++ b/plutus-chain-index/plutus-chain-index.cabal
@@ -49,6 +49,7 @@ library
         cardano-api -any,
         containers -any,
         contra-tracer -any,
+        data-default -any,
         freer-simple -any,
         iohk-monitoring -any,
         lens -any,

--- a/plutus-chain-index/src/Plutus/ChainIndex/App.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/App.hs
@@ -24,6 +24,7 @@ import Prettyprinter (Pretty (..))
 import Cardano.BM.Configuration.Model qualified as CM
 
 import Plutus.ChainIndex.CommandLine (AppConfig (..), Command (..), applyOverrides, cmdWithHelpParser)
+import Plutus.ChainIndex.Compatibility (fromCardanoBlockNo)
 import Plutus.ChainIndex.Config qualified as Config
 import Plutus.ChainIndex.Lib (defaultChainSynHandler, getTipSlot, showingProgress, storeFromBlockNo, syncChainIndex,
                               withRunRequirements)
@@ -74,7 +75,7 @@ runMain logConfig config = do
 
     syncHandler
       <- defaultChainSynHandler runReq
-        & storeFromBlockNo (Config.cicStoreFrom config)
+        & storeFromBlockNo (fromCardanoBlockNo $ Config.cicStoreFrom config)
         & showingProgress
 
     putStrLn $ "Connecting to the node using socket: " <> Config.cicSocketPath config

--- a/plutus-chain-index/src/Plutus/ChainIndex/App.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/App.hs
@@ -13,118 +13,22 @@
 -}
 module Plutus.ChainIndex.App(main, runMain) where
 
-import Control.Concurrent.STM qualified as STM
 import Control.Exception (throwIO)
-import Control.Monad.Freer (Eff, send)
-import Control.Monad.Freer.Extras (LogMsg (..))
-import Control.Monad.Freer.Extras.Beam (BeamEffect, BeamLog (..))
-import Control.Monad.Freer.Extras.Log (LogLevel (..), LogMessage (..))
-import Control.Tracer (nullTracer)
 import Data.Aeson qualified as A
-import Data.Foldable (for_, traverse_)
+import Data.Foldable (for_)
 import Data.Function ((&))
-import Data.Functor (void)
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import Data.Sequence ((<|))
 import Data.Yaml qualified as Y
-import Database.Beam.Migrate.Simple (autoMigrate)
-import Database.Beam.Sqlite qualified as Sqlite
-import Database.Beam.Sqlite.Migrate qualified as Sqlite
-import Database.SQLite.Simple qualified as Sqlite
 import Options.Applicative (execParser)
 import Prettyprinter (Pretty (..))
 
 import Cardano.BM.Configuration.Model qualified as CM
-import Cardano.BM.Setup (setupTrace_)
-import Cardano.BM.Trace (Trace, logDebug, logError)
 
-import Cardano.Api qualified as C
-import Cardano.Protocol.Socket.Client (ChainSyncEvent (..), runChainSync)
-import Cardano.Protocol.Socket.Type (epochSlots)
-import Plutus.ChainIndex (ChainIndexLog (..), RunRequirements (..), runChainIndexEffects)
 import Plutus.ChainIndex.CommandLine (AppConfig (..), Command (..), applyOverrides, cmdWithHelpParser)
-import Plutus.ChainIndex.Compatibility (fromCardanoBlock, fromCardanoPoint, tipFromCardanoBlock)
 import Plutus.ChainIndex.Config qualified as Config
-import Plutus.ChainIndex.DbSchema (checkedSqliteDb)
-import Plutus.ChainIndex.Effects (ChainIndexControlEffect (..), ChainIndexQueryEffect (..), appendBlock, resumeSync,
-                                  rollback)
-import Plutus.ChainIndex.Handlers (getResumePoints)
+import Plutus.ChainIndex.Lib (defaultChainSynHandler, getTipSlot, showingProgress, storeFromBlockNo, syncChainIndex,
+                              withRunRequirements)
 import Plutus.ChainIndex.Logging qualified as Logging
 import Plutus.ChainIndex.Server qualified as Server
-import Plutus.ChainIndex.Types (BlockProcessOption (..), pointSlot)
-import Plutus.Monitoring.Util (runLogEffects)
-
-
-runChainIndex
-  :: RunRequirements
-  -> Eff '[ChainIndexQueryEffect, ChainIndexControlEffect, BeamEffect] a
-  -> IO (Maybe a)
-runChainIndex runReq effect = do
-  (errOrResult, logMessages') <- runChainIndexEffects runReq effect
-  (result, logMessages) <- case errOrResult of
-      Left err ->
-        pure (Nothing, LogMessage Error (Err err) <| logMessages')
-      Right result -> do
-        pure (Just result, logMessages')
-  -- Log all previously captured messages
-  traverse_ (send . LMessage) logMessages
-    & runLogEffects (trace runReq)
-  pure result
-
-chainSyncHandler
-  :: RunRequirements
-  -> Config.ChainIndexConfig
-  -> IORef (Integer, Integer)
-  -> ChainSyncEvent
-  -> IO ()
-chainSyncHandler runReq config lastProgressRef
-  (RollForward block@(C.BlockInMode (C.Block (C.BlockHeader blockSlot _ blockNo) _) _) _) = do
-    showProgress config lastProgressRef blockSlot
-    let ciBlock = fromCardanoBlock block
-    case ciBlock of
-      Left err    ->
-        logError (trace runReq) (ConversionFailed err)
-      Right txs -> void $ runChainIndex runReq $
-        appendBlock (tipFromCardanoBlock block) txs (BlockProcessOption (blockNo >= Config.cicStoreFrom config))
-chainSyncHandler runReq _ _
-  (RollBackward point _) = do
-    putStr "Rolling back to "
-    print point
-    -- Do we really want to pass the tip of the new blockchain to the
-    -- rollback function (rather than the point where the chains diverge)?
-    void $ runChainIndex runReq $ rollback (fromCardanoPoint point)
-chainSyncHandler runReq _ _
-  (Resume point) = do
-    putStr "Resuming from "
-    print point
-    void $ runChainIndex runReq $ resumeSync $ fromCardanoPoint point
-
-showResumePoints :: [C.ChainPoint] -> String
-showResumePoints = \case
-  []  -> "none"
-  [x] -> showPoint x
-  xs  -> showPoint (head xs) ++ ", " ++ showPoint (xs !! 1) ++ " .. " ++ showPoint (last xs)
-  where
-    showPoint = show . toInteger . pointSlot . fromCardanoPoint
-
-getTipSlot :: Config.ChainIndexConfig -> IO Integer
-getTipSlot config = do
-  C.ChainTip (C.SlotNo slotNo) _ _ <- C.getLocalChainTip $ C.LocalNodeConnectInfo
-    { C.localConsensusModeParams = C.CardanoModeParams epochSlots
-    , C.localNodeNetworkId = Config.cicNetworkId config
-    , C.localNodeSocketPath = Config.cicSocketPath config
-    }
-  pure $ fromIntegral slotNo
-
-showProgress :: Config.ChainIndexConfig -> IORef (Integer, Integer) -> C.SlotNo -> IO ()
-showProgress config lastProgressRef (C.SlotNo blockSlot) = do
-  (lastProgress, tipSlot) <- readIORef lastProgressRef
-  let pct = (100 * fromIntegral blockSlot) `div` tipSlot
-  if pct > lastProgress then do
-    putStrLn $ "Syncing (" ++ show pct ++ "%)"
-    newTipSlot <- getTipSlot config
-    writeIORef lastProgressRef (pct, newTipSlot)
-  else pure ()
 
 main :: IO ()
 main = do
@@ -142,7 +46,6 @@ main = do
       -- Initialise logging
       logConfig <- maybe Logging.defaultConfig Logging.loadConfig acLogConfigPath
       for_ acMinLogLevel $ \ll -> CM.setMinSeverity logConfig ll
-      (trace :: Trace IO ChainIndexLog, _) <- setupTrace_ logConfig "chain-index"
 
       -- Reading configuration file
       config <- applyOverrides acCLIConfigOverrides <$> case acConfigPath of
@@ -159,50 +62,23 @@ main = do
       putStrLn "\nChain Index config:"
       print (pretty config)
 
-      runMain trace config
+      runMain logConfig config
 
-runMain :: Trace IO ChainIndexLog -> Config.ChainIndexConfig -> IO ()
-runMain trace config = do
-  Sqlite.withConnection (Config.cicDbPath config) $ \conn -> do
+runMain :: CM.Configuration -> Config.ChainIndexConfig -> IO ()
+runMain logConfig config = do
+  withRunRequirements logConfig config $ \runReq -> do
 
-    -- Optimize Sqlite for write performance, halves the sync time.
-    -- https://sqlite.org/wal.html
-    Sqlite.execute_ conn "PRAGMA journal_mode=WAL"
-    Sqlite.runBeamSqliteDebug (logDebug trace . (BeamLogItem . SqlLog)) conn $ do
-      autoMigrate Sqlite.migrationBackend checkedSqliteDb
-
-    -- Automatically delete the input when an output from a matching input/output pair is deleted.
-    -- See reduceOldUtxoDb in Plutus.ChainIndex.Handlers
-    Sqlite.execute_ conn "DROP TRIGGER IF EXISTS delete_matching_input"
-    Sqlite.execute_ conn
-      "CREATE TRIGGER delete_matching_input AFTER DELETE ON unspent_outputs \
-      \BEGIN \
-      \  DELETE FROM unmatched_inputs WHERE input_row_tip__row_slot = old.output_row_tip__row_slot \
-      \                                 AND input_row_out_ref = old.output_row_out_ref; \
-      \END"
-
-    stateTVar <- STM.newTVarIO mempty
-    let runReq = RunRequirements trace stateTVar conn (Config.cicSecurityParam config)
-
-    Just resumePoints <- runChainIndex runReq getResumePoints
-
-    putStr "\nPossible resume slots: "
-    putStrLn $ showResumePoints resumePoints
-
-    -- The primary purpose of this query is to get the first response of the node for potential errors before opening the DB and starting the chain index.
-    -- See #69.
     putStr "\nThe tip of the local node: "
     slotNo <- getTipSlot config
     print slotNo
-    progressRef <- newIORef (0, slotNo)
+
+    syncHandler
+      <- defaultChainSynHandler runReq
+        & storeFromBlockNo (Config.cicStoreFrom config)
+        & showingProgress
 
     putStrLn $ "Connecting to the node using socket: " <> Config.cicSocketPath config
-    void $ runChainSync (Config.cicSocketPath config)
-                        nullTracer
-                        (Config.cicSlotConfig config)
-                        (Config.cicNetworkId  config)
-                        resumePoints
-                        (\evt _ -> chainSyncHandler runReq config progressRef evt)
+    syncChainIndex config runReq syncHandler
 
     let port = show (Config.cicPort config)
     putStrLn $ "Starting webserver on port " <> port

--- a/plutus-chain-index/src/Plutus/ChainIndex/App.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/App.hs
@@ -26,7 +26,7 @@ import Cardano.BM.Configuration.Model qualified as CM
 import Plutus.ChainIndex.CommandLine (AppConfig (..), Command (..), applyOverrides, cmdWithHelpParser)
 import Plutus.ChainIndex.Compatibility (fromCardanoBlockNo)
 import Plutus.ChainIndex.Config qualified as Config
-import Plutus.ChainIndex.Lib (defaultChainSynHandler, getTipSlot, showingProgress, storeFromBlockNo, syncChainIndex,
+import Plutus.ChainIndex.Lib (defaultChainSyncHandler, getTipSlot, showingProgress, storeFromBlockNo, syncChainIndex,
                               withRunRequirements)
 import Plutus.ChainIndex.Logging qualified as Logging
 import Plutus.ChainIndex.Server qualified as Server
@@ -74,7 +74,7 @@ runMain logConfig config = do
     print slotNo
 
     syncHandler
-      <- defaultChainSynHandler runReq
+      <- defaultChainSyncHandler runReq
         & storeFromBlockNo (fromCardanoBlockNo $ Config.cicStoreFrom config)
         & showingProgress
 

--- a/plutus-chain-index/src/Plutus/ChainIndex/Config.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Config.hs
@@ -52,13 +52,13 @@ deriving anyclass instance ToJSON NetworkMagic
 deriving anyclass instance FromJSON BlockNo
 deriving anyclass instance ToJSON BlockNo
 
--- | These settings work with the Alonzo Purple testnet
+-- | These settings work with the main testnet
 defaultConfig :: ChainIndexConfig
 defaultConfig = ChainIndexConfig
-  { cicSocketPath = "/tmp/node-server.sock"
+  { cicSocketPath = "testnet/node.sock"
   , cicDbPath     = "/tmp/chain-index.db"
   , cicPort       = 9083
-  , cicNetworkId  = Testnet $ NetworkMagic 8
+  , cicNetworkId  = Testnet $ NetworkMagic 1097911063
   , cicSecurityParam = 2160
   , cicSlotConfig =
       SlotConfig

--- a/plutus-chain-index/src/Plutus/ChainIndex/Lib.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Lib.hs
@@ -40,7 +40,7 @@ module Plutus.ChainIndex.Lib (
     , getTipSlot
 ) where
 
-import Control.Concurrent.STM qualified as STM
+import Control.Concurrent.MVar (newMVar)
 import Control.Monad.Freer (Eff)
 import Control.Monad.Freer.Extras.Beam (BeamEffect, BeamLog (SqlLog))
 import Control.Monad.Freer.Extras.Log qualified as Log
@@ -94,8 +94,8 @@ withRunRequirements logConfig config cont = do
         \                                 AND input_row_out_ref = old.output_row_out_ref; \
         \END"
 
-    stateTVar <- STM.newTVarIO mempty
-    cont $ RunRequirements trace stateTVar conn (Config.cicSecurityParam config)
+    stateMVar <- newMVar mempty
+    cont $ RunRequirements trace stateMVar conn (Config.cicSecurityParam config)
 
 -- | Generate the requirements to run the chain index effects given default configurations.
 withDefaultRunRequirements :: (RunRequirements -> IO ()) -> IO ()

--- a/plutus-chain-index/src/Plutus/ChainIndex/Lib.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Lib.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-| Using the chain index as a library.
+
+A minimal example that just syncs the chain index:
+
+@
+`withDefaultRunRequirements` $ \runReq -> do
+
+    syncHandler <- `showingProgress` $ `defaultChainSynHandler` runReq
+
+    `syncChainIndex` `defaultConfig` runReq syncHandler
+
+    void getLine
+@
+
+-}
+module Plutus.ChainIndex.Lib where
+
+import Control.Concurrent.STM qualified as STM
+import Control.Monad.Freer (Eff)
+import Control.Monad.Freer.Extras.Beam (BeamEffect, BeamLog (SqlLog))
+import Control.Monad.Freer.Extras.Log qualified as Log
+import Data.Functor (void)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Database.Beam.Migrate.Simple (autoMigrate)
+import Database.Beam.Sqlite qualified as Sqlite
+import Database.Beam.Sqlite.Migrate qualified as Sqlite
+import Database.SQLite.Simple qualified as Sqlite
+
+import Cardano.Api qualified as C
+import Cardano.BM.Configuration.Model qualified as CM
+import Cardano.BM.Setup (setupTrace_)
+import Cardano.BM.Trace (Trace, logDebug, logError, nullTracer)
+
+import Cardano.Protocol.Socket.Client (ChainSyncEvent (..), runChainSync)
+import Cardano.Protocol.Socket.Type (epochSlots)
+import Plutus.ChainIndex (ChainIndexLog (BeamLogItem), RunRequirements (RunRequirements), getResumePoints,
+                          runChainIndexEffects)
+import Plutus.ChainIndex qualified as CI
+import Plutus.ChainIndex.Compatibility (fromCardanoBlock, fromCardanoPoint, tipFromCardanoBlock)
+import Plutus.ChainIndex.Config qualified as Config
+import Plutus.ChainIndex.DbSchema (checkedSqliteDb)
+import Plutus.ChainIndex.Effects (ChainIndexControlEffect (..), ChainIndexQueryEffect (..), appendBlock, resumeSync,
+                                  rollback)
+import Plutus.ChainIndex.Logging qualified as Logging
+import Plutus.Monitoring.Util (runLogEffects)
+
+withRunRequirements :: CM.Configuration -> Config.ChainIndexConfig -> (RunRequirements -> IO ()) -> IO ()
+withRunRequirements logConfig config cont = do
+  Sqlite.withConnection (Config.cicDbPath config) $ \conn -> do
+
+    (trace :: Trace IO ChainIndexLog, _) <- setupTrace_ logConfig "chain-index"
+
+    -- Optimize Sqlite for write performance, halves the sync time.
+    -- https://sqlite.org/wal.html
+    Sqlite.execute_ conn "PRAGMA journal_mode=WAL"
+    Sqlite.runBeamSqliteDebug (logDebug trace . (BeamLogItem . SqlLog)) conn $ do
+        autoMigrate Sqlite.migrationBackend checkedSqliteDb
+
+    -- Automatically delete the input when an output from a matching input/output pair is deleted.
+    -- See reduceOldUtxoDb in Plutus.ChainIndex.Handlers
+    Sqlite.execute_ conn "DROP TRIGGER IF EXISTS delete_matching_input"
+    Sqlite.execute_ conn
+        "CREATE TRIGGER delete_matching_input AFTER DELETE ON unspent_outputs \
+        \BEGIN \
+        \  DELETE FROM unmatched_inputs WHERE input_row_tip__row_slot = old.output_row_tip__row_slot \
+        \                                 AND input_row_out_ref = old.output_row_out_ref; \
+        \END"
+
+    stateTVar <- STM.newTVarIO mempty
+    cont $ RunRequirements trace stateTVar conn (Config.cicSecurityParam config)
+
+withDefaultRunRequirements :: (RunRequirements -> IO ()) -> IO ()
+withDefaultRunRequirements cont = do
+    logConfig <- Logging.defaultConfig
+    withRunRequirements logConfig Config.defaultConfig cont
+
+type ChainSyncHandler = ChainSyncEvent -> IO ()
+
+defaultChainSynHandler :: RunRequirements -> ChainSyncHandler
+defaultChainSynHandler runReq
+    (RollForward block _ opt) = do
+        let ciBlock = fromCardanoBlock block
+        case ciBlock of
+            Left err    ->
+                logError (CI.trace runReq) (CI.ConversionFailed err)
+            Right txs -> void $ runChainIndexDuringSync runReq $
+                appendBlock (tipFromCardanoBlock block) txs opt
+defaultChainSynHandler runReq
+    (RollBackward point _) = do
+        void $ runChainIndexDuringSync runReq $ rollback (fromCardanoPoint point)
+defaultChainSynHandler runReq
+    (Resume point) = do
+        void $ runChainIndexDuringSync runReq $ resumeSync $ fromCardanoPoint point
+
+storeFromBlockNo :: C.BlockNo -> ChainSyncHandler -> ChainSyncHandler
+storeFromBlockNo storeFrom handler (RollForward block@(C.BlockInMode (C.Block (C.BlockHeader _ _ blockNo) _) _) tip opt) =
+    handler (RollForward block tip opt{ CI.bpoStoreTxs = blockNo >= storeFrom })
+storeFromBlockNo _ handler evt = handler evt
+
+-- filterTxs :: (C.Tx era -> Bool) -> ChainSyncHandler -> ChainSyncHandler
+-- filterTxs isAccepted handler (RollForward (C.BlockInMode (C.Block header txs) mode) tip opt) =
+--     handler (RollForward (C.BlockInMode (C.Block header (filter isAccepted txs) mode) tip opt))
+-- filterTxs _ handler evt = handler evt
+
+-- | Get the slot number of the current tip of the node.
+getTipSlot :: Config.ChainIndexConfig -> IO Integer
+getTipSlot config = do
+  C.ChainTip (C.SlotNo slotNo) _ _ <- C.getLocalChainTip $ C.LocalNodeConnectInfo
+    { C.localConsensusModeParams = C.CardanoModeParams epochSlots
+    , C.localNodeNetworkId = Config.cicNetworkId config
+    , C.localNodeSocketPath = Config.cicSocketPath config
+    }
+  pure $ fromIntegral slotNo
+
+showProgress :: IORef Integer -> C.SlotNo -> C.SlotNo -> IO ()
+showProgress lastProgressRef (C.SlotNo tipSlot) (C.SlotNo blockSlot) = do
+  lastProgress <- readIORef lastProgressRef
+  let pct = (100 * fromIntegral blockSlot) `div` fromIntegral tipSlot
+  if pct > lastProgress then do
+    putStrLn $ "Syncing (" ++ show pct ++ "%)"
+    writeIORef lastProgressRef pct
+  else pure ()
+
+-- | Changes the given @ChainSyncHandler@ to print out the synchronisation progress percentages.
+showingProgress :: ChainSyncHandler -> IO ChainSyncHandler
+showingProgress handler = do
+    -- The primary purpose of this query is to get the first response of the node for potential errors before opening the DB and starting the chain index.
+    -- See #69.
+    lastProgressRef <- newIORef 0
+    pure $ \case
+        (RollForward block@(C.BlockInMode (C.Block (C.BlockHeader blockSlot _ _) _) _) tip@(C.ChainTip tipSlot _ _) opt) -> do
+            showProgress lastProgressRef tipSlot blockSlot
+            handler $ RollForward block tip opt
+        evt -> handler evt
+
+syncChainIndex :: Config.ChainIndexConfig -> RunRequirements -> ChainSyncHandler -> IO ()
+syncChainIndex config runReq syncHandler = do
+    Just resumePoints <- runChainIndexDuringSync runReq getResumePoints
+    void $ runChainSync (Config.cicSocketPath config)
+                        nullTracer
+                        (Config.cicSlotConfig config)
+                        (Config.cicNetworkId  config)
+                        resumePoints
+                        syncHandler
+
+
+runChainIndexDuringSync
+  :: RunRequirements
+  -> Eff '[ChainIndexQueryEffect, ChainIndexControlEffect, BeamEffect] a
+  -> IO (Maybe a)
+runChainIndexDuringSync runReq effect = do
+    errOrResult <- runChainIndexEffects runReq effect
+    case errOrResult of
+        Left err -> do
+            runLogEffects (CI.trace runReq) $ Log.logError $ CI.Err err
+            pure Nothing
+        Right result -> do
+            pure (Just result)

--- a/plutus-contract/src/Plutus/Trace/Emulator/System.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/System.hs
@@ -31,8 +31,8 @@ import Wallet.Emulator.MultiAgent (MultiAgentControlEffect, MultiAgentEffect, wa
 import Data.Hashable (hash)
 import Data.String (IsString (..))
 import Ledger (Block, Slot, TxId (..), eitherTx, txId)
-import Plutus.ChainIndex (BlockId (..), ChainIndexControlEffect, Tip (Tip, TipAtGenesis), appendBlock, fromOnChainTx,
-                          getTip)
+import Plutus.ChainIndex (BlockId (..), ChainIndexControlEffect, ChainSyncBlock (Block), Tip (Tip, TipAtGenesis),
+                          appendBlock, fromOnChainTx, getTip)
 import Plutus.Trace.Emulator.Types (EmulatorMessage (..))
 import Plutus.Trace.Scheduler (EmSystemCall, MessageCall (..), Priority (..), Tag, fork, mkSysCall, sleep)
 import Wallet.Emulator.NodeClient (ChainClientNotification (..), clientNotify)
@@ -149,4 +149,4 @@ appendNewTipBlock lastTip block newSlot = do
               $ (Text.encodeUtf8 . Text.pack . show . hash)
               $ foldMap (getTxId . eitherTx txId txId) block
   let newTip = Tip newSlot blockId nextBlockNo
-  appendBlock newTip (fmap fromOnChainTx block) def
+  appendBlock (Block newTip (fmap (\tx -> (fromOnChainTx tx, def)) block))

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
@@ -99,7 +99,7 @@ processChainSyncEvent :: BlockchainEnv -> ChainSyncEvent -> STM (Either SyncActi
 processChainSyncEvent blockchainEnv event = do
   result <- case event of
               Resume _ -> Right <$> blockAndSlot blockchainEnv
-              RollForward (BlockInMode (C.Block header transactions) era) _ _ ->
+              RollForward (BlockInMode (C.Block header transactions) era) _ ->
                 case era of
                   -- Unfortunately, we need to pattern match again all eras because
                   -- 'processBlock' has the constraints 'C.IsCardanoEra era', but not

--- a/plutus-pab/sync-client/Main.hs
+++ b/plutus-pab/sync-client/Main.hs
@@ -17,7 +17,6 @@ import Cardano.Api (Block (..), BlockHeader (..), BlockInMode (..), ChainPoint (
 import Cardano.Protocol.Socket.Client (ChainSyncEvent (..), runChainSync)
 import Cardano.Protocol.Socket.Type (cfgNetworkId)
 import Cardano.Slotting.Slot (SlotNo (..))
-import Ledger (Slot)
 import Ledger.TimeSlot (SlotConfig (..))
 
 -- | We only need to know the location of the socket.
@@ -39,20 +38,19 @@ slotConfig =
 -- | A simple callback that reads the incoming data, from the node.
 processBlock
   :: ChainSyncEvent
-  -> Slot
   -> IO ()
-processBlock (RollForward (BlockInMode (Block (BlockHeader (SlotNo slot) hsh _) _) _) _) _ =
+processBlock (RollForward (BlockInMode (Block (BlockHeader (SlotNo slot) hsh _) _) _) _) =
   putStrLn $ "Received block " <> show (serialiseToRawBytesHexText hsh)
           <> " for slot "      <> show slot
-processBlock (Resume (ChainPoint (SlotNo slot) hsh)) _ =
+processBlock (Resume (ChainPoint (SlotNo slot) hsh)) =
   putStrLn $ "Resuming from slot " <> show slot
           <> " at hash " <> show (serialiseToRawBytesHexText hsh)
-processBlock (Resume ChainPointAtGenesis) _ =
+processBlock (Resume ChainPointAtGenesis) =
   putStrLn "Resuming from genesis block"
-processBlock (RollBackward (ChainPoint (SlotNo slot) hsh) _) _ =
+processBlock (RollBackward (ChainPoint (SlotNo slot) hsh) _) =
   putStrLn $ "Rolling backward to slot " <> show slot
           <> " at hash " <> show (serialiseToRawBytesHexText hsh)
-processBlock (RollBackward ChainPointAtGenesis _) _ =
+processBlock (RollBackward ChainPointAtGenesis _) =
   putStrLn $ "Rolling backward to genesis"
 
 hashParser :: ReadM ChainPoint

--- a/plutus-pab/sync-client/Main.hs
+++ b/plutus-pab/sync-client/Main.hs
@@ -41,7 +41,7 @@ processBlock
   :: ChainSyncEvent
   -> Slot
   -> IO ()
-processBlock (RollForward (BlockInMode (Block (BlockHeader (SlotNo slot) hsh _) _) _) _ _) _ =
+processBlock (RollForward (BlockInMode (Block (BlockHeader (SlotNo slot) hsh _) _) _) _) _ =
   putStrLn $ "Received block " <> show (serialiseToRawBytesHexText hsh)
           <> " for slot "      <> show slot
 processBlock (Resume (ChainPoint (SlotNo slot) hsh)) _ =

--- a/plutus-pab/sync-client/Main.hs
+++ b/plutus-pab/sync-client/Main.hs
@@ -41,7 +41,7 @@ processBlock
   :: ChainSyncEvent
   -> Slot
   -> IO ()
-processBlock (RollForward (BlockInMode (Block (BlockHeader (SlotNo slot) hsh _) _) _) _) _ =
+processBlock (RollForward (BlockInMode (Block (BlockHeader (SlotNo slot) hsh _) _) _) _ _) _ =
   putStrLn $ "Received block " <> show (serialiseToRawBytesHexText hsh)
           <> " for slot "      <> show slot
 processBlock (Resume (ChainPoint (SlotNo slot) hsh)) _ =


### PR DESCRIPTION
Refactoring so the chain index can be used more easily as a library, with the following goals.

- Clear entry point `Plutus.ChainIndex.Lib` which collects and documents what's needed to run a chain index.
- Separated out functions in a more modular way so:
  - a user can select the parts they do and don't want to use
  - there are clear extension points for custom code.
- Allow for custom effects when executing the chain index effects.

The main focus in this PR is on `ChainSyncHandler`s, since customising what to sync and store is the biggest request (see `filterTxs`), and to make it easy to run the syncing once you have built such a handler.

This is just a first step, we expect to be building this out over the coming months.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
