### PR TITLE
WIP chore(HLS): bump HLS version to 1.5.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -83,15 +83,15 @@
       "flake": false,
       "locked": {
         "lastModified": 1627623934,
-        "narHash": "sha256-RjPRzpcfL2UNGp2IYEh3rIrBeSnpdafdJhMAvrtXrbA=",
+        "narHash": "sha256-Reo9BQ12O+OX7tuRfaDPZPBpJW4jnxZetm63BxYncoM=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "e7c5e90b6df5dff2760d76169eddaea3bdd6a831",
+        "rev": "745ef26f406dbdd5e4a538585f8519af9f1ccb09",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "1.3.0",
+        "ref": "1.5.1 ",
         "repo": "haskell-language-server",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
     };
     haskell-language-server = {
       # Pinned to a release
-      url = "github:haskell/haskell-language-server?ref=1.3.0";
+      url = "github:haskell/haskell-language-server?ref=1.5.1";
       flake = false;
     };
     iohk-nix = {

--- a/nix/pkgs/haskell/hls-darwin.sha
+++ b/nix/pkgs/haskell/hls-darwin.sha
@@ -1,1 +1,1 @@
-00r15hn2q609j59ajgn3bdq6vlzh426sjhb0war8wj5dbz5z5zis
+0braqiz6rmy73xav68y7is7hi14kdgivwdqrqzlg1apacr6npiq4

--- a/nix/pkgs/haskell/hls-linux.sha
+++ b/nix/pkgs/haskell/hls-linux.sha
@@ -1,1 +1,1 @@
-1gk5ispzwn3yv3z9583xg86w0ih3j7ac65bnaxjn6gb1lr530v6y
+08g0pbrqzw55l8cam8qq4v0q0gyrqv84z5y1zgzynkg9i709ypwy


### PR DESCRIPTION
Bumping HLS to 1.5.1

A bit weird I did not get the same sha1 for the linux version there for I am quite sure the darwin may be wrong too (cannot test it).

Double check is required anyway.

Fix #209

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
