### PR TITLE
Add AssetName serialization to hex in wallet exporting (fix #192).

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Wallet.hs
+++ b/plutus-contract/src/Plutus/Contract/Wallet.hs
@@ -230,7 +230,7 @@ instance ToJSON ExportTxInput where
             , "address" .= C.serialiseAddress etxiAddress
             , "amount" .= object ["quantity" .= etxiLovelaceQuantity, "unit" .= ("lovelace" :: String)]
             , "datum" .= etxiDatumHash
-            , "assets" .= fmap (\(p, a, q) -> object ["policy_id" .= p, "asset_name" .= a, "quantity" .= q]) etxiAssets
+            , "assets" .= fmap (\(p, a, q) -> object ["policy_id" .= p, "asset_name" .= (C.serialiseToRawBytesHexText a), "quantity" .= q]) etxiAssets
             ]
 
 export :: C.ProtocolParameters -> C.NetworkId -> UnbalancedTx -> Either CardanoAPI.ToCardanoError ExportTx


### PR DESCRIPTION
The proper fix would be `cardano-node`'s version bump but it's impossible at the moment as `cardano-wallet` uses an too old version of `cardano-node`.

fix #192 

---

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
