### PR TITLE
SCP-3096 - Remove wallet proxy

### DIFF
--- a/plutus-pab-executables/src/Plutus/PAB/Run/PSGenerator.hs
+++ b/plutus-pab-executables/src/Plutus/PAB/Run/PSGenerator.hs
@@ -41,7 +41,6 @@ import Plutus.PAB.Webserver.API qualified as API
 import Plutus.PAB.Webserver.Types (ChainReport, CombinedWSStreamToClient, CombinedWSStreamToServer,
                                    ContractActivationArgs, ContractInstanceClientState, ContractReport,
                                    ContractSignatureResponse, FullReport, InstanceStatusToClient)
-import Servant ((:<|>))
 import Servant.PureScript (HasBridge, Settings, apiModuleName, defaultBridge, defaultSettings, languageBridge,
                            writeAPIModuleWithSettings)
 
@@ -126,8 +125,7 @@ generateAPIModule _ outputDir = do
         mySettings
         outputDir
         pabBridgeProxy
-        (    Proxy @(API.API (Contract.ContractDef (Builtin a)) Text.Text
-        :<|> API.WalletProxy Text.Text)
+        (    Proxy @(API.API (Contract.ContractDef (Builtin a)) Text.Text)
         )
 
 -- | Generate PS modules in 'outputDir' which includes common types for the PAB.

--- a/plutus-pab/src/Plutus/PAB/Run/Cli.hs
+++ b/plutus-pab/src/Plutus/PAB/Run/Cli.hs
@@ -170,8 +170,7 @@ runConfigCommand contractHandler ConfigCommandArgs{ccaTrace, ccaPABConfig=config
                     logInfo @(LM.PABMultiAgentMsg (Builtin a)) (LM.PABStateRestored $ length ts)
 
               -- then, actually start the server.
-              let walletClientEnv = App.walletClientEnv (Core.appEnv env)
-              (mvar, _) <- PABServer.startServer pabWebserverConfig (Left walletClientEnv) ccaAvailability
+              (mvar, _) <- PABServer.startServer pabWebserverConfig ccaAvailability
               liftIO $ takeMVar mvar
         either handleError return result
   where

--- a/plutus-pab/src/Plutus/PAB/Webserver/API.hs
+++ b/plutus-pab/src/Plutus/PAB/Webserver/API.hs
@@ -6,11 +6,9 @@
 module Plutus.PAB.Webserver.API
     ( API
     , WSAPI
-    , WalletProxy
     , SwaggerAPI
     ) where
 
-import Cardano.Wallet.Mock.API qualified as Wallet
 import Data.Aeson qualified as JSON
 import Data.Text (Text)
 import Plutus.PAB.Webserver.Types (ContractActivationArgs, ContractInstanceClientState, ContractSignatureResponse,
@@ -19,9 +17,6 @@ import Servant.API (Capture, Description, Get, JSON, Post, Put, QueryParam, ReqB
 import Servant.API.WebSocket (WebSocketPending)
 import Servant.Swagger.UI (SwaggerSchemaUI)
 import Wallet.Types (ContractInstanceId)
-
--- TODO: This wallet proxy will be eventually removed. See SCP-3096.
-type WalletProxy walletId = "wallet" :> Wallet.API walletId
 
 type WSAPI =
     "ws" :>


### PR DESCRIPTION
Don't proxy the wallet backend through our webserver anymore.

Fixes SCP-3096

TODO:

- [ ] When we do a release of plutus-starter, update that endpoint call as well.

The main change here is `curl` calls like this:

```
> curl -s -d '' http://localhost:9080/wallet/create
```

go direct to the wallet server instead:

```
> curl -s -d '' http://localhost:9081/create
```


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
