### PR TITLE
Experiment: remove traces & inline trivial lambdas in usecase tests

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -241,7 +241,7 @@ source-repository-package
 source-repository-package
  type: git
  location: https://github.com/input-output-hk/plutus
- tag: 2721c59fd2302b75c4138456c29fd5b509e8340a
+ tag: c8c5183f7facd967d48fe07b3b14465b8dd48fe7
  subdir:
    plutus-ledger-api
    word-array

--- a/cabal.project
+++ b/cabal.project
@@ -240,8 +240,8 @@ source-repository-package
 -- are also updated
 source-repository-package
  type: git
- location: https://github.com/input-output-hk/plutus
- tag: c8c5183f7facd967d48fe07b3b14465b8dd48fe7
+ location: https://github.com/HachiSecurity/plutus
+ tag: c8accb12d87de646544fd4200fa240835046a995
  subdir:
    plutus-ledger-api
    word-array

--- a/flake.lock
+++ b/flake.lock
@@ -165,14 +165,14 @@
       "flake": false,
       "locked": {
         "lastModified": 1636924888,
-        "narHash": "sha256-80ReuqPGaZrg6GnvyaG/f2Qn6GheCK9RvYQ63+i/6Ak=",
-        "owner": "input-output-hk",
+        "narHash": "sha256-9G5IXKMrMkDhlLwVEoVYskqFIqjO29Bag8pJQHtv1Cc=",
+        "owner": "HachiSecurity",
         "repo": "plutus",
-        "rev": "c8c5183f7facd967d48fe07b3b14465b8dd48fe7",
+        "rev": "c8accb12d87de646544fd4200fa240835046a995",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "HachiSecurity",
         "repo": "plutus",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -168,7 +168,7 @@
         "narHash": "sha256-80ReuqPGaZrg6GnvyaG/f2Qn6GheCK9RvYQ63+i/6Ak=",
         "owner": "input-output-hk",
         "repo": "plutus",
-        "rev": "2721c59fd2302b75c4138456c29fd5b509e8340a",
+        "rev": "c8c5183f7facd967d48fe07b3b14465b8dd48fe7",
         "type": "github"
       },
       "original": {

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -54,7 +54,7 @@ let
       "https://github.com/input-output-hk/hedgehog-extras"."edf6945007177a638fbeb8802397f3a6f4e47c14" = "0wc7qzkc7j4ns2rz562h6qrx2f8xyq7yjcb7zidnj7f6j0pcd0i9";
       "https://github.com/input-output-hk/cardano-wallet"."760140e238a5fbca61d1b286d7a80ece058dc729" = "014njpddrlqm9bbab636h2gf58zkm0bx04i1jsn07vh5j3k0gri6";
       "https://github.com/input-output-hk/cardano-addresses"."d2f86caa085402a953920c6714a0de6a50b655ec" = "0p6jbnd7ky2yf7bwb1350k8880py8dgqg39k49q02a6ij4ld01ay";
-      "https://github.com/input-output-hk/plutus"."c8c5183f7facd967d48fe07b3b14465b8dd48fe7" = "01fmakdp589h9nllc31s3mkys6gic6ba38s9r3ycfb9r1j5n1cja";
+      "https://github.com/HachiSecurity/plutus"."c8accb12d87de646544fd4200fa240835046a995" = "09yldxxl0jfahddd1nyfm0i8ajmjb22i45dwjkhl0cibldf4hvpl";
     };
     # Configuration settings needed for cabal configure to work when cross compiling
     # for windows. We can't use `modules` for these as `modules` are only applied

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -54,7 +54,7 @@ let
       "https://github.com/input-output-hk/hedgehog-extras"."edf6945007177a638fbeb8802397f3a6f4e47c14" = "0wc7qzkc7j4ns2rz562h6qrx2f8xyq7yjcb7zidnj7f6j0pcd0i9";
       "https://github.com/input-output-hk/cardano-wallet"."760140e238a5fbca61d1b286d7a80ece058dc729" = "014njpddrlqm9bbab636h2gf58zkm0bx04i1jsn07vh5j3k0gri6";
       "https://github.com/input-output-hk/cardano-addresses"."d2f86caa085402a953920c6714a0de6a50b655ec" = "0p6jbnd7ky2yf7bwb1350k8880py8dgqg39k49q02a6ij4ld01ay";
-      "https://github.com/input-output-hk/plutus"."2721c59fd2302b75c4138456c29fd5b509e8340a" = "02g8pzldyfl4pm8sy22yd3l2fr3zpyhwkvv9x3h9lsf6lfx5wi7k";
+      "https://github.com/input-output-hk/plutus"."c8c5183f7facd967d48fe07b3b14465b8dd48fe7" = "01fmakdp589h9nllc31s3mkys6gic6ba38s9r3ycfb9r1j5n1cja";
     };
     # Configuration settings needed for cabal configure to work when cross compiling
     # for windows. We can't use `modules` for these as `modules` are only applied

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
@@ -291,7 +291,6 @@
           "PlutusIR/TypeCheck"
           "UntypedPlutusCore"
           "UntypedPlutusCore/DeBruijn"
-          "UntypedPlutusCore/Evaluation/HOAS"
           "UntypedPlutusCore/Evaluation/Machine/Cek"
           "UntypedPlutusCore/Evaluation/Machine/Cek/Internal"
           "UntypedPlutusCore/Parser"
@@ -335,6 +334,7 @@
         "plc" = {
           depends = [
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
@@ -375,6 +375,7 @@
         "pir" = {
           depends = [
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
@@ -405,6 +406,7 @@
             (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
             ];
           buildable = true;
+          modules = [ "Common" ];
           hsSourceDirs = [ "executables/traceToStacks" ];
           mainPath = [ "Main.hs" ];
           };
@@ -513,9 +515,25 @@
             "Evaluation/Golden"
             "Evaluation/Machines"
             "Transform/Simplify"
+            "DeBruijn/Spec"
             ];
           hsSourceDirs = [ "untyped-plutus-core/test" ];
           mainPath = [ "Spec.hs" ];
+          };
+        "traceToStacks-test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cassava" or (errorHandler.buildDepError "cassava"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
+            ];
+          buildable = true;
+          modules = [ "Common" ];
+          hsSourceDirs = [ "executables/traceToStacks" ];
+          mainPath = [ "TestGetStacks.hs" ];
           };
         "index-envs-test" = {
           depends = [

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-ledger-api.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-ledger-api.nix
@@ -87,16 +87,20 @@
         "plutus-ledger-api-test" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
             (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
             (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
             (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             ];
           buildable = true;
-          modules = [ "Spec/Interval" "Spec/Time" ];
+          modules = [ "Spec/Interval" "Spec/Time" "Spec/Eval" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Spec.hs" ];
           };

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-tx-plugin.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-tx-plugin.nix
@@ -106,6 +106,7 @@
             "Plugin/Errors/Spec"
             "Plugin/Functions/Spec"
             "Plugin/Laziness/Spec"
+            "Plugin/NoTrace/Spec"
             "Plugin/Primitives/Spec"
             "Plugin/Profiling/Spec"
             "Plugin/Typeclasses/Spec"

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
@@ -291,7 +291,6 @@
           "PlutusIR/TypeCheck"
           "UntypedPlutusCore"
           "UntypedPlutusCore/DeBruijn"
-          "UntypedPlutusCore/Evaluation/HOAS"
           "UntypedPlutusCore/Evaluation/Machine/Cek"
           "UntypedPlutusCore/Evaluation/Machine/Cek/Internal"
           "UntypedPlutusCore/Parser"
@@ -335,6 +334,7 @@
         "plc" = {
           depends = [
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
@@ -375,6 +375,7 @@
         "pir" = {
           depends = [
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
@@ -405,6 +406,7 @@
             (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
             ];
           buildable = true;
+          modules = [ "Common" ];
           hsSourceDirs = [ "executables/traceToStacks" ];
           mainPath = [ "Main.hs" ];
           };
@@ -513,9 +515,25 @@
             "Evaluation/Golden"
             "Evaluation/Machines"
             "Transform/Simplify"
+            "DeBruijn/Spec"
             ];
           hsSourceDirs = [ "untyped-plutus-core/test" ];
           mainPath = [ "Spec.hs" ];
+          };
+        "traceToStacks-test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cassava" or (errorHandler.buildDepError "cassava"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
+            ];
+          buildable = true;
+          modules = [ "Common" ];
+          hsSourceDirs = [ "executables/traceToStacks" ];
+          mainPath = [ "TestGetStacks.hs" ];
           };
         "index-envs-test" = {
           depends = [

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-ledger-api.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-ledger-api.nix
@@ -87,16 +87,20 @@
         "plutus-ledger-api-test" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
             (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
             (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
             (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             ];
           buildable = true;
-          modules = [ "Spec/Interval" "Spec/Time" ];
+          modules = [ "Spec/Interval" "Spec/Time" "Spec/Eval" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Spec.hs" ];
           };

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-tx-plugin.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-tx-plugin.nix
@@ -106,6 +106,7 @@
             "Plugin/Errors/Spec"
             "Plugin/Functions/Spec"
             "Plugin/Laziness/Spec"
+            "Plugin/NoTrace/Spec"
             "Plugin/Primitives/Spec"
             "Plugin/Profiling/Spec"
             "Plugin/Typeclasses/Spec"

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-core.nix
@@ -291,7 +291,6 @@
           "PlutusIR/TypeCheck"
           "UntypedPlutusCore"
           "UntypedPlutusCore/DeBruijn"
-          "UntypedPlutusCore/Evaluation/HOAS"
           "UntypedPlutusCore/Evaluation/Machine/Cek"
           "UntypedPlutusCore/Evaluation/Machine/Cek/Internal"
           "UntypedPlutusCore/Parser"
@@ -335,6 +334,7 @@
         "plc" = {
           depends = [
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
@@ -375,6 +375,7 @@
         "pir" = {
           depends = [
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
@@ -405,6 +406,7 @@
             (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
             ];
           buildable = true;
+          modules = [ "Common" ];
           hsSourceDirs = [ "executables/traceToStacks" ];
           mainPath = [ "Main.hs" ];
           };
@@ -513,9 +515,25 @@
             "Evaluation/Golden"
             "Evaluation/Machines"
             "Transform/Simplify"
+            "DeBruijn/Spec"
             ];
           hsSourceDirs = [ "untyped-plutus-core/test" ];
           mainPath = [ "Spec.hs" ];
+          };
+        "traceToStacks-test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cassava" or (errorHandler.buildDepError "cassava"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
+            ];
+          buildable = true;
+          modules = [ "Common" ];
+          hsSourceDirs = [ "executables/traceToStacks" ];
+          mainPath = [ "TestGetStacks.hs" ];
           };
         "index-envs-test" = {
           depends = [

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-ledger-api.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-ledger-api.nix
@@ -87,16 +87,20 @@
         "plutus-ledger-api-test" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
             (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
             (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
             (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             ];
           buildable = true;
-          modules = [ "Spec/Interval" "Spec/Time" ];
+          modules = [ "Spec/Interval" "Spec/Time" "Spec/Eval" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Spec.hs" ];
           };

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-tx-plugin.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-tx-plugin.nix
@@ -106,6 +106,7 @@
             "Plugin/Errors/Spec"
             "Plugin/Functions/Spec"
             "Plugin/Laziness/Spec"
+            "Plugin/NoTrace/Spec"
             "Plugin/Primitives/Spec"
             "Plugin/Profiling/Spec"
             "Plugin/Typeclasses/Spec"

--- a/plutus-use-cases/test/Spec/Future.hs
+++ b/plutus-use-cases/test/Spec/Future.hs
@@ -9,6 +9,8 @@
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:remove-trace #-}
+
 module Spec.Future(tests, testAccounts, theFuture, increaseMarginTrace, settleEarlyTrace, payOutTrace) where
 
 import Control.Lens

--- a/plutus-use-cases/test/Spec/GameStateMachine.hs
+++ b/plutus-use-cases/test/Spec/GameStateMachine.hs
@@ -14,6 +14,8 @@
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:remove-trace #-}
+
 module Spec.GameStateMachine
   ( tests, successTrace, successTrace2, traceLeaveOneAdaInScript, failTrace
   , prop_Game, propGame', prop_GameWhitelist

--- a/plutus-use-cases/test/Spec/Governance.hs
+++ b/plutus-use-cases/test/Spec/Governance.hs
@@ -7,6 +7,8 @@
 {-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:remove-trace #-}
+
 module Spec.Governance(tests, doVoting) where
 
 import Control.Lens (view)

--- a/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
+++ b/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
@@ -8,6 +8,7 @@
 
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:debug-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:remove-trace #-}
 
 module Spec.MultiSigStateMachine(tests, lockProposeSignPay) where
 

--- a/plutus-use-cases/test/Spec/Vesting.hs
+++ b/plutus-use-cases/test/Spec/Vesting.hs
@@ -11,6 +11,8 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns -fno-warn-unused-do-bind -fno-warn-name-shadowing #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:remove-trace #-}
+
 module Spec.Vesting (tests, prop_Vesting, prop_CheckNoLockedFundsProof, retrieveFundsTrace) where
 
 import Control.Lens hiding (elements)

--- a/plutus-use-cases/test/Spec/crowdfunding.pir
+++ b/plutus-use-cases/test/Spec/crowdfunding.pir
@@ -9,70 +9,8 @@
         (vardecl Collect CampaignAction) (vardecl Refund CampaignAction)
       )
     )
-    (datatypebind
-      (datatype
-        (tyvardecl Credential (type))
-
-        Credential_match
-        (vardecl PubKeyCredential (fun (con bytestring) Credential))
-        (vardecl ScriptCredential (fun (con bytestring) Credential))
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl StakingCredential (type))
-
-        StakingCredential_match
-        (vardecl StakingHash (fun Credential StakingCredential))
-        (vardecl
-          StakingPtr
-          (fun
-            (con integer)
-            (fun (con integer) (fun (con integer) StakingCredential))
-          )
-        )
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl DCert (type))
-
-        DCert_match
-        (vardecl DCertDelegDeRegKey (fun StakingCredential DCert))
-        (vardecl
-          DCertDelegDelegate
-          (fun StakingCredential (fun (con bytestring) DCert))
-        )
-        (vardecl DCertDelegRegKey (fun StakingCredential DCert))
-        (vardecl DCertGenesis DCert)
-        (vardecl DCertMir DCert)
-        (vardecl
-          DCertPoolRegister (fun (con bytestring) (fun (con bytestring) DCert))
-        )
-        (vardecl
-          DCertPoolRetire (fun (con bytestring) (fun (con integer) DCert))
-        )
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl TxOutRef (type))
-
-        TxOutRef_match
-        (vardecl TxOutRef (fun (con bytestring) (fun (con integer) TxOutRef)))
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl ScriptPurpose (type))
-
-        ScriptPurpose_match
-        (vardecl Certifying (fun DCert ScriptPurpose))
-        (vardecl Minting (fun (con bytestring) ScriptPurpose))
-        (vardecl Rewarding (fun StakingCredential ScriptPurpose))
-        (vardecl Spending (fun TxOutRef ScriptPurpose))
-      )
-    )
+    (typebind (tyvardecl ScriptPurpose (type)) (all a (type) (fun a a)))
+    (typebind (tyvardecl DCert (type)) (all a (type) (fun a a)))
     (datatypebind
       (datatype
         (tyvardecl Bool (type))
@@ -117,31 +55,12 @@
         )
       )
     )
-    (datatypebind
-      (datatype
-        (tyvardecl Maybe (fun (type) (type)))
-        (tyvardecl a (type))
-        Maybe_match
-        (vardecl Just (fun a [ Maybe a ])) (vardecl Nothing [ Maybe a ])
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl Address (type))
-
-        Address_match
-        (vardecl
-          Address (fun Credential (fun [ Maybe StakingCredential ] Address))
-        )
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl Tuple2 (fun (type) (fun (type) (type))))
-        (tyvardecl a (type)) (tyvardecl b (type))
-        Tuple2_match
-        (vardecl Tuple2 (fun a (fun b [ [ Tuple2 a ] b ])))
-      )
+    (typebind (tyvardecl TxInInfo (type)) (all a (type) (fun a a)))
+    (typebind (tyvardecl TxOut (type)) (all a (type) (fun a a)))
+    (typebind (tyvardecl StakingCredential (type)) (all a (type) (fun a a)))
+    (typebind
+      (tyvardecl Tuple2 (fun (type) (fun (type) (type))))
+      (lam a (type) (lam a (type) (all a (type) (fun a a))))
     )
     (let
       (rec)
@@ -156,45 +75,6 @@
       )
       (let
         (nonrec)
-        (datatypebind
-          (datatype
-            (tyvardecl TxOut (type))
-
-            TxOut_match
-            (vardecl
-              TxOut
-              (fun
-                Address
-                (fun
-                  [
-                    [
-                      (lam k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ]))
-                      (con bytestring)
-                    ]
-                    [
-                      [
-                        (lam
-                          k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ])
-                        )
-                        (con bytestring)
-                      ]
-                      (con integer)
-                    ]
-                  ]
-                  (fun [ Maybe (con bytestring) ] TxOut)
-                )
-              )
-            )
-          )
-        )
-        (datatypebind
-          (datatype
-            (tyvardecl TxInInfo (type))
-
-            TxInInfo_match
-            (vardecl TxInInfo (fun TxOutRef (fun TxOut TxInInfo)))
-          )
-        )
         (datatypebind
           (datatype
             (tyvardecl TxInfo (type))
@@ -292,8 +172,8 @@
         )
         (termbind
           (strict)
-          (vardecl fail (fun (all a (type) a) Ordering))
-          (lam ds (all a (type) a) (error Ordering))
+          (vardecl fail (fun (con unit) Ordering))
+          (lam ds (con unit) (error Ordering))
         )
         (datatypebind
           (datatype
@@ -396,10 +276,10 @@
                     (nonrec)
                     (termbind
                       (strict)
-                      (vardecl fail (fun (all a (type) a) Ordering))
+                      (vardecl fail (fun (con unit) Ordering))
                       (lam
                         ds
-                        (all a (type) a)
+                        (con unit)
                         {
                           [
                             [
@@ -463,21 +343,13 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     ]
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   ]
                                                   (all dead (type) dead)
@@ -486,9 +358,7 @@
                                             )
                                           ]
                                           (abs
-                                            dead
-                                            (type)
-                                            [ fail (abs e (type) (error e)) ]
+                                            dead (type) [ fail (con unit ()) ]
                                           )
                                         ]
                                         (abs dead (type) GT)
@@ -546,19 +416,13 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               ]
                                               (all dead (type) dead)
@@ -566,11 +430,7 @@
                                           )
                                         )
                                       ]
-                                      (abs
-                                        dead
-                                        (type)
-                                        [ fail (abs e (type) (error e)) ]
-                                      )
+                                      (abs dead (type) [ fail (con unit ()) ])
                                     ]
                                     (abs dead (type) GT)
                                   ]
@@ -586,10 +446,10 @@
                     )
                     (termbind
                       (strict)
-                      (vardecl fail (fun (all a (type) a) Ordering))
+                      (vardecl fail (fun (con unit) Ordering))
                       (lam
                         ds
-                        (all a (type) a)
+                        (con unit)
                         {
                           [
                             [
@@ -653,21 +513,13 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     ]
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   ]
                                                   (all dead (type) dead)
@@ -676,9 +528,7 @@
                                             )
                                           ]
                                           (abs
-                                            dead
-                                            (type)
-                                            [ fail (abs e (type) (error e)) ]
+                                            dead (type) [ fail (con unit ()) ]
                                           )
                                         ]
                                         (abs dead (type) GT)
@@ -736,19 +586,13 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               ]
                                               (all dead (type) dead)
@@ -756,11 +600,7 @@
                                           )
                                         )
                                       ]
-                                      (abs
-                                        dead
-                                        (type)
-                                        [ fail (abs e (type) (error e)) ]
-                                      )
+                                      (abs dead (type) [ fail (con unit ()) ])
                                     ]
                                     (abs dead (type) GT)
                                   ]
@@ -776,10 +616,10 @@
                     )
                     (termbind
                       (strict)
-                      (vardecl fail (fun (all a (type) a) Ordering))
+                      (vardecl fail (fun (con unit) Ordering))
                       (lam
                         ds
-                        (all a (type) a)
+                        (con unit)
                         {
                           [
                             [
@@ -843,21 +683,13 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     ]
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   ]
                                                   (all dead (type) dead)
@@ -866,9 +698,7 @@
                                             )
                                           ]
                                           (abs
-                                            dead
-                                            (type)
-                                            [ fail (abs e (type) (error e)) ]
+                                            dead (type) [ fail (con unit ()) ]
                                           )
                                         ]
                                         (abs dead (type) GT)
@@ -926,19 +756,13 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               ]
                                               (all dead (type) dead)
@@ -946,11 +770,7 @@
                                           )
                                         )
                                       ]
-                                      (abs
-                                        dead
-                                        (type)
-                                        [ fail (abs e (type) (error e)) ]
-                                      )
+                                      (abs dead (type) [ fail (con unit ()) ])
                                     ]
                                     (abs dead (type) GT)
                                   ]
@@ -966,10 +786,10 @@
                     )
                     (termbind
                       (strict)
-                      (vardecl fail (fun (all a (type) a) Ordering))
+                      (vardecl fail (fun (con unit) Ordering))
                       (lam
                         ds
-                        (all a (type) a)
+                        (con unit)
                         {
                           [
                             [
@@ -1033,21 +853,13 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     ]
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   ]
                                                   (all dead (type) dead)
@@ -1056,9 +868,7 @@
                                             )
                                           ]
                                           (abs
-                                            dead
-                                            (type)
-                                            [ fail (abs e (type) (error e)) ]
+                                            dead (type) [ fail (con unit ()) ]
                                           )
                                         ]
                                         (abs dead (type) GT)
@@ -1116,19 +926,13 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               ]
                                               (all dead (type) dead)
@@ -1136,11 +940,7 @@
                                           )
                                         )
                                       ]
-                                      (abs
-                                        dead
-                                        (type)
-                                        [ fail (abs e (type) (error e)) ]
-                                      )
+                                      (abs dead (type) [ fail (con unit ()) ])
                                     ]
                                     (abs dead (type) GT)
                                   ]
@@ -1198,22 +998,14 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     )
                                                   ]
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs
@@ -1244,11 +1036,7 @@
                                                               (type)
                                                               [
                                                                 fail
-                                                                (abs
-                                                                  e
-                                                                  (type)
-                                                                  (error e)
-                                                                )
+                                                                (con unit ())
                                                               ]
                                                             )
                                                           )
@@ -1256,12 +1044,7 @@
                                                         (abs
                                                           dead
                                                           (type)
-                                                          [
-                                                            fail
-                                                            (abs
-                                                              e (type) (error e)
-                                                            )
-                                                          ]
+                                                          [ fail (con unit ()) ]
                                                         )
                                                       ]
                                                       (abs dead (type) EQ)
@@ -1294,17 +1077,12 @@
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               )
                                             ]
                                             (abs
-                                              dead
-                                              (type)
-                                              [ fail (abs e (type) (error e)) ]
+                                              dead (type) [ fail (con unit ()) ]
                                             )
                                           ]
                                           (abs
@@ -1326,22 +1104,14 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     )
                                                   ]
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs dead (type) EQ)
@@ -1411,17 +1181,12 @@
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               )
                                             ]
                                             (abs
-                                              dead
-                                              (type)
-                                              [ fail (abs e (type) (error e)) ]
+                                              dead (type) [ fail (con unit ()) ]
                                             )
                                           ]
                                           (abs
@@ -1443,22 +1208,14 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     )
                                                   ]
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs dead (type) EQ)
@@ -1489,17 +1246,11 @@
                                           default_arg0
                                           a
                                           (abs
-                                            dead
-                                            (type)
-                                            [ fail (abs e (type) (error e)) ]
+                                            dead (type) [ fail (con unit ()) ]
                                           )
                                         )
                                       ]
-                                      (abs
-                                        dead
-                                        (type)
-                                        [ fail (abs e (type) (error e)) ]
-                                      )
+                                      (abs dead (type) [ fail (con unit ()) ])
                                     ]
                                     (abs
                                       dead
@@ -1518,17 +1269,12 @@
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               )
                                             ]
                                             (abs
-                                              dead
-                                              (type)
-                                              [ fail (abs e (type) (error e)) ]
+                                              dead (type) [ fail (con unit ()) ]
                                             )
                                           ]
                                           (abs dead (type) EQ)
@@ -1999,6 +1745,14 @@
           )
           (let
             (nonrec)
+            (datatypebind
+              (datatype
+                (tyvardecl Maybe (fun (type) (type)))
+                (tyvardecl a (type))
+                Maybe_match
+                (vardecl Just (fun a [ Maybe a ])) (vardecl Nothing [ Maybe a ])
+              )
+            )
             (termbind
               (strict)
               (vardecl

--- a/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
@@ -19,12 +19,12 @@ Slot 1: 00000000-0000-4000-8000-000000000002 {Wallet Wc30e}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",10000000)])])"
 Slot 1: W7ce812d: Balancing an unbalanced transaction:
                     Tx:
-                      Tx e185d3cf67edc3ad39d0b39cc1974e33ce3c04c400126dae4a35183e52876392:
+                      Tx 93381a5d39dd378d10c9bde221c0b04e3faffcfd5dd5099b636fa91ec2f0eee6:
                         {inputs:
                         collateral inputs:
                         outputs:
                           - Value (Map [(,Map [("",10000000)])]) addressed to
-                            ScriptCredential: 845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b (no staking credential)
+                            ScriptCredential: aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7 (no staking credential)
                         mint: Value (Map [])
                         fee: Value (Map [])
                         mps:
@@ -36,23 +36,23 @@ Slot 1: W7ce812d: Balancing an unbalanced transaction:
                     Utxo index:
                     Validity range:
                       (-∞ , POSIXTime 1596059111000 ]
-Slot 1: W7ce812d: Finished balancing. e9628f4a7231fbe76f221ae02309b0d44df8d902154ab1bd93e38a274d52f370
+Slot 1: W7ce812d: Finished balancing. ac172495ff852ef583cac6ef4893c8a4e5ffd41dd490c01b6946b5f7c6a04cbd
 Slot 1: 00000000-0000-4000-8000-000000000003 {Wallet W5f5a}:
           Contract instance started
-Slot 1: W7ce812d: Submitting tx: e9628f4a7231fbe76f221ae02309b0d44df8d902154ab1bd93e38a274d52f370
-Slot 1: W7ce812d: TxSubmit: e9628f4a7231fbe76f221ae02309b0d44df8d902154ab1bd93e38a274d52f370
+Slot 1: W7ce812d: Submitting tx: ac172495ff852ef583cac6ef4893c8a4e5ffd41dd490c01b6946b5f7c6a04cbd
+Slot 1: W7ce812d: TxSubmit: ac172495ff852ef583cac6ef4893c8a4e5ffd41dd490c01b6946b5f7c6a04cbd
 Slot 1: 00000000-0000-4000-8000-000000000003 {Wallet W5f5a}:
           Receive endpoint call on 'contribute' for Object (fromList [("contents",Array [Object (fromList [("getEndpointDescription",String "contribute")]),Object (fromList [("unEndpointValue",Object (fromList [("contribValue",Object (fromList [("getValue",Array [Array [Object (fromList [("unCurrencySymbol",String "")]),Array [Array [Object (fromList [("unTokenName",String "")]),Number 2500000.0]]]])]))]))])]),("tag",String "ExposeEndpointResp")])
 Slot 1: 00000000-0000-4000-8000-000000000003 {Wallet W5f5a}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",2500000)])])"
 Slot 1: Wc30efb7: Balancing an unbalanced transaction:
                     Tx:
-                      Tx e9e0e61a68074145f5b96fbfad3095312fd6f108e8c190bcbd085065af920a41:
+                      Tx eea0ebc3de0c5f5eb585429301913618d16e8c8dd8f86b0f80006ae8ebe043f1:
                         {inputs:
                         collateral inputs:
                         outputs:
                           - Value (Map [(,Map [("",10000000)])]) addressed to
-                            ScriptCredential: 845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b (no staking credential)
+                            ScriptCredential: aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7 (no staking credential)
                         mint: Value (Map [])
                         fee: Value (Map [])
                         mps:
@@ -64,17 +64,17 @@ Slot 1: Wc30efb7: Balancing an unbalanced transaction:
                     Utxo index:
                     Validity range:
                       (-∞ , POSIXTime 1596059111000 ]
-Slot 1: Wc30efb7: Finished balancing. 2f869889c09e76fb2cbfe2a3a0d512bfc86fe515d0cee53ecea4a79d3e695029
-Slot 1: Wc30efb7: Submitting tx: 2f869889c09e76fb2cbfe2a3a0d512bfc86fe515d0cee53ecea4a79d3e695029
-Slot 1: Wc30efb7: TxSubmit: 2f869889c09e76fb2cbfe2a3a0d512bfc86fe515d0cee53ecea4a79d3e695029
+Slot 1: Wc30efb7: Finished balancing. 7ac5fbd2b7413f6f126291ad3e72e497d4b4bf4d73e6ca6d231a745fb7e31810
+Slot 1: Wc30efb7: Submitting tx: 7ac5fbd2b7413f6f126291ad3e72e497d4b4bf4d73e6ca6d231a745fb7e31810
+Slot 1: Wc30efb7: TxSubmit: 7ac5fbd2b7413f6f126291ad3e72e497d4b4bf4d73e6ca6d231a745fb7e31810
 Slot 1: W5f5a4f5: Balancing an unbalanced transaction:
                     Tx:
-                      Tx 1fc4e01d293a1b7f63d9081d8845c3502cfa549004f4bbb41ed6a2d8adb810a2:
+                      Tx c1cb6dae63daeda74c0a28811e1c5d6d8545a64de9bd65f691d95068bc25f9ab:
                         {inputs:
                         collateral inputs:
                         outputs:
                           - Value (Map [(,Map [("",2500000)])]) addressed to
-                            ScriptCredential: 845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b (no staking credential)
+                            ScriptCredential: aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7 (no staking credential)
                         mint: Value (Map [])
                         fee: Value (Map [])
                         mps:
@@ -86,23 +86,23 @@ Slot 1: W5f5a4f5: Balancing an unbalanced transaction:
                     Utxo index:
                     Validity range:
                       (-∞ , POSIXTime 1596059111000 ]
-Slot 1: W5f5a4f5: Finished balancing. c351875a8d5d26a87f1cf365f007f8a543040e9d8d182d608223edd245c5ea9e
-Slot 1: W5f5a4f5: Submitting tx: c351875a8d5d26a87f1cf365f007f8a543040e9d8d182d608223edd245c5ea9e
-Slot 1: W5f5a4f5: TxSubmit: c351875a8d5d26a87f1cf365f007f8a543040e9d8d182d608223edd245c5ea9e
-Slot 1: TxnValidate c351875a8d5d26a87f1cf365f007f8a543040e9d8d182d608223edd245c5ea9e
-Slot 1: TxnValidate 2f869889c09e76fb2cbfe2a3a0d512bfc86fe515d0cee53ecea4a79d3e695029
-Slot 1: TxnValidate e9628f4a7231fbe76f221ae02309b0d44df8d902154ab1bd93e38a274d52f370
+Slot 1: W5f5a4f5: Finished balancing. 47d829d148d9ea933f56866a8fcb665de1eeff287f8551b510cf6c5e600568d4
+Slot 1: W5f5a4f5: Submitting tx: 47d829d148d9ea933f56866a8fcb665de1eeff287f8551b510cf6c5e600568d4
+Slot 1: W5f5a4f5: TxSubmit: 47d829d148d9ea933f56866a8fcb665de1eeff287f8551b510cf6c5e600568d4
+Slot 1: TxnValidate 47d829d148d9ea933f56866a8fcb665de1eeff287f8551b510cf6c5e600568d4
+Slot 1: TxnValidate 7ac5fbd2b7413f6f126291ad3e72e497d4b4bf4d73e6ca6d231a745fb7e31810
+Slot 1: TxnValidate ac172495ff852ef583cac6ef4893c8a4e5ffd41dd490c01b6946b5f7c6a04cbd
 Slot 20: 00000000-0000-4000-8000-000000000000 {Wallet W872c}:
            Contract log: String "Collecting funds"
 Slot 20: W872cb83: Balancing an unbalanced transaction:
                      Tx:
-                       Tx e76a2eef029a8ed6f69bba989c02632b04da7ad691299365cadcbc78a41eb0cf:
+                       Tx b82c535d7f5818fd50f99ef5bcb223db5ec49369a4302a626d26e61bf14292ad:
                          {inputs:
-                            - 2f869889c09e76fb2cbfe2a3a0d512bfc86fe515d0cee53ecea4a79d3e695029!1
+                            - 47d829d148d9ea933f56866a8fcb665de1eeff287f8551b510cf6c5e600568d4!1
                               <>
-                            - c351875a8d5d26a87f1cf365f007f8a543040e9d8d182d608223edd245c5ea9e!1
+                            - 7ac5fbd2b7413f6f126291ad3e72e497d4b4bf4d73e6ca6d231a745fb7e31810!1
                               <>
-                            - e9628f4a7231fbe76f221ae02309b0d44df8d902154ab1bd93e38a274d52f370!1
+                            - ac172495ff852ef583cac6ef4893c8a4e5ffd41dd490c01b6946b5f7c6a04cbd!1
                               <>
                          collateral inputs:
                          outputs:
@@ -114,20 +114,20 @@ Slot 20: W872cb83: Balancing an unbalanced transaction:
                          data:}
                      Requires signatures:
                      Utxo index:
-                       ( 2f869889c09e76fb2cbfe2a3a0d512bfc86fe515d0cee53ecea4a79d3e695029!1
-                       , - Value (Map [(,Map [("",10000000)])]) addressed to
-                           845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b )
-                       ( c351875a8d5d26a87f1cf365f007f8a543040e9d8d182d608223edd245c5ea9e!1
+                       ( 47d829d148d9ea933f56866a8fcb665de1eeff287f8551b510cf6c5e600568d4!1
                        , - Value (Map [(,Map [("",2500000)])]) addressed to
-                           845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b )
-                       ( e9628f4a7231fbe76f221ae02309b0d44df8d902154ab1bd93e38a274d52f370!1
+                           aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7 )
+                       ( 7ac5fbd2b7413f6f126291ad3e72e497d4b4bf4d73e6ca6d231a745fb7e31810!1
                        , - Value (Map [(,Map [("",10000000)])]) addressed to
-                           845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b )
+                           aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7 )
+                       ( ac172495ff852ef583cac6ef4893c8a4e5ffd41dd490c01b6946b5f7c6a04cbd!1
+                       , - Value (Map [(,Map [("",10000000)])]) addressed to
+                           aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7 )
                      Validity range:
                        [ POSIXTime 1596059111000 , POSIXTime 1596059120999 ]
-Slot 20: W872cb83: Finished balancing. 3a20125dbda70ddc4408207505e362966252b6941ec7eb334ca11f11fc96ac35
-Slot 20: W872cb83: Submitting tx: 3a20125dbda70ddc4408207505e362966252b6941ec7eb334ca11f11fc96ac35
-Slot 20: W872cb83: TxSubmit: 3a20125dbda70ddc4408207505e362966252b6941ec7eb334ca11f11fc96ac35
+Slot 20: W872cb83: Finished balancing. 177585baeaf1fb3c541219d7992fb4ea810397b5594caf37dce6f5396de9fc8b
+Slot 20: W872cb83: Submitting tx: 177585baeaf1fb3c541219d7992fb4ea810397b5594caf37dce6f5396de9fc8b
+Slot 20: W872cb83: TxSubmit: 177585baeaf1fb3c541219d7992fb4ea810397b5594caf37dce6f5396de9fc8b
 Slot 20: 00000000-0000-4000-8000-000000000000 {Wallet W872c}:
            Contract instance stopped (no errors)
-Slot 20: TxnValidate 3a20125dbda70ddc4408207505e362966252b6941ec7eb334ca11f11fc96ac35
+Slot 20: TxnValidate 177585baeaf1fb3c541219d7992fb4ea810397b5594caf37dce6f5396de9fc8b

--- a/plutus-use-cases/test/Spec/future.pir
+++ b/plutus-use-cases/test/Spec/future.pir
@@ -1,97 +1,8 @@
 (program
   (let
     (nonrec)
-    (termbind (strict) (vardecl void (all a (type) a)) (abs e (type) (error e)))
-    (datatypebind
-      (datatype
-        (tyvardecl TxOutRef (type))
-
-        TxOutRef_match
-        (vardecl TxOutRef (fun (con bytestring) (fun (con integer) TxOutRef)))
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl ThreadToken (type))
-
-        ThreadToken_match
-        (vardecl ThreadToken (fun TxOutRef (fun (con bytestring) ThreadToken)))
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl Credential (type))
-
-        Credential_match
-        (vardecl PubKeyCredential (fun (con bytestring) Credential))
-        (vardecl ScriptCredential (fun (con bytestring) Credential))
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl StakingCredential (type))
-
-        StakingCredential_match
-        (vardecl StakingHash (fun Credential StakingCredential))
-        (vardecl
-          StakingPtr
-          (fun
-            (con integer)
-            (fun (con integer) (fun (con integer) StakingCredential))
-          )
-        )
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl DCert (type))
-
-        DCert_match
-        (vardecl DCertDelegDeRegKey (fun StakingCredential DCert))
-        (vardecl
-          DCertDelegDelegate
-          (fun StakingCredential (fun (con bytestring) DCert))
-        )
-        (vardecl DCertDelegRegKey (fun StakingCredential DCert))
-        (vardecl DCertGenesis DCert)
-        (vardecl DCertMir DCert)
-        (vardecl
-          DCertPoolRegister (fun (con bytestring) (fun (con bytestring) DCert))
-        )
-        (vardecl
-          DCertPoolRetire (fun (con bytestring) (fun (con integer) DCert))
-        )
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl ScriptPurpose (type))
-
-        ScriptPurpose_match
-        (vardecl Certifying (fun DCert ScriptPurpose))
-        (vardecl Minting (fun (con bytestring) ScriptPurpose))
-        (vardecl Rewarding (fun StakingCredential ScriptPurpose))
-        (vardecl Spending (fun TxOutRef ScriptPurpose))
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl Maybe (fun (type) (type)))
-        (tyvardecl a (type))
-        Maybe_match
-        (vardecl Just (fun a [ Maybe a ])) (vardecl Nothing [ Maybe a ])
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl Address (type))
-
-        Address_match
-        (vardecl
-          Address (fun Credential (fun [ Maybe StakingCredential ] Address))
-        )
-      )
-    )
+    (typebind (tyvardecl ThreadToken (type)) (all a (type) (fun a a)))
+    (typebind (tyvardecl ScriptContext (type)) (all a (type) (fun a a)))
     (datatypebind
       (datatype
         (tyvardecl Tuple2 (fun (type) (fun (type) (type))))
@@ -115,13 +26,13 @@
         (nonrec)
         (datatypebind
           (datatype
-            (tyvardecl TxOut (type))
-
-            TxOut_match
+            (tyvardecl State (fun (type) (type)))
+            (tyvardecl s (type))
+            State_match
             (vardecl
-              TxOut
+              State
               (fun
-                Address
+                s
                 (fun
                   [
                     [
@@ -138,19 +49,19 @@
                       (con integer)
                     ]
                   ]
-                  (fun [ Maybe (con bytestring) ] TxOut)
+                  [ State s ]
                 )
               )
             )
           )
         )
-        (datatypebind
-          (datatype
-            (tyvardecl TxInInfo (type))
-
-            TxInInfo_match
-            (vardecl TxInInfo (fun TxOutRef (fun TxOut TxInInfo)))
-          )
+        (typebind
+          (tyvardecl InputConstraint (fun (type) (type)))
+          (lam a (type) (all a (type) (fun a a)))
+        )
+        (typebind
+          (tyvardecl OutputConstraint (fun (type) (type)))
+          (lam a (type) (all a (type) (fun a a)))
         )
         (datatypebind
           (datatype
@@ -203,163 +114,13 @@
         )
         (datatypebind
           (datatype
-            (tyvardecl TxInfo (type))
-
-            TxInfo_match
-            (vardecl
-              TxInfo
-              (fun
-                [ List TxInInfo ]
-                (fun
-                  [ List TxOut ]
-                  (fun
-                    [
-                      [
-                        (lam
-                          k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ])
-                        )
-                        (con bytestring)
-                      ]
-                      [
-                        [
-                          (lam
-                            k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ])
-                          )
-                          (con bytestring)
-                        ]
-                        (con integer)
-                      ]
-                    ]
-                    (fun
-                      [
-                        [
-                          (lam
-                            k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ])
-                          )
-                          (con bytestring)
-                        ]
-                        [
-                          [
-                            (lam
-                              k
-                              (type)
-                              (lam v (type) [ List [ [ Tuple2 k ] v ] ])
-                            )
-                            (con bytestring)
-                          ]
-                          (con integer)
-                        ]
-                      ]
-                      (fun
-                        [ List DCert ]
-                        (fun
-                          [
-                            List [ [ Tuple2 StakingCredential ] (con integer) ]
-                          ]
-                          (fun
-                            [ Interval (con integer) ]
-                            (fun
-                              [ List (con bytestring) ]
-                              (fun
-                                [
-                                  List
-                                  [ [ Tuple2 (con bytestring) ] (con data) ]
-                                ]
-                                (fun (con bytestring) TxInfo)
-                              )
-                            )
-                          )
-                        )
-                      )
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (datatypebind
-          (datatype
-            (tyvardecl ScriptContext (type))
-
-            ScriptContext_match
-            (vardecl
-              ScriptContext (fun TxInfo (fun ScriptPurpose ScriptContext))
-            )
-          )
-        )
-        (datatypebind
-          (datatype
-            (tyvardecl State (fun (type) (type)))
-            (tyvardecl s (type))
-            State_match
-            (vardecl
-              State
-              (fun
-                s
-                (fun
-                  [
-                    [
-                      (lam k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ]))
-                      (con bytestring)
-                    ]
-                    [
-                      [
-                        (lam
-                          k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ])
-                        )
-                        (con bytestring)
-                      ]
-                      (con integer)
-                    ]
-                  ]
-                  [ State s ]
-                )
-              )
-            )
-          )
-        )
-        (datatypebind
-          (datatype
-            (tyvardecl InputConstraint (fun (type) (type)))
+            (tyvardecl Maybe (fun (type) (type)))
             (tyvardecl a (type))
-            InputConstraint_match
-            (vardecl
-              InputConstraint (fun a (fun TxOutRef [ InputConstraint a ]))
-            )
+            Maybe_match
+            (vardecl Just (fun a [ Maybe a ])) (vardecl Nothing [ Maybe a ])
           )
         )
-        (datatypebind
-          (datatype
-            (tyvardecl OutputConstraint (fun (type) (type)))
-            (tyvardecl a (type))
-            OutputConstraint_match
-            (vardecl
-              OutputConstraint
-              (fun
-                a
-                (fun
-                  [
-                    [
-                      (lam k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ]))
-                      (con bytestring)
-                    ]
-                    [
-                      [
-                        (lam
-                          k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ])
-                        )
-                        (con bytestring)
-                      ]
-                      (con integer)
-                    ]
-                  ]
-                  [ OutputConstraint a ]
-                )
-              )
-            )
-          )
-        )
+        (typebind (tyvardecl TxOutRef (type)) (all a (type) (fun a a)))
         (let
           (rec)
           (datatypebind
@@ -528,7 +289,7 @@
                 )
               )
             )
-            (datatypebind (datatype (tyvardecl Void (type))  Void_match ))
+            (typebind (tyvardecl Void (type)) (all a (type) (fun a a)))
             (datatypebind
               (datatype
                 (tyvardecl StateMachine (fun (type) (fun (type) (type))))

--- a/plutus-use-cases/test/Spec/future.pir
+++ b/plutus-use-cases/test/Spec/future.pir
@@ -1471,10 +1471,12 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      [
-                                                        {
-                                                          (builtin trace)
+                                                    (let
+                                                      (nonrec)
+                                                      (termbind
+                                                        (strict)
+                                                        (vardecl
+                                                          a
                                                           [
                                                             [
                                                               Either
@@ -1491,28 +1493,29 @@
                                                               ]
                                                             ]
                                                           ]
-                                                        }
-                                                        (con string "Li")
-                                                      ]
-                                                      [
-                                                        {
+                                                        )
+                                                        [
                                                           {
-                                                            Left
-                                                            SignedMessageCheckError
-                                                          }
-                                                          [
-                                                            [ Tuple2 a ]
+                                                            {
+                                                              Left
+                                                              SignedMessageCheckError
+                                                            }
                                                             [
+                                                              [ Tuple2 a ]
                                                               [
-                                                                TxConstraints i
+                                                                [
+                                                                  TxConstraints
+                                                                  i
+                                                                ]
+                                                                o
                                                               ]
-                                                              o
                                                             ]
-                                                          ]
-                                                        }
-                                                        DecodingError
-                                                      ]
-                                                    ]
+                                                          }
+                                                          DecodingError
+                                                        ]
+                                                      )
+                                                      a
+                                                    )
                                                   )
                                                 ]
                                                 (all dead (type) dead)

--- a/plutus-use-cases/test/Spec/gameStateMachine.pir
+++ b/plutus-use-cases/test/Spec/gameStateMachine.pir
@@ -27,16 +27,7 @@
         (con unit)
         [
           { error [ [ Tuple2 (con bytestring) ] (con bytestring) ] }
-          [
-            {
-              [
-                Unit_match
-                [ [ { (builtin trace) Unit } (con string "Lg") ] Unit ]
-              ]
-              (con unit)
-            }
-            (con unit ())
-          ]
+          [ { [ Unit_match Unit ] (con unit) } (con unit ()) ]
         ]
       )
     )
@@ -47,26 +38,6 @@
         Bool_match
         (vardecl True Bool) (vardecl False Bool)
       )
-    )
-    (termbind
-      (nonstrict)
-      (vardecl j Bool)
-      [ [ { (builtin trace) Bool } (con string "Ld") ] False ]
-    )
-    (termbind
-      (nonstrict)
-      (vardecl j Bool)
-      [ [ { (builtin trace) Bool } (con string "L7") ] False ]
-    )
-    (termbind
-      (nonstrict)
-      (vardecl j Bool)
-      [ [ { (builtin trace) Bool } (con string "La") ] False ]
-    )
-    (termbind
-      (nonstrict)
-      (vardecl j Bool)
-      [ [ { (builtin trace) Bool } (con string "Lc") ] False ]
     )
     (termbind
       (strict)
@@ -6262,21 +6233,7 @@
                                                                                   (abs
                                                                                     dead
                                                                                     (type)
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          (builtin
-                                                                                            trace
-                                                                                          )
-                                                                                          Bool
-                                                                                        }
-                                                                                        (con
-                                                                                          string
-                                                                                          "L4"
-                                                                                        )
-                                                                                      ]
-                                                                                      False
-                                                                                    ]
+                                                                                    False
                                                                                   )
                                                                                 ]
                                                                                 (all
@@ -6873,7 +6830,7 @@
                                                                                             (abs
                                                                                               dead
                                                                                               (type)
-                                                                                              j
+                                                                                              False
                                                                                             )
                                                                                           ]
                                                                                           (all
@@ -6888,7 +6845,7 @@
                                                                                   (abs
                                                                                     dead
                                                                                     (type)
-                                                                                    j
+                                                                                    False
                                                                                   )
                                                                                 ]
                                                                                 (all
@@ -7234,21 +7191,7 @@
                                                                               (abs
                                                                                 dead
                                                                                 (type)
-                                                                                [
-                                                                                  [
-                                                                                    {
-                                                                                      (builtin
-                                                                                        trace
-                                                                                      )
-                                                                                      Bool
-                                                                                    }
-                                                                                    (con
-                                                                                      string
-                                                                                      "L2"
-                                                                                    )
-                                                                                  ]
-                                                                                  False
-                                                                                ]
+                                                                                False
                                                                               )
                                                                             ]
                                                                             (all
@@ -7532,22 +7475,7 @@
                                                               )
                                                             ]
                                                             (abs
-                                                              dead
-                                                              (type)
-                                                              [
-                                                                [
-                                                                  {
-                                                                    (builtin
-                                                                      trace
-                                                                    )
-                                                                    Bool
-                                                                  }
-                                                                  (con
-                                                                    string "L9"
-                                                                  )
-                                                                ]
-                                                                False
-                                                              ]
+                                                              dead (type) False
                                                             )
                                                           ]
                                                           (all dead (type) dead)
@@ -8510,21 +8438,7 @@
                                                                               (abs
                                                                                 dead
                                                                                 (type)
-                                                                                [
-                                                                                  [
-                                                                                    {
-                                                                                      (builtin
-                                                                                        trace
-                                                                                      )
-                                                                                      Bool
-                                                                                    }
-                                                                                    (con
-                                                                                      string
-                                                                                      "Lb"
-                                                                                    )
-                                                                                  ]
-                                                                                  False
-                                                                                ]
+                                                                                False
                                                                               )
                                                                             ]
                                                                             (all
@@ -10128,7 +10042,7 @@
                                                                                       (abs
                                                                                         dead
                                                                                         (type)
-                                                                                        j
+                                                                                        False
                                                                                       )
                                                                                     ]
                                                                                     (all
@@ -10150,7 +10064,7 @@
                                                             ]
                                                           )
                                                         ]
-                                                        (abs dead (type) j)
+                                                        (abs dead (type) False)
                                                       ]
                                                       (all dead (type) dead)
                                                     }
@@ -10650,17 +10564,7 @@
                                                   }
                                                   (abs dead (type) True)
                                                 ]
-                                                (abs
-                                                  dead
-                                                  (type)
-                                                  [
-                                                    [
-                                                      { (builtin trace) Bool }
-                                                      (con string "L6")
-                                                    ]
-                                                    False
-                                                  ]
-                                                )
+                                                (abs dead (type) False)
                                               ]
                                               (all dead (type) dead)
                                             }
@@ -10737,17 +10641,7 @@
                                                 }
                                                 (abs dead (type) True)
                                               ]
-                                              (abs
-                                                dead
-                                                (type)
-                                                [
-                                                  [
-                                                    { (builtin trace) Bool }
-                                                    (con string "Ld")
-                                                  ]
-                                                  False
-                                                ]
-                                              )
+                                              (abs dead (type) False)
                                             ]
                                             (all dead (type) dead)
                                           }
@@ -11297,17 +11191,7 @@
                                               }
                                               (abs dead (type) True)
                                             ]
-                                            (abs
-                                              dead
-                                              (type)
-                                              [
-                                                [
-                                                  { (builtin trace) Bool }
-                                                  (con string "L5")
-                                                ]
-                                                False
-                                              ]
-                                            )
+                                            (abs dead (type) False)
                                           ]
                                           (all dead (type) dead)
                                         }
@@ -11674,7 +11558,7 @@
                                                                                             (abs
                                                                                               dead
                                                                                               (type)
-                                                                                              j
+                                                                                              False
                                                                                             )
                                                                                           )
                                                                                         ]
@@ -11701,7 +11585,9 @@
                                                                   )
                                                                 ]
                                                                 (abs
-                                                                  dead (type) j
+                                                                  dead
+                                                                  (type)
+                                                                  False
                                                                 )
                                                               ]
                                                               (all
@@ -11977,21 +11863,7 @@
                                                                 (abs
                                                                   dead
                                                                   (type)
-                                                                  [
-                                                                    [
-                                                                      {
-                                                                        (builtin
-                                                                          trace
-                                                                        )
-                                                                        Bool
-                                                                      }
-                                                                      (con
-                                                                        string
-                                                                        "L8"
-                                                                      )
-                                                                    ]
-                                                                    False
-                                                                  ]
+                                                                  False
                                                                 )
                                                               ]
                                                               (all
@@ -12860,21 +12732,7 @@
                                                                                     (abs
                                                                                       dead
                                                                                       (type)
-                                                                                      [
-                                                                                        [
-                                                                                          {
-                                                                                            (builtin
-                                                                                              trace
-                                                                                            )
-                                                                                            Bool
-                                                                                          }
-                                                                                          (con
-                                                                                            string
-                                                                                            "L3"
-                                                                                          )
-                                                                                        ]
-                                                                                        False
-                                                                                      ]
+                                                                                      False
                                                                                     )
                                                                                   ]
                                                                                   (all
@@ -13556,21 +13414,7 @@
                                                                                                         (abs
                                                                                                           dead
                                                                                                           (type)
-                                                                                                          [
-                                                                                                            [
-                                                                                                              {
-                                                                                                                (builtin
-                                                                                                                  trace
-                                                                                                                )
-                                                                                                                Bool
-                                                                                                              }
-                                                                                                              (con
-                                                                                                                string
-                                                                                                                "L0"
-                                                                                                              )
-                                                                                                            ]
-                                                                                                            False
-                                                                                                          ]
+                                                                                                          False
                                                                                                         )
                                                                                                       ]
                                                                                                       (all
@@ -14775,21 +14619,7 @@
                                                                                                                                       {
                                                                                                                                         [
                                                                                                                                           Unit_match
-                                                                                                                                          [
-                                                                                                                                            [
-                                                                                                                                              {
-                                                                                                                                                (builtin
-                                                                                                                                                  trace
-                                                                                                                                                )
-                                                                                                                                                Unit
-                                                                                                                                              }
-                                                                                                                                              (con
-                                                                                                                                                string
-                                                                                                                                                "Lf"
-                                                                                                                                              )
-                                                                                                                                            ]
-                                                                                                                                            Unit
-                                                                                                                                          ]
+                                                                                                                                          Unit
                                                                                                                                         ]
                                                                                                                                         (con
                                                                                                                                           unit
@@ -14826,21 +14656,7 @@
                                                                                                                     (abs
                                                                                                                       dead
                                                                                                                       (type)
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            (builtin
-                                                                                                                              trace
-                                                                                                                            )
-                                                                                                                            Bool
-                                                                                                                          }
-                                                                                                                          (con
-                                                                                                                            string
-                                                                                                                            "L1"
-                                                                                                                          )
-                                                                                                                        ]
-                                                                                                                        False
-                                                                                                                      ]
+                                                                                                                      False
                                                                                                                     )
                                                                                                                   ]
                                                                                                                   (all
@@ -14887,7 +14703,9 @@
                                                                 )
                                                               ]
                                                               (abs
-                                                                dead (type) j
+                                                                dead
+                                                                (type)
+                                                                False
                                                               )
                                                             ]
                                                             (all
@@ -14896,13 +14714,13 @@
                                                           }
                                                         )
                                                       ]
-                                                      (abs dead (type) j)
+                                                      (abs dead (type) False)
                                                     ]
                                                     (all dead (type) dead)
                                                   }
                                                 )
                                               ]
-                                              (abs dead (type) j)
+                                              (abs dead (type) False)
                                             ]
                                             (all dead (type) dead)
                                           }
@@ -18358,21 +18176,7 @@
                                                                                                 {
                                                                                                   [
                                                                                                     Unit_match
-                                                                                                    [
-                                                                                                      [
-                                                                                                        {
-                                                                                                          (builtin
-                                                                                                            trace
-                                                                                                          )
-                                                                                                          Unit
-                                                                                                        }
-                                                                                                        (con
-                                                                                                          string
-                                                                                                          "S0"
-                                                                                                        )
-                                                                                                      ]
-                                                                                                      Unit
-                                                                                                    ]
+                                                                                                    Unit
                                                                                                   ]
                                                                                                   (con
                                                                                                     unit
@@ -18639,21 +18443,7 @@
                                                                                         (abs
                                                                                           dead
                                                                                           (type)
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                (builtin
-                                                                                                  trace
-                                                                                                )
-                                                                                                Bool
-                                                                                              }
-                                                                                              (con
-                                                                                                string
-                                                                                                "S4"
-                                                                                              )
-                                                                                            ]
-                                                                                            False
-                                                                                          ]
+                                                                                          False
                                                                                         )
                                                                                       ]
                                                                                       (all
@@ -18794,21 +18584,7 @@
                                                                                                       {
                                                                                                         [
                                                                                                           Bool_match
-                                                                                                          [
-                                                                                                            [
-                                                                                                              {
-                                                                                                                (builtin
-                                                                                                                  trace
-                                                                                                                )
-                                                                                                                Bool
-                                                                                                              }
-                                                                                                              (con
-                                                                                                                string
-                                                                                                                "S3"
-                                                                                                              )
-                                                                                                            ]
-                                                                                                            False
-                                                                                                          ]
+                                                                                                          False
                                                                                                         ]
                                                                                                         (all
                                                                                                           dead
@@ -19237,21 +19013,7 @@
                                                                                                     (abs
                                                                                                       dead
                                                                                                       (type)
-                                                                                                      [
-                                                                                                        [
-                                                                                                          {
-                                                                                                            (builtin
-                                                                                                              trace
-                                                                                                            )
-                                                                                                            Bool
-                                                                                                          }
-                                                                                                          (con
-                                                                                                            string
-                                                                                                            "S5"
-                                                                                                          )
-                                                                                                        ]
-                                                                                                        False
-                                                                                                      ]
+                                                                                                      False
                                                                                                     )
                                                                                                   ]
                                                                                                   (all
@@ -19285,21 +19047,7 @@
                                                               (abs
                                                                 dead
                                                                 (type)
-                                                                [
-                                                                  [
-                                                                    {
-                                                                      (builtin
-                                                                        trace
-                                                                      )
-                                                                      Bool
-                                                                    }
-                                                                    (con
-                                                                      string
-                                                                      "S6"
-                                                                    )
-                                                                  ]
-                                                                  False
-                                                                ]
+                                                                False
                                                               )
                                                             ]
                                                             (all
@@ -19420,21 +19168,7 @@
                                                                                 {
                                                                                   [
                                                                                     Bool_match
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          (builtin
-                                                                                            trace
-                                                                                          )
-                                                                                          Bool
-                                                                                        }
-                                                                                        (con
-                                                                                          string
-                                                                                          "S2"
-                                                                                        )
-                                                                                      ]
-                                                                                      False
-                                                                                    ]
+                                                                                    False
                                                                                   ]
                                                                                   (all
                                                                                     dead
@@ -19512,21 +19246,7 @@
                                                                     {
                                                                       [
                                                                         Bool_match
-                                                                        [
-                                                                          [
-                                                                            {
-                                                                              (builtin
-                                                                                trace
-                                                                              )
-                                                                              Bool
-                                                                            }
-                                                                            (con
-                                                                              string
-                                                                              "S1"
-                                                                            )
-                                                                          ]
-                                                                          False
-                                                                        ]
+                                                                        False
                                                                       ]
                                                                       (all
                                                                         dead

--- a/plutus-use-cases/test/Spec/gameStateMachine.pir
+++ b/plutus-use-cases/test/Spec/gameStateMachine.pir
@@ -1,6 +1,9 @@
 (program
   (let
     (nonrec)
+    (datatypebind
+      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
+    )
     (termbind
       (strict)
       (vardecl error (all a (type) (fun (con unit) a)))
@@ -14,18 +17,14 @@
         (vardecl Tuple2 (fun a (fun b [ [ Tuple2 a ] b ])))
       )
     )
-    (datatypebind
-      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
-    )
     (termbind
       (strict)
       (vardecl
-        fail
-        (fun (all a (type) a) [ [ Tuple2 (con bytestring) ] (con bytestring) ])
+        fail (fun (con unit) [ [ Tuple2 (con bytestring) ] (con bytestring) ])
       )
       (lam
         ds
-        (all a (type) a)
+        (con unit)
         [
           { error [ [ Tuple2 (con bytestring) ] (con bytestring) ] }
           [
@@ -41,7 +40,6 @@
         ]
       )
     )
-    (termbind (strict) (vardecl void (all a (type) a)) (abs e (type) (error e)))
     (datatypebind
       (datatype
         (tyvardecl Bool (type))
@@ -575,8 +573,8 @@
     )
     (termbind
       (strict)
-      (vardecl fail (fun (all a (type) a) Ordering))
-      (lam ds (all a (type) a) (error Ordering))
+      (vardecl fail (fun (con unit) Ordering))
+      (lam ds (con unit) (error Ordering))
     )
     (datatypebind
       (datatype
@@ -683,10 +681,10 @@
                 (nonrec)
                 (termbind
                   (strict)
-                  (vardecl fail (fun (all a (type) a) Ordering))
+                  (vardecl fail (fun (con unit) Ordering))
                   (lam
                     ds
-                    (all a (type) a)
+                    (con unit)
                     {
                       [
                         [
@@ -746,19 +744,13 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               ]
                                               (all dead (type) dead)
@@ -766,11 +758,7 @@
                                           )
                                         )
                                       ]
-                                      (abs
-                                        dead
-                                        (type)
-                                        [ fail (abs e (type) (error e)) ]
-                                      )
+                                      (abs dead (type) [ fail (con unit ()) ])
                                     ]
                                     (abs dead (type) GT)
                                   ]
@@ -822,15 +810,11 @@
                                               (abs
                                                 dead
                                                 (type)
-                                                [
-                                                  fail (abs e (type) (error e))
-                                                ]
+                                                [ fail (con unit ()) ]
                                               )
                                             ]
                                             (abs
-                                              dead
-                                              (type)
-                                              [ fail (abs e (type) (error e)) ]
+                                              dead (type) [ fail (con unit ()) ]
                                             )
                                           ]
                                           (all dead (type) dead)
@@ -838,11 +822,7 @@
                                       )
                                     )
                                   ]
-                                  (abs
-                                    dead
-                                    (type)
-                                    [ fail (abs e (type) (error e)) ]
-                                  )
+                                  (abs dead (type) [ fail (con unit ()) ])
                                 ]
                                 (abs dead (type) GT)
                               ]
@@ -858,10 +838,10 @@
                 )
                 (termbind
                   (strict)
-                  (vardecl fail (fun (all a (type) a) Ordering))
+                  (vardecl fail (fun (con unit) Ordering))
                   (lam
                     ds
-                    (all a (type) a)
+                    (con unit)
                     {
                       [
                         [
@@ -921,19 +901,13 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               ]
                                               (all dead (type) dead)
@@ -941,11 +915,7 @@
                                           )
                                         )
                                       ]
-                                      (abs
-                                        dead
-                                        (type)
-                                        [ fail (abs e (type) (error e)) ]
-                                      )
+                                      (abs dead (type) [ fail (con unit ()) ])
                                     ]
                                     (abs dead (type) GT)
                                   ]
@@ -997,15 +967,11 @@
                                               (abs
                                                 dead
                                                 (type)
-                                                [
-                                                  fail (abs e (type) (error e))
-                                                ]
+                                                [ fail (con unit ()) ]
                                               )
                                             ]
                                             (abs
-                                              dead
-                                              (type)
-                                              [ fail (abs e (type) (error e)) ]
+                                              dead (type) [ fail (con unit ()) ]
                                             )
                                           ]
                                           (all dead (type) dead)
@@ -1013,11 +979,7 @@
                                       )
                                     )
                                   ]
-                                  (abs
-                                    dead
-                                    (type)
-                                    [ fail (abs e (type) (error e)) ]
-                                  )
+                                  (abs dead (type) [ fail (con unit ()) ])
                                 ]
                                 (abs dead (type) GT)
                               ]
@@ -1033,10 +995,10 @@
                 )
                 (termbind
                   (strict)
-                  (vardecl fail (fun (all a (type) a) Ordering))
+                  (vardecl fail (fun (con unit) Ordering))
                   (lam
                     ds
-                    (all a (type) a)
+                    (con unit)
                     {
                       [
                         [
@@ -1096,19 +1058,13 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               ]
                                               (all dead (type) dead)
@@ -1116,11 +1072,7 @@
                                           )
                                         )
                                       ]
-                                      (abs
-                                        dead
-                                        (type)
-                                        [ fail (abs e (type) (error e)) ]
-                                      )
+                                      (abs dead (type) [ fail (con unit ()) ])
                                     ]
                                     (abs dead (type) GT)
                                   ]
@@ -1172,15 +1124,11 @@
                                               (abs
                                                 dead
                                                 (type)
-                                                [
-                                                  fail (abs e (type) (error e))
-                                                ]
+                                                [ fail (con unit ()) ]
                                               )
                                             ]
                                             (abs
-                                              dead
-                                              (type)
-                                              [ fail (abs e (type) (error e)) ]
+                                              dead (type) [ fail (con unit ()) ]
                                             )
                                           ]
                                           (all dead (type) dead)
@@ -1188,11 +1136,7 @@
                                       )
                                     )
                                   ]
-                                  (abs
-                                    dead
-                                    (type)
-                                    [ fail (abs e (type) (error e)) ]
-                                  )
+                                  (abs dead (type) [ fail (con unit ()) ])
                                 ]
                                 (abs dead (type) GT)
                               ]
@@ -1208,10 +1152,10 @@
                 )
                 (termbind
                   (strict)
-                  (vardecl fail (fun (all a (type) a) Ordering))
+                  (vardecl fail (fun (con unit) Ordering))
                   (lam
                     ds
-                    (all a (type) a)
+                    (con unit)
                     {
                       [
                         [
@@ -1271,19 +1215,13 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               ]
                                               (all dead (type) dead)
@@ -1291,11 +1229,7 @@
                                           )
                                         )
                                       ]
-                                      (abs
-                                        dead
-                                        (type)
-                                        [ fail (abs e (type) (error e)) ]
-                                      )
+                                      (abs dead (type) [ fail (con unit ()) ])
                                     ]
                                     (abs dead (type) GT)
                                   ]
@@ -1347,15 +1281,11 @@
                                               (abs
                                                 dead
                                                 (type)
-                                                [
-                                                  fail (abs e (type) (error e))
-                                                ]
+                                                [ fail (con unit ()) ]
                                               )
                                             ]
                                             (abs
-                                              dead
-                                              (type)
-                                              [ fail (abs e (type) (error e)) ]
+                                              dead (type) [ fail (con unit ()) ]
                                             )
                                           ]
                                           (all dead (type) dead)
@@ -1363,11 +1293,7 @@
                                       )
                                     )
                                   ]
-                                  (abs
-                                    dead
-                                    (type)
-                                    [ fail (abs e (type) (error e)) ]
-                                  )
+                                  (abs dead (type) [ fail (con unit ()) ])
                                 ]
                                 (abs dead (type) GT)
                               ]
@@ -1422,19 +1348,14 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 )
                                               ]
                                               (abs
                                                 dead
                                                 (type)
-                                                [
-                                                  fail (abs e (type) (error e))
-                                                ]
+                                                [ fail (con unit ()) ]
                                               )
                                             ]
                                             (abs
@@ -1459,22 +1380,14 @@
                                                         (abs
                                                           dead
                                                           (type)
-                                                          [
-                                                            fail
-                                                            (abs
-                                                              e (type) (error e)
-                                                            )
-                                                          ]
+                                                          [ fail (con unit ()) ]
                                                         )
                                                       )
                                                     ]
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   ]
                                                   (abs dead (type) EQ)
@@ -1505,17 +1418,11 @@
                                             default_arg0
                                             a
                                             (abs
-                                              dead
-                                              (type)
-                                              [ fail (abs e (type) (error e)) ]
+                                              dead (type) [ fail (con unit ()) ]
                                             )
                                           )
                                         ]
-                                        (abs
-                                          dead
-                                          (type)
-                                          [ fail (abs e (type) (error e)) ]
-                                        )
+                                        (abs dead (type) [ fail (con unit ()) ])
                                       ]
                                       (abs
                                         dead
@@ -1534,19 +1441,14 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 )
                                               ]
                                               (abs
                                                 dead
                                                 (type)
-                                                [
-                                                  fail (abs e (type) (error e))
-                                                ]
+                                                [ fail (con unit ()) ]
                                               )
                                             ]
                                             (abs dead (type) EQ)
@@ -1614,17 +1516,11 @@
                                             default_arg0
                                             a
                                             (abs
-                                              dead
-                                              (type)
-                                              [ fail (abs e (type) (error e)) ]
+                                              dead (type) [ fail (con unit ()) ]
                                             )
                                           )
                                         ]
-                                        (abs
-                                          dead
-                                          (type)
-                                          [ fail (abs e (type) (error e)) ]
-                                        )
+                                        (abs dead (type) [ fail (con unit ()) ])
                                       ]
                                       (abs
                                         dead
@@ -1643,19 +1539,14 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 )
                                               ]
                                               (abs
                                                 dead
                                                 (type)
-                                                [
-                                                  fail (abs e (type) (error e))
-                                                ]
+                                                [ fail (con unit ()) ]
                                               )
                                             ]
                                             (abs dead (type) EQ)
@@ -1685,18 +1576,10 @@
                                     (lam
                                       default_arg0
                                       a
-                                      (abs
-                                        dead
-                                        (type)
-                                        [ fail (abs e (type) (error e)) ]
-                                      )
+                                      (abs dead (type) [ fail (con unit ()) ])
                                     )
                                   ]
-                                  (abs
-                                    dead
-                                    (type)
-                                    [ fail (abs e (type) (error e)) ]
-                                  )
+                                  (abs dead (type) [ fail (con unit ()) ])
                                 ]
                                 (abs
                                   dead
@@ -1713,17 +1596,11 @@
                                             default_arg0
                                             a
                                             (abs
-                                              dead
-                                              (type)
-                                              [ fail (abs e (type) (error e)) ]
+                                              dead (type) [ fail (con unit ()) ]
                                             )
                                           )
                                         ]
-                                        (abs
-                                          dead
-                                          (type)
-                                          [ fail (abs e (type) (error e)) ]
-                                        )
+                                        (abs dead (type) [ fail (con unit ()) ])
                                       ]
                                       (abs dead (type) EQ)
                                     ]
@@ -5835,32 +5712,8 @@
                           }
                         ]
                       )
-                      (datatypebind
-                        (datatype
-                          (tyvardecl DCert (type))
-
-                          DCert_match
-                          (vardecl
-                            DCertDelegDeRegKey (fun StakingCredential DCert)
-                          )
-                          (vardecl
-                            DCertDelegDelegate
-                            (fun StakingCredential (fun (con bytestring) DCert))
-                          )
-                          (vardecl
-                            DCertDelegRegKey (fun StakingCredential DCert)
-                          )
-                          (vardecl DCertGenesis DCert)
-                          (vardecl DCertMir DCert)
-                          (vardecl
-                            DCertPoolRegister
-                            (fun (con bytestring) (fun (con bytestring) DCert))
-                          )
-                          (vardecl
-                            DCertPoolRetire
-                            (fun (con bytestring) (fun (con integer) DCert))
-                          )
-                        )
+                      (typebind
+                        (tyvardecl DCert (type)) (all a (type) (fun a a))
                       )
                       (datatypebind
                         (datatype
@@ -13090,119 +12943,104 @@
                               (lam
                                 ww
                                 ScriptPurpose
-                                {
+                                [
                                   [
                                     [
                                       [
-                                        [
-                                          {
-                                            [ ScriptPurpose_match ww ]
-                                            (all dead (type) [ Maybe TxInInfo ])
-                                          }
-                                          (lam
-                                            default_arg0
-                                            DCert
-                                            (abs
-                                              dead (type) { Nothing TxInInfo }
-                                            )
-                                          )
-                                        ]
+                                        {
+                                          [ ScriptPurpose_match ww ]
+                                          [ Maybe TxInInfo ]
+                                        }
                                         (lam
                                           default_arg0
-                                          (con bytestring)
-                                          (abs dead (type) { Nothing TxInInfo })
+                                          DCert
+                                          { Nothing TxInInfo }
                                         )
                                       ]
                                       (lam
                                         default_arg0
-                                        StakingCredential
-                                        (abs dead (type) { Nothing TxInInfo })
+                                        (con bytestring)
+                                        { Nothing TxInInfo }
                                       )
                                     ]
                                     (lam
-                                      txOutRef
-                                      TxOutRef
-                                      (abs
-                                        dead
-                                        (type)
-                                        [
-                                          [
-                                            [
-                                              {
-                                                {
-                                                  fFoldableNil_cfoldMap
-                                                  [
-                                                    (lam a (type) [ Maybe a ])
-                                                    TxInInfo
-                                                  ]
-                                                }
-                                                TxInInfo
-                                              }
-                                              { fMonoidFirst TxInInfo }
-                                            ]
-                                            (lam
-                                              x
-                                              TxInInfo
-                                              [
-                                                {
-                                                  [ TxInInfo_match x ]
-                                                  [ Maybe TxInInfo ]
-                                                }
-                                                (lam
-                                                  ds
-                                                  TxOutRef
-                                                  (lam
-                                                    ds
-                                                    TxOut
-                                                    {
-                                                      [
-                                                        [
-                                                          {
-                                                            [
-                                                              Bool_match
-                                                              [
-                                                                [
-                                                                  fEqTxOutRef_c
-                                                                  ds
-                                                                ]
-                                                                txOutRef
-                                                              ]
-                                                            ]
-                                                            (all
-                                                              dead
-                                                              (type)
-                                                              [ Maybe TxInInfo ]
-                                                            )
-                                                          }
-                                                          (abs
-                                                            dead
-                                                            (type)
-                                                            [
-                                                              { Just TxInInfo }
-                                                              x
-                                                            ]
-                                                          )
-                                                        ]
-                                                        (abs
-                                                          dead
-                                                          (type)
-                                                          { Nothing TxInInfo }
-                                                        )
-                                                      ]
-                                                      (all dead (type) dead)
-                                                    }
-                                                  )
-                                                )
-                                              ]
-                                            )
-                                          ]
-                                          ww
-                                        ]
-                                      )
+                                      default_arg0
+                                      StakingCredential
+                                      { Nothing TxInInfo }
                                     )
                                   ]
-                                  (all dead (type) dead)
-                                }
+                                  (lam
+                                    txOutRef
+                                    TxOutRef
+                                    [
+                                      [
+                                        [
+                                          {
+                                            {
+                                              fFoldableNil_cfoldMap
+                                              [
+                                                (lam a (type) [ Maybe a ])
+                                                TxInInfo
+                                              ]
+                                            }
+                                            TxInInfo
+                                          }
+                                          { fMonoidFirst TxInInfo }
+                                        ]
+                                        (lam
+                                          x
+                                          TxInInfo
+                                          [
+                                            {
+                                              [ TxInInfo_match x ]
+                                              [ Maybe TxInInfo ]
+                                            }
+                                            (lam
+                                              ds
+                                              TxOutRef
+                                              (lam
+                                                ds
+                                                TxOut
+                                                {
+                                                  [
+                                                    [
+                                                      {
+                                                        [
+                                                          Bool_match
+                                                          [
+                                                            [ fEqTxOutRef_c ds ]
+                                                            txOutRef
+                                                          ]
+                                                        ]
+                                                        (all
+                                                          dead
+                                                          (type)
+                                                          [ Maybe TxInInfo ]
+                                                        )
+                                                      }
+                                                      (abs
+                                                        dead
+                                                        (type)
+                                                        [ { Just TxInInfo } x ]
+                                                      )
+                                                    ]
+                                                    (abs
+                                                      dead
+                                                      (type)
+                                                      { Nothing TxInInfo }
+                                                    )
+                                                  ]
+                                                  (all dead (type) dead)
+                                                }
+                                              )
+                                            )
+                                          ]
+                                        )
+                                      ]
+                                      ww
+                                    ]
+                                  )
+                                ]
                               )
                             )
                           )
@@ -15560,12 +15398,9 @@
                                                                                                     )
                                                                                                     [
                                                                                                       fail
-                                                                                                      (abs
-                                                                                                        e
-                                                                                                        (type)
-                                                                                                        (error
-                                                                                                          e
-                                                                                                        )
+                                                                                                      (con
+                                                                                                        unit
+                                                                                                        ()
                                                                                                       )
                                                                                                     ]
                                                                                                   )
@@ -15637,12 +15472,9 @@
                                                                                                         (type)
                                                                                                         [
                                                                                                           fail
-                                                                                                          (abs
-                                                                                                            e
-                                                                                                            (type)
-                                                                                                            (error
-                                                                                                              e
-                                                                                                            )
+                                                                                                          (con
+                                                                                                            unit
+                                                                                                            ()
                                                                                                           )
                                                                                                         ]
                                                                                                       )
@@ -15673,12 +15505,9 @@
                                                                       (type)
                                                                       [
                                                                         fail
-                                                                        (abs
-                                                                          e
-                                                                          (type)
-                                                                          (error
-                                                                            e
-                                                                          )
+                                                                        (con
+                                                                          unit
+                                                                          ()
                                                                         )
                                                                       ]
                                                                     )

--- a/plutus-use-cases/test/Spec/governance.pir
+++ b/plutus-use-cases/test/Spec/governance.pir
@@ -145,29 +145,25 @@
           )
           (let
             (nonrec)
-            (termbind
-              (strict) (vardecl void (all a (type) a)) (abs e (type) (error e))
+            (datatypebind
+              (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
             )
             (termbind
               (strict)
               (vardecl error (all a (type) (fun (con unit) a)))
               (abs a (type) (lam thunk (con unit) (error a)))
             )
-            (datatypebind
-              (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
-            )
             (termbind
               (strict)
               (vardecl
                 fail
                 (fun
-                  (all a (type) a)
-                  [ [ Tuple2 (con bytestring) ] (con bytestring) ]
+                  (con unit) [ [ Tuple2 (con bytestring) ] (con bytestring) ]
                 )
               )
               (lam
                 ds
-                (all a (type) a)
+                (con unit)
                 [
                   { error [ [ Tuple2 (con bytestring) ] (con bytestring) ] }
                   [
@@ -767,8 +763,8 @@
             )
             (termbind
               (strict)
-              (vardecl fail (fun (all a (type) a) Ordering))
-              (lam ds (all a (type) a) (error Ordering))
+              (vardecl fail (fun (con unit) Ordering))
+              (lam ds (con unit) (error Ordering))
             )
             (datatypebind
               (datatype
@@ -886,10 +882,10 @@
                         (nonrec)
                         (termbind
                           (strict)
-                          (vardecl fail (fun (all a (type) a) Ordering))
+                          (vardecl fail (fun (con unit) Ordering))
                           (lam
                             ds
-                            (all a (type) a)
+                            (con unit)
                             {
                               [
                                 [
@@ -962,24 +958,14 @@
                                                             dead
                                                             (type)
                                                             [
-                                                              fail
-                                                              (abs
-                                                                e
-                                                                (type)
-                                                                (error e)
-                                                              )
+                                                              fail (con unit ())
                                                             ]
                                                           )
                                                         ]
                                                         (abs
                                                           dead
                                                           (type)
-                                                          [
-                                                            fail
-                                                            (abs
-                                                              e (type) (error e)
-                                                            )
-                                                          ]
+                                                          [ fail (con unit ()) ]
                                                         )
                                                       ]
                                                       (all dead (type) dead)
@@ -990,9 +976,7 @@
                                               (abs
                                                 dead
                                                 (type)
-                                                [
-                                                  fail (abs e (type) (error e))
-                                                ]
+                                                [ fail (con unit ()) ]
                                               )
                                             ]
                                             (abs dead (type) GT)
@@ -1054,21 +1038,13 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     ]
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   ]
                                                   (all dead (type) dead)
@@ -1077,9 +1053,7 @@
                                             )
                                           ]
                                           (abs
-                                            dead
-                                            (type)
-                                            [ fail (abs e (type) (error e)) ]
+                                            dead (type) [ fail (con unit ()) ]
                                           )
                                         ]
                                         (abs dead (type) GT)
@@ -1096,10 +1070,10 @@
                         )
                         (termbind
                           (strict)
-                          (vardecl fail (fun (all a (type) a) Ordering))
+                          (vardecl fail (fun (con unit) Ordering))
                           (lam
                             ds
-                            (all a (type) a)
+                            (con unit)
                             {
                               [
                                 [
@@ -1172,24 +1146,14 @@
                                                             dead
                                                             (type)
                                                             [
-                                                              fail
-                                                              (abs
-                                                                e
-                                                                (type)
-                                                                (error e)
-                                                              )
+                                                              fail (con unit ())
                                                             ]
                                                           )
                                                         ]
                                                         (abs
                                                           dead
                                                           (type)
-                                                          [
-                                                            fail
-                                                            (abs
-                                                              e (type) (error e)
-                                                            )
-                                                          ]
+                                                          [ fail (con unit ()) ]
                                                         )
                                                       ]
                                                       (all dead (type) dead)
@@ -1200,9 +1164,7 @@
                                               (abs
                                                 dead
                                                 (type)
-                                                [
-                                                  fail (abs e (type) (error e))
-                                                ]
+                                                [ fail (con unit ()) ]
                                               )
                                             ]
                                             (abs dead (type) GT)
@@ -1264,21 +1226,13 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     ]
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   ]
                                                   (all dead (type) dead)
@@ -1287,9 +1241,7 @@
                                             )
                                           ]
                                           (abs
-                                            dead
-                                            (type)
-                                            [ fail (abs e (type) (error e)) ]
+                                            dead (type) [ fail (con unit ()) ]
                                           )
                                         ]
                                         (abs dead (type) GT)
@@ -1306,10 +1258,10 @@
                         )
                         (termbind
                           (strict)
-                          (vardecl fail (fun (all a (type) a) Ordering))
+                          (vardecl fail (fun (con unit) Ordering))
                           (lam
                             ds
-                            (all a (type) a)
+                            (con unit)
                             {
                               [
                                 [
@@ -1382,24 +1334,14 @@
                                                             dead
                                                             (type)
                                                             [
-                                                              fail
-                                                              (abs
-                                                                e
-                                                                (type)
-                                                                (error e)
-                                                              )
+                                                              fail (con unit ())
                                                             ]
                                                           )
                                                         ]
                                                         (abs
                                                           dead
                                                           (type)
-                                                          [
-                                                            fail
-                                                            (abs
-                                                              e (type) (error e)
-                                                            )
-                                                          ]
+                                                          [ fail (con unit ()) ]
                                                         )
                                                       ]
                                                       (all dead (type) dead)
@@ -1410,9 +1352,7 @@
                                               (abs
                                                 dead
                                                 (type)
-                                                [
-                                                  fail (abs e (type) (error e))
-                                                ]
+                                                [ fail (con unit ()) ]
                                               )
                                             ]
                                             (abs dead (type) GT)
@@ -1474,21 +1414,13 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     ]
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   ]
                                                   (all dead (type) dead)
@@ -1497,9 +1429,7 @@
                                             )
                                           ]
                                           (abs
-                                            dead
-                                            (type)
-                                            [ fail (abs e (type) (error e)) ]
+                                            dead (type) [ fail (con unit ()) ]
                                           )
                                         ]
                                         (abs dead (type) GT)
@@ -1516,10 +1446,10 @@
                         )
                         (termbind
                           (strict)
-                          (vardecl fail (fun (all a (type) a) Ordering))
+                          (vardecl fail (fun (con unit) Ordering))
                           (lam
                             ds
-                            (all a (type) a)
+                            (con unit)
                             {
                               [
                                 [
@@ -1592,24 +1522,14 @@
                                                             dead
                                                             (type)
                                                             [
-                                                              fail
-                                                              (abs
-                                                                e
-                                                                (type)
-                                                                (error e)
-                                                              )
+                                                              fail (con unit ())
                                                             ]
                                                           )
                                                         ]
                                                         (abs
                                                           dead
                                                           (type)
-                                                          [
-                                                            fail
-                                                            (abs
-                                                              e (type) (error e)
-                                                            )
-                                                          ]
+                                                          [ fail (con unit ()) ]
                                                         )
                                                       ]
                                                       (all dead (type) dead)
@@ -1620,9 +1540,7 @@
                                               (abs
                                                 dead
                                                 (type)
-                                                [
-                                                  fail (abs e (type) (error e))
-                                                ]
+                                                [ fail (con unit ()) ]
                                               )
                                             ]
                                             (abs dead (type) GT)
@@ -1684,21 +1602,13 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     ]
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   ]
                                                   (all dead (type) dead)
@@ -1707,9 +1617,7 @@
                                             )
                                           ]
                                           (abs
-                                            dead
-                                            (type)
-                                            [ fail (abs e (type) (error e)) ]
+                                            dead (type) [ fail (con unit ()) ]
                                           )
                                         ]
                                         (abs dead (type) GT)
@@ -1772,12 +1680,7 @@
                                                             dead
                                                             (type)
                                                             [
-                                                              fail
-                                                              (abs
-                                                                e
-                                                                (type)
-                                                                (error e)
-                                                              )
+                                                              fail (con unit ())
                                                             ]
                                                           )
                                                         )
@@ -1785,12 +1688,7 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     ]
                                                     (abs
@@ -1822,10 +1720,8 @@
                                                                   (type)
                                                                   [
                                                                     fail
-                                                                    (abs
-                                                                      e
-                                                                      (type)
-                                                                      (error e)
+                                                                    (con
+                                                                      unit ()
                                                                     )
                                                                   ]
                                                                 )
@@ -1836,11 +1732,7 @@
                                                               (type)
                                                               [
                                                                 fail
-                                                                (abs
-                                                                  e
-                                                                  (type)
-                                                                  (error e)
-                                                                )
+                                                                (con unit ())
                                                               ]
                                                             )
                                                           ]
@@ -1874,20 +1766,14 @@
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   )
                                                 ]
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               ]
                                               (abs
@@ -1913,12 +1799,7 @@
                                                             dead
                                                             (type)
                                                             [
-                                                              fail
-                                                              (abs
-                                                                e
-                                                                (type)
-                                                                (error e)
-                                                              )
+                                                              fail (con unit ())
                                                             ]
                                                           )
                                                         )
@@ -1926,12 +1807,7 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     ]
                                                     (abs dead (type) EQ)
@@ -2003,20 +1879,14 @@
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   )
                                                 ]
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               ]
                                               (abs
@@ -2042,12 +1912,7 @@
                                                             dead
                                                             (type)
                                                             [
-                                                              fail
-                                                              (abs
-                                                                e
-                                                                (type)
-                                                                (error e)
-                                                              )
+                                                              fail (con unit ())
                                                             ]
                                                           )
                                                         )
@@ -2055,12 +1920,7 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     ]
                                                     (abs dead (type) EQ)
@@ -2093,16 +1953,12 @@
                                               (abs
                                                 dead
                                                 (type)
-                                                [
-                                                  fail (abs e (type) (error e))
-                                                ]
+                                                [ fail (con unit ()) ]
                                               )
                                             )
                                           ]
                                           (abs
-                                            dead
-                                            (type)
-                                            [ fail (abs e (type) (error e)) ]
+                                            dead (type) [ fail (con unit ()) ]
                                           )
                                         ]
                                         (abs
@@ -2122,20 +1978,14 @@
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   )
                                                 ]
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               ]
                                               (abs dead (type) EQ)
@@ -6738,41 +6588,8 @@
                                 }
                               ]
                             )
-                            (datatypebind
-                              (datatype
-                                (tyvardecl DCert (type))
-
-                                DCert_match
-                                (vardecl
-                                  DCertDelegDeRegKey
-                                  (fun StakingCredential DCert)
-                                )
-                                (vardecl
-                                  DCertDelegDelegate
-                                  (fun
-                                    StakingCredential
-                                    (fun (con bytestring) DCert)
-                                  )
-                                )
-                                (vardecl
-                                  DCertDelegRegKey (fun StakingCredential DCert)
-                                )
-                                (vardecl DCertGenesis DCert)
-                                (vardecl DCertMir DCert)
-                                (vardecl
-                                  DCertPoolRegister
-                                  (fun
-                                    (con bytestring)
-                                    (fun (con bytestring) DCert)
-                                  )
-                                )
-                                (vardecl
-                                  DCertPoolRetire
-                                  (fun
-                                    (con bytestring) (fun (con integer) DCert)
-                                  )
-                                )
-                              )
+                            (typebind
+                              (tyvardecl DCert (type)) (all a (type) (fun a a))
                             )
                             (datatypebind
                               (datatype
@@ -14227,144 +14044,114 @@
                                     (lam
                                       ww
                                       ScriptPurpose
-                                      {
+                                      [
                                         [
                                           [
                                             [
-                                              [
-                                                {
-                                                  [ ScriptPurpose_match ww ]
-                                                  (all
-                                                    dead
-                                                    (type)
-                                                    [ Maybe TxInInfo ]
-                                                  )
-                                                }
-                                                (lam
-                                                  default_arg0
-                                                  DCert
-                                                  (abs
-                                                    dead
-                                                    (type)
-                                                    { Nothing TxInInfo }
-                                                  )
-                                                )
-                                              ]
+                                              {
+                                                [ ScriptPurpose_match ww ]
+                                                [ Maybe TxInInfo ]
+                                              }
                                               (lam
                                                 default_arg0
-                                                (con bytestring)
-                                                (abs
-                                                  dead
-                                                  (type)
-                                                  { Nothing TxInInfo }
-                                                )
+                                                DCert
+                                                { Nothing TxInInfo }
                                               )
                                             ]
                                             (lam
                                               default_arg0
-                                              StakingCredential
-                                              (abs
-                                                dead (type) { Nothing TxInInfo }
-                                              )
+                                              (con bytestring)
+                                              { Nothing TxInInfo }
                                             )
                                           ]
                                           (lam
-                                            txOutRef
-                                            TxOutRef
-                                            (abs
-                                              dead
-                                              (type)
-                                              [
-                                                [
-                                                  [
-                                                    {
-                                                      {
-                                                        fFoldableNil_cfoldMap
-                                                        [
-                                                          (lam
-                                                            a (type) [ Maybe a ]
-                                                          )
-                                                          TxInInfo
-                                                        ]
-                                                      }
-                                                      TxInInfo
-                                                    }
-                                                    { fMonoidFirst TxInInfo }
-                                                  ]
-                                                  (lam
-                                                    x
-                                                    TxInInfo
-                                                    [
-                                                      {
-                                                        [ TxInInfo_match x ]
-                                                        [ Maybe TxInInfo ]
-                                                      }
-                                                      (lam
-                                                        ds
-                                                        TxOutRef
-                                                        (lam
-                                                          ds
-                                                          TxOut
-                                                          {
-                                                            [
-                                                              [
-                                                                {
-                                                                  [
-                                                                    Bool_match
-                                                                    [
-                                                                      [
-                                                                        fEqTxOutRef_c
-                                                                        ds
-                                                                      ]
-                                                                      txOutRef
-                                                                    ]
-                                                                  ]
-                                                                  (all
-                                                                    dead
-                                                                    (type)
-                                                                    [
-                                                                      Maybe
-                                                                      TxInInfo
-                                                                    ]
-                                                                  )
-                                                                }
-                                                                (abs
-                                                                  dead
-                                                                  (type)
-                                                                  [
-                                                                    {
-                                                                      Just
-                                                                      TxInInfo
-                                                                    }
-                                                                    x
-                                                                  ]
-                                                                )
-                                                              ]
-                                                              (abs
-                                                                dead
-                                                                (type)
-                                                                {
-                                                                  Nothing
-                                                                  TxInInfo
-                                                                }
-                                                              )
-                                                            ]
-                                                            (all
-                                                              dead (type) dead
-                                                            )
-                                                          }
-                                                        )
-                                                      )
-                                                    ]
-                                                  )
-                                                ]
-                                                ww
-                                              ]
-                                            )
+                                            default_arg0
+                                            StakingCredential
+                                            { Nothing TxInInfo }
                                           )
                                         ]
-                                        (all dead (type) dead)
-                                      }
+                                        (lam
+                                          txOutRef
+                                          TxOutRef
+                                          [
+                                            [
+                                              [
+                                                {
+                                                  {
+                                                    fFoldableNil_cfoldMap
+                                                    [
+                                                      (lam a (type) [ Maybe a ])
+                                                      TxInInfo
+                                                    ]
+                                                  }
+                                                  TxInInfo
+                                                }
+                                                { fMonoidFirst TxInInfo }
+                                              ]
+                                              (lam
+                                                x
+                                                TxInInfo
+                                                [
+                                                  {
+                                                    [ TxInInfo_match x ]
+                                                    [ Maybe TxInInfo ]
+                                                  }
+                                                  (lam
+                                                    ds
+                                                    TxOutRef
+                                                    (lam
+                                                      ds
+                                                      TxOut
+                                                      {
+                                                        [
+                                                          [
+                                                            {
+                                                              [
+                                                                Bool_match
+                                                                [
+                                                                  [
+                                                                    fEqTxOutRef_c
+                                                                    ds
+                                                                  ]
+                                                                  txOutRef
+                                                                ]
+                                                              ]
+                                                              (all
+                                                                dead
+                                                                (type)
+                                                                [
+                                                                  Maybe TxInInfo
+                                                                ]
+                                                              )
+                                                            }
+                                                            (abs
+                                                              dead
+                                                              (type)
+                                                              [
+                                                                {
+                                                                  Just TxInInfo
+                                                                }
+                                                                x
+                                                              ]
+                                                            )
+                                                          ]
+                                                          (abs
+                                                            dead
+                                                            (type)
+                                                            { Nothing TxInInfo }
+                                                          )
+                                                        ]
+                                                        (all dead (type) dead)
+                                                      }
+                                                    )
+                                                  )
+                                                ]
+                                              )
+                                            ]
+                                            ww
+                                          ]
+                                        )
+                                      ]
                                     )
                                   )
                                 )
@@ -16782,12 +16569,9 @@
                                                                                                           )
                                                                                                           [
                                                                                                             fail
-                                                                                                            (abs
-                                                                                                              e
-                                                                                                              (type)
-                                                                                                              (error
-                                                                                                                e
-                                                                                                              )
+                                                                                                            (con
+                                                                                                              unit
+                                                                                                              ()
                                                                                                             )
                                                                                                           ]
                                                                                                         )
@@ -16859,12 +16643,9 @@
                                                                                                               (type)
                                                                                                               [
                                                                                                                 fail
-                                                                                                                (abs
-                                                                                                                  e
-                                                                                                                  (type)
-                                                                                                                  (error
-                                                                                                                    e
-                                                                                                                  )
+                                                                                                                (con
+                                                                                                                  unit
+                                                                                                                  ()
                                                                                                                 )
                                                                                                               ]
                                                                                                             )
@@ -16895,12 +16676,9 @@
                                                                             (type)
                                                                             [
                                                                               fail
-                                                                              (abs
-                                                                                e
-                                                                                (type)
-                                                                                (error
-                                                                                  e
-                                                                                )
+                                                                              (con
+                                                                                unit
+                                                                                ()
                                                                               )
                                                                             ]
                                                                           )

--- a/plutus-use-cases/test/Spec/governance.pir
+++ b/plutus-use-cases/test/Spec/governance.pir
@@ -166,38 +166,9 @@
                 (con unit)
                 [
                   { error [ [ Tuple2 (con bytestring) ] (con bytestring) ] }
-                  [
-                    {
-                      [
-                        Unit_match
-                        [ [ { (builtin trace) Unit } (con string "Lg") ] Unit ]
-                      ]
-                      (con unit)
-                    }
-                    (con unit ())
-                  ]
+                  [ { [ Unit_match Unit ] (con unit) } (con unit ()) ]
                 ]
               )
-            )
-            (termbind
-              (nonstrict)
-              (vardecl j Bool)
-              [ [ { (builtin trace) Bool } (con string "Ld") ] False ]
-            )
-            (termbind
-              (nonstrict)
-              (vardecl j Bool)
-              [ [ { (builtin trace) Bool } (con string "L7") ] False ]
-            )
-            (termbind
-              (nonstrict)
-              (vardecl j Bool)
-              [ [ { (builtin trace) Bool } (con string "La") ] False ]
-            )
-            (termbind
-              (nonstrict)
-              (vardecl j Bool)
-              [ [ { (builtin trace) Bool } (con string "Lc") ] False ]
             )
             (termbind
               (strict)
@@ -7169,21 +7140,7 @@
                                                                                         (abs
                                                                                           dead
                                                                                           (type)
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                (builtin
-                                                                                                  trace
-                                                                                                )
-                                                                                                Bool
-                                                                                              }
-                                                                                              (con
-                                                                                                string
-                                                                                                "L4"
-                                                                                              )
-                                                                                            ]
-                                                                                            False
-                                                                                          ]
+                                                                                          False
                                                                                         )
                                                                                       ]
                                                                                       (all
@@ -7789,7 +7746,7 @@
                                                                                                   (abs
                                                                                                     dead
                                                                                                     (type)
-                                                                                                    j
+                                                                                                    False
                                                                                                   )
                                                                                                 ]
                                                                                                 (all
@@ -7804,7 +7761,7 @@
                                                                                         (abs
                                                                                           dead
                                                                                           (type)
-                                                                                          j
+                                                                                          False
                                                                                         )
                                                                                       ]
                                                                                       (all
@@ -8162,21 +8119,7 @@
                                                                                     (abs
                                                                                       dead
                                                                                       (type)
-                                                                                      [
-                                                                                        [
-                                                                                          {
-                                                                                            (builtin
-                                                                                              trace
-                                                                                            )
-                                                                                            Bool
-                                                                                          }
-                                                                                          (con
-                                                                                            string
-                                                                                            "L2"
-                                                                                          )
-                                                                                        ]
-                                                                                        False
-                                                                                      ]
+                                                                                      False
                                                                                     )
                                                                                   ]
                                                                                   (all
@@ -8464,21 +8407,7 @@
                                                                   (abs
                                                                     dead
                                                                     (type)
-                                                                    [
-                                                                      [
-                                                                        {
-                                                                          (builtin
-                                                                            trace
-                                                                          )
-                                                                          Bool
-                                                                        }
-                                                                        (con
-                                                                          string
-                                                                          "L9"
-                                                                        )
-                                                                      ]
-                                                                      False
-                                                                    ]
+                                                                    False
                                                                   )
                                                                 ]
                                                                 (all
@@ -9466,21 +9395,7 @@
                                                                                     (abs
                                                                                       dead
                                                                                       (type)
-                                                                                      [
-                                                                                        [
-                                                                                          {
-                                                                                            (builtin
-                                                                                              trace
-                                                                                            )
-                                                                                            Bool
-                                                                                          }
-                                                                                          (con
-                                                                                            string
-                                                                                            "Lb"
-                                                                                          )
-                                                                                        ]
-                                                                                        False
-                                                                                      ]
+                                                                                      False
                                                                                     )
                                                                                   ]
                                                                                   (all
@@ -11099,7 +11014,7 @@
                                                                                             (abs
                                                                                               dead
                                                                                               (type)
-                                                                                              j
+                                                                                              False
                                                                                             )
                                                                                           ]
                                                                                           (all
@@ -11122,7 +11037,9 @@
                                                                 )
                                                               ]
                                                               (abs
-                                                                dead (type) j
+                                                                dead
+                                                                (type)
+                                                                False
                                                               )
                                                             ]
                                                             (all
@@ -11642,20 +11559,7 @@
                                                         }
                                                         (abs dead (type) True)
                                                       ]
-                                                      (abs
-                                                        dead
-                                                        (type)
-                                                        [
-                                                          [
-                                                            {
-                                                              (builtin trace)
-                                                              Bool
-                                                            }
-                                                            (con string "L6")
-                                                          ]
-                                                          False
-                                                        ]
-                                                      )
+                                                      (abs dead (type) False)
                                                     ]
                                                     (all dead (type) dead)
                                                   }
@@ -11742,19 +11646,7 @@
                                                       }
                                                       (abs dead (type) True)
                                                     ]
-                                                    (abs
-                                                      dead
-                                                      (type)
-                                                      [
-                                                        [
-                                                          {
-                                                            (builtin trace) Bool
-                                                          }
-                                                          (con string "Ld")
-                                                        ]
-                                                        False
-                                                      ]
-                                                    )
+                                                    (abs dead (type) False)
                                                   ]
                                                   (all dead (type) dead)
                                                 }
@@ -12328,17 +12220,7 @@
                                                     }
                                                     (abs dead (type) True)
                                                   ]
-                                                  (abs
-                                                    dead
-                                                    (type)
-                                                    [
-                                                      [
-                                                        { (builtin trace) Bool }
-                                                        (con string "L5")
-                                                      ]
-                                                      False
-                                                    ]
-                                                  )
+                                                  (abs dead (type) False)
                                                 ]
                                                 (all dead (type) dead)
                                               }
@@ -12721,7 +12603,7 @@
                                                                                                   (abs
                                                                                                     dead
                                                                                                     (type)
-                                                                                                    j
+                                                                                                    False
                                                                                                   )
                                                                                                 )
                                                                                               ]
@@ -12750,7 +12632,7 @@
                                                                       (abs
                                                                         dead
                                                                         (type)
-                                                                        j
+                                                                        False
                                                                       )
                                                                     ]
                                                                     (all
@@ -13044,21 +12926,7 @@
                                                                       (abs
                                                                         dead
                                                                         (type)
-                                                                        [
-                                                                          [
-                                                                            {
-                                                                              (builtin
-                                                                                trace
-                                                                              )
-                                                                              Bool
-                                                                            }
-                                                                            (con
-                                                                              string
-                                                                              "L8"
-                                                                            )
-                                                                          ]
-                                                                          False
-                                                                        ]
+                                                                        False
                                                                       )
                                                                     ]
                                                                     (all
@@ -13955,21 +13823,7 @@
                                                                                           (abs
                                                                                             dead
                                                                                             (type)
-                                                                                            [
-                                                                                              [
-                                                                                                {
-                                                                                                  (builtin
-                                                                                                    trace
-                                                                                                  )
-                                                                                                  Bool
-                                                                                                }
-                                                                                                (con
-                                                                                                  string
-                                                                                                  "L3"
-                                                                                                )
-                                                                                              ]
-                                                                                              False
-                                                                                            ]
+                                                                                            False
                                                                                           )
                                                                                         ]
                                                                                         (all
@@ -14683,21 +14537,7 @@
                                                                                                               (abs
                                                                                                                 dead
                                                                                                                 (type)
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    {
-                                                                                                                      (builtin
-                                                                                                                        trace
-                                                                                                                      )
-                                                                                                                      Bool
-                                                                                                                    }
-                                                                                                                    (con
-                                                                                                                      string
-                                                                                                                      "L0"
-                                                                                                                    )
-                                                                                                                  ]
-                                                                                                                  False
-                                                                                                                ]
+                                                                                                                False
                                                                                                               )
                                                                                                             ]
                                                                                                             (all
@@ -15906,21 +15746,7 @@
                                                                                                                                             {
                                                                                                                                               [
                                                                                                                                                 Unit_match
-                                                                                                                                                [
-                                                                                                                                                  [
-                                                                                                                                                    {
-                                                                                                                                                      (builtin
-                                                                                                                                                        trace
-                                                                                                                                                      )
-                                                                                                                                                      Unit
-                                                                                                                                                    }
-                                                                                                                                                    (con
-                                                                                                                                                      string
-                                                                                                                                                      "Lf"
-                                                                                                                                                    )
-                                                                                                                                                  ]
-                                                                                                                                                  Unit
-                                                                                                                                                ]
+                                                                                                                                                Unit
                                                                                                                                               ]
                                                                                                                                               (con
                                                                                                                                                 unit
@@ -15957,21 +15783,7 @@
                                                                                                                           (abs
                                                                                                                             dead
                                                                                                                             (type)
-                                                                                                                            [
-                                                                                                                              [
-                                                                                                                                {
-                                                                                                                                  (builtin
-                                                                                                                                    trace
-                                                                                                                                  )
-                                                                                                                                  Bool
-                                                                                                                                }
-                                                                                                                                (con
-                                                                                                                                  string
-                                                                                                                                  "L1"
-                                                                                                                                )
-                                                                                                                              ]
-                                                                                                                              False
-                                                                                                                            ]
+                                                                                                                            False
                                                                                                                           )
                                                                                                                         ]
                                                                                                                         (all
@@ -16020,7 +15832,7 @@
                                                                     (abs
                                                                       dead
                                                                       (type)
-                                                                      j
+                                                                      False
                                                                     )
                                                                   ]
                                                                   (all
@@ -16031,13 +15843,15 @@
                                                                 }
                                                               )
                                                             ]
-                                                            (abs dead (type) j)
+                                                            (abs
+                                                              dead (type) False
+                                                            )
                                                           ]
                                                           (all dead (type) dead)
                                                         }
                                                       )
                                                     ]
-                                                    (abs dead (type) j)
+                                                    (abs dead (type) False)
                                                   ]
                                                   (all dead (type) dead)
                                                 }
@@ -25894,21 +25708,7 @@
                                                                                                             {
                                                                                                               [
                                                                                                                 Unit_match
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    {
-                                                                                                                      (builtin
-                                                                                                                        trace
-                                                                                                                      )
-                                                                                                                      Unit
-                                                                                                                    }
-                                                                                                                    (con
-                                                                                                                      string
-                                                                                                                      "S0"
-                                                                                                                    )
-                                                                                                                  ]
-                                                                                                                  Unit
-                                                                                                                ]
+                                                                                                                Unit
                                                                                                               ]
                                                                                                               (con
                                                                                                                 unit
@@ -26177,21 +25977,7 @@
                                                                                                     (abs
                                                                                                       dead
                                                                                                       (type)
-                                                                                                      [
-                                                                                                        [
-                                                                                                          {
-                                                                                                            (builtin
-                                                                                                              trace
-                                                                                                            )
-                                                                                                            Bool
-                                                                                                          }
-                                                                                                          (con
-                                                                                                            string
-                                                                                                            "S4"
-                                                                                                          )
-                                                                                                        ]
-                                                                                                        False
-                                                                                                      ]
+                                                                                                      False
                                                                                                     )
                                                                                                   ]
                                                                                                   (all
@@ -26634,21 +26420,7 @@
                                                                                                                   {
                                                                                                                     [
                                                                                                                       Bool_match
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            (builtin
-                                                                                                                              trace
-                                                                                                                            )
-                                                                                                                            Bool
-                                                                                                                          }
-                                                                                                                          (con
-                                                                                                                            string
-                                                                                                                            "S3"
-                                                                                                                          )
-                                                                                                                        ]
-                                                                                                                        False
-                                                                                                                      ]
+                                                                                                                      False
                                                                                                                     ]
                                                                                                                     (all
                                                                                                                       dead
@@ -27224,21 +26996,7 @@
                                                                                                                 (abs
                                                                                                                   dead
                                                                                                                   (type)
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      {
-                                                                                                                        (builtin
-                                                                                                                          trace
-                                                                                                                        )
-                                                                                                                        Bool
-                                                                                                                      }
-                                                                                                                      (con
-                                                                                                                        string
-                                                                                                                        "S5"
-                                                                                                                      )
-                                                                                                                    ]
-                                                                                                                    False
-                                                                                                                  ]
+                                                                                                                  False
                                                                                                                 )
                                                                                                               ]
                                                                                                               (all
@@ -27272,21 +27030,7 @@
                                                                           (abs
                                                                             dead
                                                                             (type)
-                                                                            [
-                                                                              [
-                                                                                {
-                                                                                  (builtin
-                                                                                    trace
-                                                                                  )
-                                                                                  Bool
-                                                                                }
-                                                                                (con
-                                                                                  string
-                                                                                  "S6"
-                                                                                )
-                                                                              ]
-                                                                              False
-                                                                            ]
+                                                                            False
                                                                           )
                                                                         ]
                                                                         (all
@@ -27411,21 +27155,7 @@
                                                                                             {
                                                                                               [
                                                                                                 Bool_match
-                                                                                                [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      (builtin
-                                                                                                        trace
-                                                                                                      )
-                                                                                                      Bool
-                                                                                                    }
-                                                                                                    (con
-                                                                                                      string
-                                                                                                      "S2"
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  False
-                                                                                                ]
+                                                                                                False
                                                                                               ]
                                                                                               (all
                                                                                                 dead
@@ -27513,21 +27243,7 @@
                                                                                 {
                                                                                   [
                                                                                     Bool_match
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          (builtin
-                                                                                            trace
-                                                                                          )
-                                                                                          Bool
-                                                                                        }
-                                                                                        (con
-                                                                                          string
-                                                                                          "S1"
-                                                                                        )
-                                                                                      ]
-                                                                                      False
-                                                                                    ]
+                                                                                    False
                                                                                   ]
                                                                                   (all
                                                                                     dead

--- a/plutus-use-cases/test/Spec/multisigStateMachine.pir
+++ b/plutus-use-cases/test/Spec/multisigStateMachine.pir
@@ -50,6 +50,9 @@
       )
       (let
         (nonrec)
+        (datatypebind
+          (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
+        )
         (termbind
           (strict)
           (vardecl error (all a (type) (fun (con unit) a)))
@@ -63,20 +66,15 @@
             (vardecl Tuple2 (fun a (fun b [ [ Tuple2 a ] b ])))
           )
         )
-        (datatypebind
-          (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
-        )
         (termbind
           (strict)
           (vardecl
             fail
-            (fun
-              (all a (type) a) [ [ Tuple2 (con bytestring) ] (con bytestring) ]
-            )
+            (fun (con unit) [ [ Tuple2 (con bytestring) ] (con bytestring) ])
           )
           (lam
             ds
-            (all a (type) a)
+            (con unit)
             [
               { error [ [ Tuple2 (con bytestring) ] (con bytestring) ] }
               [
@@ -804,8 +802,8 @@
         )
         (termbind
           (strict)
-          (vardecl fail (fun (all a (type) a) Ordering))
-          (lam ds (all a (type) a) (error Ordering))
+          (vardecl fail (fun (con unit) Ordering))
+          (lam ds (con unit) (error Ordering))
         )
         (datatypebind
           (datatype
@@ -918,10 +916,10 @@
                     (nonrec)
                     (termbind
                       (strict)
-                      (vardecl fail (fun (all a (type) a) Ordering))
+                      (vardecl fail (fun (con unit) Ordering))
                       (lam
                         ds
-                        (all a (type) a)
+                        (con unit)
                         {
                           [
                             [
@@ -985,21 +983,13 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     ]
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   ]
                                                   (all dead (type) dead)
@@ -1008,9 +998,7 @@
                                             )
                                           ]
                                           (abs
-                                            dead
-                                            (type)
-                                            [ fail (abs e (type) (error e)) ]
+                                            dead (type) [ fail (con unit ()) ]
                                           )
                                         ]
                                         (abs dead (type) GT)
@@ -1068,19 +1056,13 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               ]
                                               (all dead (type) dead)
@@ -1088,11 +1070,7 @@
                                           )
                                         )
                                       ]
-                                      (abs
-                                        dead
-                                        (type)
-                                        [ fail (abs e (type) (error e)) ]
-                                      )
+                                      (abs dead (type) [ fail (con unit ()) ])
                                     ]
                                     (abs dead (type) GT)
                                   ]
@@ -1108,10 +1086,10 @@
                     )
                     (termbind
                       (strict)
-                      (vardecl fail (fun (all a (type) a) Ordering))
+                      (vardecl fail (fun (con unit) Ordering))
                       (lam
                         ds
-                        (all a (type) a)
+                        (con unit)
                         {
                           [
                             [
@@ -1175,21 +1153,13 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     ]
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   ]
                                                   (all dead (type) dead)
@@ -1198,9 +1168,7 @@
                                             )
                                           ]
                                           (abs
-                                            dead
-                                            (type)
-                                            [ fail (abs e (type) (error e)) ]
+                                            dead (type) [ fail (con unit ()) ]
                                           )
                                         ]
                                         (abs dead (type) GT)
@@ -1258,19 +1226,13 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               ]
                                               (all dead (type) dead)
@@ -1278,11 +1240,7 @@
                                           )
                                         )
                                       ]
-                                      (abs
-                                        dead
-                                        (type)
-                                        [ fail (abs e (type) (error e)) ]
-                                      )
+                                      (abs dead (type) [ fail (con unit ()) ])
                                     ]
                                     (abs dead (type) GT)
                                   ]
@@ -1298,10 +1256,10 @@
                     )
                     (termbind
                       (strict)
-                      (vardecl fail (fun (all a (type) a) Ordering))
+                      (vardecl fail (fun (con unit) Ordering))
                       (lam
                         ds
-                        (all a (type) a)
+                        (con unit)
                         {
                           [
                             [
@@ -1365,21 +1323,13 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     ]
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   ]
                                                   (all dead (type) dead)
@@ -1388,9 +1338,7 @@
                                             )
                                           ]
                                           (abs
-                                            dead
-                                            (type)
-                                            [ fail (abs e (type) (error e)) ]
+                                            dead (type) [ fail (con unit ()) ]
                                           )
                                         ]
                                         (abs dead (type) GT)
@@ -1448,19 +1396,13 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               ]
                                               (all dead (type) dead)
@@ -1468,11 +1410,7 @@
                                           )
                                         )
                                       ]
-                                      (abs
-                                        dead
-                                        (type)
-                                        [ fail (abs e (type) (error e)) ]
-                                      )
+                                      (abs dead (type) [ fail (con unit ()) ])
                                     ]
                                     (abs dead (type) GT)
                                   ]
@@ -1488,10 +1426,10 @@
                     )
                     (termbind
                       (strict)
-                      (vardecl fail (fun (all a (type) a) Ordering))
+                      (vardecl fail (fun (con unit) Ordering))
                       (lam
                         ds
-                        (all a (type) a)
+                        (con unit)
                         {
                           [
                             [
@@ -1555,21 +1493,13 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     ]
                                                     (abs
                                                       dead
                                                       (type)
-                                                      [
-                                                        fail
-                                                        (abs e (type) (error e))
-                                                      ]
+                                                      [ fail (con unit ()) ]
                                                     )
                                                   ]
                                                   (all dead (type) dead)
@@ -1578,9 +1508,7 @@
                                             )
                                           ]
                                           (abs
-                                            dead
-                                            (type)
-                                            [ fail (abs e (type) (error e)) ]
+                                            dead (type) [ fail (con unit ()) ]
                                           )
                                         ]
                                         (abs dead (type) GT)
@@ -1638,19 +1566,13 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               ]
                                               (all dead (type) dead)
@@ -1658,11 +1580,7 @@
                                           )
                                         )
                                       ]
-                                      (abs
-                                        dead
-                                        (type)
-                                        [ fail (abs e (type) (error e)) ]
-                                      )
+                                      (abs dead (type) [ fail (con unit ()) ])
                                     ]
                                     (abs dead (type) GT)
                                   ]
@@ -1720,22 +1638,14 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     )
                                                   ]
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs
@@ -1766,11 +1676,7 @@
                                                               (type)
                                                               [
                                                                 fail
-                                                                (abs
-                                                                  e
-                                                                  (type)
-                                                                  (error e)
-                                                                )
+                                                                (con unit ())
                                                               ]
                                                             )
                                                           )
@@ -1778,12 +1684,7 @@
                                                         (abs
                                                           dead
                                                           (type)
-                                                          [
-                                                            fail
-                                                            (abs
-                                                              e (type) (error e)
-                                                            )
-                                                          ]
+                                                          [ fail (con unit ()) ]
                                                         )
                                                       ]
                                                       (abs dead (type) EQ)
@@ -1816,17 +1717,12 @@
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               )
                                             ]
                                             (abs
-                                              dead
-                                              (type)
-                                              [ fail (abs e (type) (error e)) ]
+                                              dead (type) [ fail (con unit ()) ]
                                             )
                                           ]
                                           (abs
@@ -1848,22 +1744,14 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     )
                                                   ]
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs dead (type) EQ)
@@ -1933,17 +1821,12 @@
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               )
                                             ]
                                             (abs
-                                              dead
-                                              (type)
-                                              [ fail (abs e (type) (error e)) ]
+                                              dead (type) [ fail (con unit ()) ]
                                             )
                                           ]
                                           (abs
@@ -1965,22 +1848,14 @@
                                                       (abs
                                                         dead
                                                         (type)
-                                                        [
-                                                          fail
-                                                          (abs
-                                                            e (type) (error e)
-                                                          )
-                                                        ]
+                                                        [ fail (con unit ()) ]
                                                       )
                                                     )
                                                   ]
                                                   (abs
                                                     dead
                                                     (type)
-                                                    [
-                                                      fail
-                                                      (abs e (type) (error e))
-                                                    ]
+                                                    [ fail (con unit ()) ]
                                                   )
                                                 ]
                                                 (abs dead (type) EQ)
@@ -2011,17 +1886,11 @@
                                           default_arg0
                                           a
                                           (abs
-                                            dead
-                                            (type)
-                                            [ fail (abs e (type) (error e)) ]
+                                            dead (type) [ fail (con unit ()) ]
                                           )
                                         )
                                       ]
-                                      (abs
-                                        dead
-                                        (type)
-                                        [ fail (abs e (type) (error e)) ]
-                                      )
+                                      (abs dead (type) [ fail (con unit ()) ])
                                     ]
                                     (abs
                                       dead
@@ -2040,17 +1909,12 @@
                                                 (abs
                                                   dead
                                                   (type)
-                                                  [
-                                                    fail
-                                                    (abs e (type) (error e))
-                                                  ]
+                                                  [ fail (con unit ()) ]
                                                 )
                                               )
                                             ]
                                             (abs
-                                              dead
-                                              (type)
-                                              [ fail (abs e (type) (error e)) ]
+                                              dead (type) [ fail (con unit ()) ]
                                             )
                                           ]
                                           (abs dead (type) EQ)
@@ -6274,36 +6138,8 @@
                             }
                           ]
                         )
-                        (datatypebind
-                          (datatype
-                            (tyvardecl DCert (type))
-
-                            DCert_match
-                            (vardecl
-                              DCertDelegDeRegKey (fun StakingCredential DCert)
-                            )
-                            (vardecl
-                              DCertDelegDelegate
-                              (fun
-                                StakingCredential (fun (con bytestring) DCert)
-                              )
-                            )
-                            (vardecl
-                              DCertDelegRegKey (fun StakingCredential DCert)
-                            )
-                            (vardecl DCertGenesis DCert)
-                            (vardecl DCertMir DCert)
-                            (vardecl
-                              DCertPoolRegister
-                              (fun
-                                (con bytestring) (fun (con bytestring) DCert)
-                              )
-                            )
-                            (vardecl
-                              DCertPoolRetire
-                              (fun (con bytestring) (fun (con integer) DCert))
-                            )
-                          )
+                        (typebind
+                          (tyvardecl DCert (type)) (all a (type) (fun a a))
                         )
                         (datatypebind
                           (datatype
@@ -13619,127 +13455,108 @@
                                 (lam
                                   ww
                                   ScriptPurpose
-                                  {
+                                  [
                                     [
                                       [
                                         [
-                                          [
-                                            {
-                                              [ ScriptPurpose_match ww ]
-                                              (all
-                                                dead (type) [ Maybe TxInInfo ]
-                                              )
-                                            }
-                                            (lam
-                                              default_arg0
-                                              DCert
-                                              (abs
-                                                dead (type) { Nothing TxInInfo }
-                                              )
-                                            )
-                                          ]
+                                          {
+                                            [ ScriptPurpose_match ww ]
+                                            [ Maybe TxInInfo ]
+                                          }
                                           (lam
                                             default_arg0
-                                            (con bytestring)
-                                            (abs
-                                              dead (type) { Nothing TxInInfo }
-                                            )
+                                            DCert
+                                            { Nothing TxInInfo }
                                           )
                                         ]
                                         (lam
                                           default_arg0
-                                          StakingCredential
-                                          (abs dead (type) { Nothing TxInInfo })
+                                          (con bytestring)
+                                          { Nothing TxInInfo }
                                         )
                                       ]
                                       (lam
-                                        txOutRef
-                                        TxOutRef
-                                        (abs
-                                          dead
-                                          (type)
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  {
-                                                    fFoldableNil_cfoldMap
-                                                    [
-                                                      (lam a (type) [ Maybe a ])
-                                                      TxInInfo
-                                                    ]
-                                                  }
-                                                  TxInInfo
-                                                }
-                                                { fMonoidFirst TxInInfo }
-                                              ]
-                                              (lam
-                                                x
-                                                TxInInfo
-                                                [
-                                                  {
-                                                    [ TxInInfo_match x ]
-                                                    [ Maybe TxInInfo ]
-                                                  }
-                                                  (lam
-                                                    ds
-                                                    TxOutRef
-                                                    (lam
-                                                      ds
-                                                      TxOut
-                                                      {
-                                                        [
-                                                          [
-                                                            {
-                                                              [
-                                                                Bool_match
-                                                                [
-                                                                  [
-                                                                    fEqTxOutRef_c
-                                                                    ds
-                                                                  ]
-                                                                  txOutRef
-                                                                ]
-                                                              ]
-                                                              (all
-                                                                dead
-                                                                (type)
-                                                                [
-                                                                  Maybe TxInInfo
-                                                                ]
-                                                              )
-                                                            }
-                                                            (abs
-                                                              dead
-                                                              (type)
-                                                              [
-                                                                {
-                                                                  Just TxInInfo
-                                                                }
-                                                                x
-                                                              ]
-                                                            )
-                                                          ]
-                                                          (abs
-                                                            dead
-                                                            (type)
-                                                            { Nothing TxInInfo }
-                                                          )
-                                                        ]
-                                                        (all dead (type) dead)
-                                                      }
-                                                    )
-                                                  )
-                                                ]
-                                              )
-                                            ]
-                                            ww
-                                          ]
-                                        )
+                                        default_arg0
+                                        StakingCredential
+                                        { Nothing TxInInfo }
                                       )
                                     ]
-                                    (all dead (type) dead)
-                                  }
+                                    (lam
+                                      txOutRef
+                                      TxOutRef
+                                      [
+                                        [
+                                          [
+                                            {
+                                              {
+                                                fFoldableNil_cfoldMap
+                                                [
+                                                  (lam a (type) [ Maybe a ])
+                                                  TxInInfo
+                                                ]
+                                              }
+                                              TxInInfo
+                                            }
+                                            { fMonoidFirst TxInInfo }
+                                          ]
+                                          (lam
+                                            x
+                                            TxInInfo
+                                            [
+                                              {
+                                                [ TxInInfo_match x ]
+                                                [ Maybe TxInInfo ]
+                                              }
+                                              (lam
+                                                ds
+                                                TxOutRef
+                                                (lam
+                                                  ds
+                                                  TxOut
+                                                  {
+                                                    [
+                                                      [
+                                                        {
+                                                          [
+                                                            Bool_match
+                                                            [
+                                                              [
+                                                                fEqTxOutRef_c ds
+                                                              ]
+                                                              txOutRef
+                                                            ]
+                                                          ]
+                                                          (all
+                                                            dead
+                                                            (type)
+                                                            [ Maybe TxInInfo ]
+                                                          )
+                                                        }
+                                                        (abs
+                                                          dead
+                                                          (type)
+                                                          [
+                                                            { Just TxInInfo } x
+                                                          ]
+                                                        )
+                                                      ]
+                                                      (abs
+                                                        dead
+                                                        (type)
+                                                        { Nothing TxInInfo }
+                                                      )
+                                                    ]
+                                                    (all dead (type) dead)
+                                                  }
+                                                )
+                                              )
+                                            ]
+                                          )
+                                        ]
+                                        ww
+                                      ]
+                                    )
+                                  ]
                                 )
                               )
                             )
@@ -16112,12 +15929,9 @@
                                                                                                       )
                                                                                                       [
                                                                                                         fail
-                                                                                                        (abs
-                                                                                                          e
-                                                                                                          (type)
-                                                                                                          (error
-                                                                                                            e
-                                                                                                          )
+                                                                                                        (con
+                                                                                                          unit
+                                                                                                          ()
                                                                                                         )
                                                                                                       ]
                                                                                                     )
@@ -16189,12 +16003,9 @@
                                                                                                           (type)
                                                                                                           [
                                                                                                             fail
-                                                                                                            (abs
-                                                                                                              e
-                                                                                                              (type)
-                                                                                                              (error
-                                                                                                                e
-                                                                                                              )
+                                                                                                            (con
+                                                                                                              unit
+                                                                                                              ()
                                                                                                             )
                                                                                                           ]
                                                                                                         )
@@ -16225,12 +16036,9 @@
                                                                         (type)
                                                                         [
                                                                           fail
-                                                                          (abs
-                                                                            e
-                                                                            (type)
-                                                                            (error
-                                                                              e
-                                                                            )
+                                                                          (con
+                                                                            unit
+                                                                            ()
                                                                           )
                                                                         ]
                                                                       )

--- a/plutus-use-cases/test/Spec/multisigStateMachine.pir
+++ b/plutus-use-cases/test/Spec/multisigStateMachine.pir
@@ -77,16 +77,7 @@
             (con unit)
             [
               { error [ [ Tuple2 (con bytestring) ] (con bytestring) ] }
-              [
-                {
-                  [
-                    Unit_match
-                    [ [ { (builtin trace) Unit } (con string "Lg") ] Unit ]
-                  ]
-                  (con unit)
-                }
-                (con unit ())
-              ]
+              [ { [ Unit_match Unit ] (con unit) } (con unit ()) ]
             ]
           )
         )
@@ -248,26 +239,6 @@
             Bool_match
             (vardecl True Bool) (vardecl False Bool)
           )
-        )
-        (termbind
-          (nonstrict)
-          (vardecl j Bool)
-          [ [ { (builtin trace) Bool } (con string "Ld") ] False ]
-        )
-        (termbind
-          (nonstrict)
-          (vardecl j Bool)
-          [ [ { (builtin trace) Bool } (con string "L7") ] False ]
-        )
-        (termbind
-          (nonstrict)
-          (vardecl j Bool)
-          [ [ { (builtin trace) Bool } (con string "La") ] False ]
-        )
-        (termbind
-          (nonstrict)
-          (vardecl j Bool)
-          [ [ { (builtin trace) Bool } (con string "Lc") ] False ]
         )
         (termbind
           (strict)
@@ -6701,21 +6672,7 @@
                                                                                     (abs
                                                                                       dead
                                                                                       (type)
-                                                                                      [
-                                                                                        [
-                                                                                          {
-                                                                                            (builtin
-                                                                                              trace
-                                                                                            )
-                                                                                            Bool
-                                                                                          }
-                                                                                          (con
-                                                                                            string
-                                                                                            "L4"
-                                                                                          )
-                                                                                        ]
-                                                                                        False
-                                                                                      ]
+                                                                                      False
                                                                                     )
                                                                                   ]
                                                                                   (all
@@ -7315,7 +7272,7 @@
                                                                                               (abs
                                                                                                 dead
                                                                                                 (type)
-                                                                                                j
+                                                                                                False
                                                                                               )
                                                                                             ]
                                                                                             (all
@@ -7330,7 +7287,7 @@
                                                                                     (abs
                                                                                       dead
                                                                                       (type)
-                                                                                      j
+                                                                                      False
                                                                                     )
                                                                                   ]
                                                                                   (all
@@ -7681,21 +7638,7 @@
                                                                                 (abs
                                                                                   dead
                                                                                   (type)
-                                                                                  [
-                                                                                    [
-                                                                                      {
-                                                                                        (builtin
-                                                                                          trace
-                                                                                        )
-                                                                                        Bool
-                                                                                      }
-                                                                                      (con
-                                                                                        string
-                                                                                        "L2"
-                                                                                      )
-                                                                                    ]
-                                                                                    False
-                                                                                  ]
+                                                                                  False
                                                                                 )
                                                                               ]
                                                                               (all
@@ -7983,21 +7926,7 @@
                                                               (abs
                                                                 dead
                                                                 (type)
-                                                                [
-                                                                  [
-                                                                    {
-                                                                      (builtin
-                                                                        trace
-                                                                      )
-                                                                      Bool
-                                                                    }
-                                                                    (con
-                                                                      string
-                                                                      "L9"
-                                                                    )
-                                                                  ]
-                                                                  False
-                                                                ]
+                                                                False
                                                               )
                                                             ]
                                                             (all
@@ -8970,21 +8899,7 @@
                                                                                 (abs
                                                                                   dead
                                                                                   (type)
-                                                                                  [
-                                                                                    [
-                                                                                      {
-                                                                                        (builtin
-                                                                                          trace
-                                                                                        )
-                                                                                        Bool
-                                                                                      }
-                                                                                      (con
-                                                                                        string
-                                                                                        "Lb"
-                                                                                      )
-                                                                                    ]
-                                                                                    False
-                                                                                  ]
+                                                                                  False
                                                                                 )
                                                                               ]
                                                                               (all
@@ -10594,7 +10509,7 @@
                                                                                         (abs
                                                                                           dead
                                                                                           (type)
-                                                                                          j
+                                                                                          False
                                                                                         )
                                                                                       ]
                                                                                       (all
@@ -10616,7 +10531,9 @@
                                                               ]
                                                             )
                                                           ]
-                                                          (abs dead (type) j)
+                                                          (abs
+                                                            dead (type) False
+                                                          )
                                                         ]
                                                         (all dead (type) dead)
                                                       }
@@ -11124,17 +11041,7 @@
                                                     }
                                                     (abs dead (type) True)
                                                   ]
-                                                  (abs
-                                                    dead
-                                                    (type)
-                                                    [
-                                                      [
-                                                        { (builtin trace) Bool }
-                                                        (con string "L6")
-                                                      ]
-                                                      False
-                                                    ]
-                                                  )
+                                                  (abs dead (type) False)
                                                 ]
                                                 (all dead (type) dead)
                                               }
@@ -11216,17 +11123,7 @@
                                                   }
                                                   (abs dead (type) True)
                                                 ]
-                                                (abs
-                                                  dead
-                                                  (type)
-                                                  [
-                                                    [
-                                                      { (builtin trace) Bool }
-                                                      (con string "Ld")
-                                                    ]
-                                                    False
-                                                  ]
-                                                )
+                                                (abs dead (type) False)
                                               ]
                                               (all dead (type) dead)
                                             }
@@ -11783,17 +11680,7 @@
                                                 }
                                                 (abs dead (type) True)
                                               ]
-                                              (abs
-                                                dead
-                                                (type)
-                                                [
-                                                  [
-                                                    { (builtin trace) Bool }
-                                                    (con string "L5")
-                                                  ]
-                                                  False
-                                                ]
-                                              )
+                                              (abs dead (type) False)
                                             ]
                                             (all dead (type) dead)
                                           }
@@ -12166,7 +12053,7 @@
                                                                                               (abs
                                                                                                 dead
                                                                                                 (type)
-                                                                                                j
+                                                                                                False
                                                                                               )
                                                                                             )
                                                                                           ]
@@ -12195,7 +12082,7 @@
                                                                   (abs
                                                                     dead
                                                                     (type)
-                                                                    j
+                                                                    False
                                                                   )
                                                                 ]
                                                                 (all
@@ -12479,21 +12366,7 @@
                                                                   (abs
                                                                     dead
                                                                     (type)
-                                                                    [
-                                                                      [
-                                                                        {
-                                                                          (builtin
-                                                                            trace
-                                                                          )
-                                                                          Bool
-                                                                        }
-                                                                        (con
-                                                                          string
-                                                                          "L8"
-                                                                        )
-                                                                      ]
-                                                                      False
-                                                                    ]
+                                                                    False
                                                                   )
                                                                 ]
                                                                 (all
@@ -13371,21 +13244,7 @@
                                                                                       (abs
                                                                                         dead
                                                                                         (type)
-                                                                                        [
-                                                                                          [
-                                                                                            {
-                                                                                              (builtin
-                                                                                                trace
-                                                                                              )
-                                                                                              Bool
-                                                                                            }
-                                                                                            (con
-                                                                                              string
-                                                                                              "L3"
-                                                                                            )
-                                                                                          ]
-                                                                                          False
-                                                                                        ]
+                                                                                        False
                                                                                       )
                                                                                     ]
                                                                                     (all
@@ -14076,21 +13935,7 @@
                                                                                                           (abs
                                                                                                             dead
                                                                                                             (type)
-                                                                                                            [
-                                                                                                              [
-                                                                                                                {
-                                                                                                                  (builtin
-                                                                                                                    trace
-                                                                                                                  )
-                                                                                                                  Bool
-                                                                                                                }
-                                                                                                                (con
-                                                                                                                  string
-                                                                                                                  "L0"
-                                                                                                                )
-                                                                                                              ]
-                                                                                                              False
-                                                                                                            ]
+                                                                                                            False
                                                                                                           )
                                                                                                         ]
                                                                                                         (all
@@ -15297,21 +15142,7 @@
                                                                                                                                         {
                                                                                                                                           [
                                                                                                                                             Unit_match
-                                                                                                                                            [
-                                                                                                                                              [
-                                                                                                                                                {
-                                                                                                                                                  (builtin
-                                                                                                                                                    trace
-                                                                                                                                                  )
-                                                                                                                                                  Unit
-                                                                                                                                                }
-                                                                                                                                                (con
-                                                                                                                                                  string
-                                                                                                                                                  "Lf"
-                                                                                                                                                )
-                                                                                                                                              ]
-                                                                                                                                              Unit
-                                                                                                                                            ]
+                                                                                                                                            Unit
                                                                                                                                           ]
                                                                                                                                           (con
                                                                                                                                             unit
@@ -15348,21 +15179,7 @@
                                                                                                                       (abs
                                                                                                                         dead
                                                                                                                         (type)
-                                                                                                                        [
-                                                                                                                          [
-                                                                                                                            {
-                                                                                                                              (builtin
-                                                                                                                                trace
-                                                                                                                              )
-                                                                                                                              Bool
-                                                                                                                            }
-                                                                                                                            (con
-                                                                                                                              string
-                                                                                                                              "L1"
-                                                                                                                            )
-                                                                                                                          ]
-                                                                                                                          False
-                                                                                                                        ]
+                                                                                                                        False
                                                                                                                       )
                                                                                                                     ]
                                                                                                                     (all
@@ -15409,7 +15226,9 @@
                                                                   )
                                                                 ]
                                                                 (abs
-                                                                  dead (type) j
+                                                                  dead
+                                                                  (type)
+                                                                  False
                                                                 )
                                                               ]
                                                               (all
@@ -15418,13 +15237,13 @@
                                                             }
                                                           )
                                                         ]
-                                                        (abs dead (type) j)
+                                                        (abs dead (type) False)
                                                       ]
                                                       (all dead (type) dead)
                                                     }
                                                   )
                                                 ]
-                                                (abs dead (type) j)
+                                                (abs dead (type) False)
                                               ]
                                               (all dead (type) dead)
                                             }
@@ -20249,21 +20068,7 @@
                                                                                                       {
                                                                                                         [
                                                                                                           Unit_match
-                                                                                                          [
-                                                                                                            [
-                                                                                                              {
-                                                                                                                (builtin
-                                                                                                                  trace
-                                                                                                                )
-                                                                                                                Unit
-                                                                                                              }
-                                                                                                              (con
-                                                                                                                string
-                                                                                                                "S0"
-                                                                                                              )
-                                                                                                            ]
-                                                                                                            Unit
-                                                                                                          ]
+                                                                                                          Unit
                                                                                                         ]
                                                                                                         (con
                                                                                                           unit
@@ -20530,21 +20335,7 @@
                                                                                               (abs
                                                                                                 dead
                                                                                                 (type)
-                                                                                                [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      (builtin
-                                                                                                        trace
-                                                                                                      )
-                                                                                                      Bool
-                                                                                                    }
-                                                                                                    (con
-                                                                                                      string
-                                                                                                      "S4"
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  False
-                                                                                                ]
+                                                                                                False
                                                                                               )
                                                                                             ]
                                                                                             (all
@@ -20685,21 +20476,7 @@
                                                                                                             {
                                                                                                               [
                                                                                                                 Bool_match
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    {
-                                                                                                                      (builtin
-                                                                                                                        trace
-                                                                                                                      )
-                                                                                                                      Bool
-                                                                                                                    }
-                                                                                                                    (con
-                                                                                                                      string
-                                                                                                                      "S3"
-                                                                                                                    )
-                                                                                                                  ]
-                                                                                                                  False
-                                                                                                                ]
+                                                                                                                False
                                                                                                               ]
                                                                                                               (all
                                                                                                                 dead
@@ -21253,21 +21030,7 @@
                                                                                                           (abs
                                                                                                             dead
                                                                                                             (type)
-                                                                                                            [
-                                                                                                              [
-                                                                                                                {
-                                                                                                                  (builtin
-                                                                                                                    trace
-                                                                                                                  )
-                                                                                                                  Bool
-                                                                                                                }
-                                                                                                                (con
-                                                                                                                  string
-                                                                                                                  "S5"
-                                                                                                                )
-                                                                                                              ]
-                                                                                                              False
-                                                                                                            ]
+                                                                                                            False
                                                                                                           )
                                                                                                         ]
                                                                                                         (all
@@ -21301,21 +21064,7 @@
                                                                     (abs
                                                                       dead
                                                                       (type)
-                                                                      [
-                                                                        [
-                                                                          {
-                                                                            (builtin
-                                                                              trace
-                                                                            )
-                                                                            Bool
-                                                                          }
-                                                                          (con
-                                                                            string
-                                                                            "S6"
-                                                                          )
-                                                                        ]
-                                                                        False
-                                                                      ]
+                                                                      False
                                                                     )
                                                                   ]
                                                                   (all
@@ -21438,21 +21187,7 @@
                                                                                       {
                                                                                         [
                                                                                           Bool_match
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                (builtin
-                                                                                                  trace
-                                                                                                )
-                                                                                                Bool
-                                                                                              }
-                                                                                              (con
-                                                                                                string
-                                                                                                "S2"
-                                                                                              )
-                                                                                            ]
-                                                                                            False
-                                                                                          ]
+                                                                                          False
                                                                                         ]
                                                                                         (all
                                                                                           dead
@@ -21540,21 +21275,7 @@
                                                                           {
                                                                             [
                                                                               Bool_match
-                                                                              [
-                                                                                [
-                                                                                  {
-                                                                                    (builtin
-                                                                                      trace
-                                                                                    )
-                                                                                    Bool
-                                                                                  }
-                                                                                  (con
-                                                                                    string
-                                                                                    "S1"
-                                                                                  )
-                                                                                ]
-                                                                                False
-                                                                              ]
+                                                                              False
                                                                             ]
                                                                             (all
                                                                               dead

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       c351875a8d5d26a87f1cf365f007f8a543040e9d8d182d608223edd245c5ea9e
+TxId:       47d829d148d9ea933f56866a8fcb665de1eeff287f8551b510cf6c5e600568d4
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: c0a4b02f44c212ba6c1197df5a5cf8bd1a3dceef...
-              Signature: 584035442e9f2f45e13e83bfa814d3a2b31e61b9...
+              Signature: 58400cfa314007c57f14744523aebe5fad5c8521...
 Inputs:
   ---- Input 0 ----
   Destination:  PaymentPubKeyHash: 557d23c0a533b4d295ac2dc14b783a7efc293bc2... (Wallet 5f5a4f5f465580a5500b9a9cede7f4e014a37ea8)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  97499990
 
   ---- Output 1 ----
-  Destination:  Script: 845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b
+  Destination:  Script: aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7
   Value:
     Ada:      Lovelace:  2500000
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b
+  Script: aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7
   Value:
     Ada:      Lovelace:  2500000
 
 ==== Slot #1, Tx #1 ====
-TxId:       2f869889c09e76fb2cbfe2a3a0d512bfc86fe515d0cee53ecea4a79d3e695029
+TxId:       7ac5fbd2b7413f6f126291ad3e72e497d4b4bf4d73e6ca6d231a745fb7e31810
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 4cdc632449cde98d811f78ad2e2d15a278731bc5...
-              Signature: 58404581bd6283b86ac94dec77a04efc37005ca8...
+              Signature: 5840a541810de2d12aa877c901f7721ffd052e23...
 Inputs:
   ---- Input 0 ----
   Destination:  PaymentPubKeyHash: 2e0ad60c3207248cecd47dbde3d752e0aad141d6... (Wallet c30efb78b4e272685c1f9f0c93787fd4b6743154)
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  89999990
 
   ---- Output 1 ----
-  Destination:  Script: 845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b
+  Destination:  Script: aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7
   Value:
     Ada:      Lovelace:  10000000
 
@@ -244,16 +244,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b
+  Script: aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7
   Value:
     Ada:      Lovelace:  12500000
 
 ==== Slot #1, Tx #2 ====
-TxId:       e9628f4a7231fbe76f221ae02309b0d44df8d902154ab1bd93e38a274d52f370
+TxId:       ac172495ff852ef583cac6ef4893c8a4e5ffd41dd490c01b6946b5f7c6a04cbd
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 98c77c40ccc536e0d433874dae97d4a0787b10b3...
-              Signature: 5840a897183b0923b6a3f0cd4a7c1738ee08956b...
+              Signature: 584029c1111e3f71acfe53a316196922b62155d8...
 Inputs:
   ---- Input 0 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
@@ -272,7 +272,7 @@ Outputs:
     Ada:      Lovelace:  89999990
 
   ---- Output 1 ----
-  Destination:  Script: 845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b
+  Destination:  Script: aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7
   Value:
     Ada:      Lovelace:  10000000
 
@@ -318,50 +318,50 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b
+  Script: aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7
   Value:
     Ada:      Lovelace:  22500000
 
 ==== Slot #2, Tx #0 ====
-TxId:       3a20125dbda70ddc4408207505e362966252b6941ec7eb334ca11f11fc96ac35
-Fee:        Ada:      Lovelace:  13666
+TxId:       177585baeaf1fb3c541219d7992fb4ea810397b5594caf37dce6f5396de9fc8b
+Fee:        Ada:      Lovelace:  12691
 Mint:       -
 Signatures  PubKey: 8d9de88fbf445b7f6c3875a14daba94caee2ffcb...
-              Signature: 5840aefbe451909743c6f10af0837cd5e6c61136...
+              Signature: 58400e4911ba9858d73fac1122e457922d7bfce8...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b
-  Value:
-    Ada:      Lovelace:  10000000
-  Source:
-    Tx:     2f869889c09e76fb2cbfe2a3a0d512bfc86fe515d0cee53ecea4a79d3e695029
-    Output #1
-    Script: 590e740100003323332223322332232323332223...
-
-  ---- Input 1 ----
-  Destination:  Script: 845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b
+  Destination:  Script: aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7
   Value:
     Ada:      Lovelace:  2500000
   Source:
-    Tx:     c351875a8d5d26a87f1cf365f007f8a543040e9d8d182d608223edd245c5ea9e
+    Tx:     47d829d148d9ea933f56866a8fcb665de1eeff287f8551b510cf6c5e600568d4
     Output #1
-    Script: 590e740100003323332223322332232323332223...
+    Script: 590db50100003323332223322332232323332223...
 
-  ---- Input 2 ----
-  Destination:  Script: 845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b
+  ---- Input 1 ----
+  Destination:  Script: aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7
   Value:
     Ada:      Lovelace:  10000000
   Source:
-    Tx:     e9628f4a7231fbe76f221ae02309b0d44df8d902154ab1bd93e38a274d52f370
+    Tx:     7ac5fbd2b7413f6f126291ad3e72e497d4b4bf4d73e6ca6d231a745fb7e31810
     Output #1
-    Script: 590e740100003323332223322332232323332223...
+    Script: 590db50100003323332223322332232323332223...
+
+  ---- Input 2 ----
+  Destination:  Script: aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7
+  Value:
+    Ada:      Lovelace:  10000000
+  Source:
+    Tx:     ac172495ff852ef583cac6ef4893c8a4e5ffd41dd490c01b6946b5f7c6a04cbd
+    Output #1
+    Script: 590db50100003323332223322332232323332223...
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  22486334
+    Ada:      Lovelace:  22487309
 
 
 Balances Carried Forward:
@@ -387,7 +387,7 @@ Balances Carried Forward:
 
   PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  122486334
+    Ada:      Lovelace:  122487309
 
   PaymentPubKeyHash: a96a668ed7be83e332c872f51da7925b4472ca98... (Wallet bdf8dbca0cadeb365480c6ec29ec746a2b85274f)
   Value:
@@ -405,6 +405,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 845f884d10feb1d0e664ebcde25320391e85c179e3f53c875583bf3b
+  Script: aeaa4586a3f0d245853690923af202b9bf75cf6220d1aa597a2740d7
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       64f1cb2b215b7776efd0fbfba053243c4abf4e0694170c55e4f5cfafa0e63b01
+TxId:       2aea0beed2c58e28578ec89038e999520b1f4f6af0852a6b8ae0b776622de1ec
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 8d9de88fbf445b7f6c3875a14daba94caee2ffcb...
-              Signature: 58402ad1a11501b69dcb887064b3a589a1b574d2...
+              Signature: 5840af48138e82a9a3490f76bec45aa1bcd6c27c...
 Inputs:
   ---- Input 0 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  91999990
 
   ---- Output 1 ----
-  Destination:  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
+  Destination:  Script: dbf276d7d37bab395414f58befc0353df8a700bffc82020e40acce02
   Value:
     Ada:      Lovelace:  8000000
 
@@ -170,51 +170,51 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
+  Script: dbf276d7d37bab395414f58befc0353df8a700bffc82020e40acce02
   Value:
     Ada:      Lovelace:  8000000
 
 ==== Slot #2, Tx #0 ====
-TxId:       0ce285177e6b60ea014b4b195656fd2865cf9f3f995f4219cbf738776f2aeb31
-Fee:        Ada:      Lovelace:  14012
-Mint:       c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
+TxId:       eed061af9d7748eaa2750fbbab685c0e92277dac3141360bdbc1128fc990c941
+Fee:        Ada:      Lovelace:  14001
+Mint:       0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  guess:    1
 Signatures  PubKey: 8d9de88fbf445b7f6c3875a14daba94caee2ffcb...
-              Signature: 584015f568f4c6a2cdeaae221e2cbdc21c054edc...
+              Signature: 584077c8d482b983127482b70d75531cb421f5f8...
 Inputs:
   ---- Input 0 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
     Ada:      Lovelace:  91999990
   Source:
-    Tx:     64f1cb2b215b7776efd0fbfba053243c4abf4e0694170c55e4f5cfafa0e63b01
+    Tx:     2aea0beed2c58e28578ec89038e999520b1f4f6af0852a6b8ae0b776622de1ec
     Output #0
 
 
   ---- Input 1 ----
-  Destination:  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
+  Destination:  Script: dbf276d7d37bab395414f58befc0353df8a700bffc82020e40acce02
   Value:
     Ada:      Lovelace:  8000000
   Source:
-    Tx:     64f1cb2b215b7776efd0fbfba053243c4abf4e0694170c55e4f5cfafa0e63b01
+    Tx:     2aea0beed2c58e28578ec89038e999520b1f4f6af0852a6b8ae0b776622de1ec
     Output #1
-    Script: 59db500100003323232332233322233322233332...
+    Script: 59db470100003323233223332223332223333222...
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  89985978
-    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  -
+    Ada:      Lovelace:  89985989
+    0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  -
 
   ---- Output 1 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
+    0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  guess:    1
     Ada:      Lovelace:  2000000
 
   ---- Output 2 ----
-  Destination:  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
+  Destination:  Script: dbf276d7d37bab395414f58befc0353df8a700bffc82020e40acce02
   Value:
     Ada:      Lovelace:  8000000
 
@@ -242,8 +242,8 @@ Balances Carried Forward:
 
   PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  91985978
-    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
+    Ada:      Lovelace:  91985989
+    0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  guess:    1
 
   PaymentPubKeyHash: a96a668ed7be83e332c872f51da7925b4472ca98... (Wallet bdf8dbca0cadeb365480c6ec29ec746a2b85274f)
   Value:
@@ -261,34 +261,34 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
+  Script: dbf276d7d37bab395414f58befc0353df8a700bffc82020e40acce02
   Value:
     Ada:      Lovelace:  8000000
 
 ==== Slot #3, Tx #0 ====
-TxId:       a77063fbc61372142a3f446a1cb670599f50d64a38b0e89f3f006393a7d5cb69
+TxId:       a7096a199c560eb0fdd1618d91356780b105f926b9fd6a86e7cad968233b6c89
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 8d9de88fbf445b7f6c3875a14daba94caee2ffcb...
-              Signature: 5840a463ccb939d69d6c529c93b26ff89585c802...
+              Signature: 58406505ceffca2e7568d5639cf3985b57df1956...
 Inputs:
   ---- Input 0 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  89985978
-    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  -
+    Ada:      Lovelace:  89985989
+    0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  -
   Source:
-    Tx:     0ce285177e6b60ea014b4b195656fd2865cf9f3f995f4219cbf738776f2aeb31
+    Tx:     eed061af9d7748eaa2750fbbab685c0e92277dac3141360bdbc1128fc990c941
     Output #0
 
 
   ---- Input 1 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
+    0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  guess:    1
     Ada:      Lovelace:  2000000
   Source:
-    Tx:     0ce285177e6b60ea014b4b195656fd2865cf9f3f995f4219cbf738776f2aeb31
+    Tx:     eed061af9d7748eaa2750fbbab685c0e92277dac3141360bdbc1128fc990c941
     Output #1
 
 
@@ -297,13 +297,13 @@ Outputs:
   ---- Output 0 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  89985968
-    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    0
+    Ada:      Lovelace:  89985979
+    0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  guess:    0
 
   ---- Output 1 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
-    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
+    0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  guess:    1
     Ada:      Lovelace:  2000000
 
 
@@ -319,7 +319,7 @@ Balances Carried Forward:
   PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
     Ada:      Lovelace:  102000000
-    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
+    0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  guess:    1
 
   PaymentPubKeyHash: 8952ed1aff55f5b7674b122804a3c0a96f4e2863... (Wallet 3a4778247ad35117d7c3150d194da389f3148f4a)
   Value:
@@ -331,8 +331,8 @@ Balances Carried Forward:
 
   PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  89985968
-    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    0
+    Ada:      Lovelace:  89985979
+    0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  guess:    0
 
   PaymentPubKeyHash: a96a668ed7be83e332c872f51da7925b4472ca98... (Wallet bdf8dbca0cadeb365480c6ec29ec746a2b85274f)
   Value:
@@ -350,27 +350,18 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
+  Script: dbf276d7d37bab395414f58befc0353df8a700bffc82020e40acce02
   Value:
     Ada:      Lovelace:  8000000
 
 ==== Slot #4, Tx #0 ====
-TxId:       b9fcad42cd77bb6fc50506f0677788607bf0ec6db078d55d09c1ba7699d8ea36
-Fee:        Ada:      Lovelace:  14012
-Mint:       c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    0
+TxId:       bb2d3007dd835f455279bad77796200eb133a7ffe89571606403db11b3901707
+Fee:        Ada:      Lovelace:  14001
+Mint:       0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  guess:    0
 Signatures  PubKey: 98c77c40ccc536e0d433874dae97d4a0787b10b3...
-              Signature: 5840ac93d0f93e1cd282e6a679c9aa7ffc2adf2f...
+              Signature: 58402d161d89bc292e2a5b3e697665d01fe29c8e...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
-  Value:
-    Ada:      Lovelace:  8000000
-  Source:
-    Tx:     0ce285177e6b60ea014b4b195656fd2865cf9f3f995f4219cbf738776f2aeb31
-    Output #2
-    Script: 59db500100003323232332233322233322233332...
-
-  ---- Input 1 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
     Ada:      Lovelace:  100000000
@@ -379,38 +370,47 @@ Inputs:
     Output #2
 
 
-  ---- Input 2 ----
+  ---- Input 1 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
-    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
+    0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  guess:    1
     Ada:      Lovelace:  2000000
   Source:
-    Tx:     a77063fbc61372142a3f446a1cb670599f50d64a38b0e89f3f006393a7d5cb69
+    Tx:     a7096a199c560eb0fdd1618d91356780b105f926b9fd6a86e7cad968233b6c89
     Output #1
 
+
+  ---- Input 2 ----
+  Destination:  Script: dbf276d7d37bab395414f58befc0353df8a700bffc82020e40acce02
+  Value:
+    Ada:      Lovelace:  8000000
+  Source:
+    Tx:     eed061af9d7748eaa2750fbbab685c0e92277dac3141360bdbc1128fc990c941
+    Output #2
+    Script: 59db470100003323233223332223332223333222...
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
-    Ada:      Lovelace:  100985988
-    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    0
+    Ada:      Lovelace:  100985999
+    0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  guess:    0
 
   ---- Output 1 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
-    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  -
+    0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  -
     Ada:      Lovelace:  2000000
 
   ---- Output 2 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
-    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
+    0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  guess:    1
     Ada:      Lovelace:  2000000
 
   ---- Output 3 ----
-  Destination:  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
+  Destination:  Script: dbf276d7d37bab395414f58befc0353df8a700bffc82020e40acce02
   Value:
     Ada:      Lovelace:  5000000
 
@@ -426,8 +426,8 @@ Balances Carried Forward:
 
   PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
-    Ada:      Lovelace:  104985988
-    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
+    Ada:      Lovelace:  104985999
+    0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  guess:    1
 
   PaymentPubKeyHash: 8952ed1aff55f5b7674b122804a3c0a96f4e2863... (Wallet 3a4778247ad35117d7c3150d194da389f3148f4a)
   Value:
@@ -439,8 +439,8 @@ Balances Carried Forward:
 
   PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  89985968
-    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    0
+    Ada:      Lovelace:  89985979
+    0cdaec89b2bb961fe019b87e5733b16a63a216919adea5fd73c9c321:  guess:    0
 
   PaymentPubKeyHash: a96a668ed7be83e332c872f51da7925b4472ca98... (Wallet bdf8dbca0cadeb365480c6ec29ec746a2b85274f)
   Value:
@@ -458,6 +458,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
+  Script: dbf276d7d37bab395414f58befc0353df8a700bffc82020e40acce02
   Value:
     Ada:      Lovelace:  5000000

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       6b753350696782a1b24dfe7ec0549bf1e8d86cd08e5ad4d343ceca646f49f457
+TxId:       64f1cb2b215b7776efd0fbfba053243c4abf4e0694170c55e4f5cfafa0e63b01
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 8d9de88fbf445b7f6c3875a14daba94caee2ffcb...
-              Signature: 5840b6ec0478f7e38365d4c5f842760b7b440b05...
+              Signature: 58402ad1a11501b69dcb887064b3a589a1b574d2...
 Inputs:
   ---- Input 0 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  91999990
 
   ---- Output 1 ----
-  Destination:  Script: 21927cbad33338d4eae6141407bf783b198aa7e55dd9089dc73c8d1d
+  Destination:  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
   Value:
     Ada:      Lovelace:  8000000
 
@@ -170,51 +170,51 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 21927cbad33338d4eae6141407bf783b198aa7e55dd9089dc73c8d1d
+  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
   Value:
     Ada:      Lovelace:  8000000
 
 ==== Slot #2, Tx #0 ====
-TxId:       f02f6bdb4e032c86578adc0c8441b15ccb1033c9cc43cc71d17d689e5d107fd3
-Fee:        Ada:      Lovelace:  14170
-Mint:       9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  guess:    1
+TxId:       0ce285177e6b60ea014b4b195656fd2865cf9f3f995f4219cbf738776f2aeb31
+Fee:        Ada:      Lovelace:  14012
+Mint:       c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
 Signatures  PubKey: 8d9de88fbf445b7f6c3875a14daba94caee2ffcb...
-              Signature: 584010f5e66630e0125bf97d894eb6b84fd0ad11...
+              Signature: 584015f568f4c6a2cdeaae221e2cbdc21c054edc...
 Inputs:
   ---- Input 0 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
     Ada:      Lovelace:  91999990
   Source:
-    Tx:     6b753350696782a1b24dfe7ec0549bf1e8d86cd08e5ad4d343ceca646f49f457
+    Tx:     64f1cb2b215b7776efd0fbfba053243c4abf4e0694170c55e4f5cfafa0e63b01
     Output #0
 
 
   ---- Input 1 ----
-  Destination:  Script: 21927cbad33338d4eae6141407bf783b198aa7e55dd9089dc73c8d1d
+  Destination:  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
   Value:
     Ada:      Lovelace:  8000000
   Source:
-    Tx:     6b753350696782a1b24dfe7ec0549bf1e8d86cd08e5ad4d343ceca646f49f457
+    Tx:     64f1cb2b215b7776efd0fbfba053243c4abf4e0694170c55e4f5cfafa0e63b01
     Output #1
-    Script: 59dba60100003323232332233322233322233332...
+    Script: 59db500100003323232332233322233322233332...
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  89985820
-    9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  -
+    Ada:      Lovelace:  89985978
+    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  -
 
   ---- Output 1 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  guess:    1
+    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
     Ada:      Lovelace:  2000000
 
   ---- Output 2 ----
-  Destination:  Script: 21927cbad33338d4eae6141407bf783b198aa7e55dd9089dc73c8d1d
+  Destination:  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
   Value:
     Ada:      Lovelace:  8000000
 
@@ -242,8 +242,8 @@ Balances Carried Forward:
 
   PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  91985820
-    9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  guess:    1
+    Ada:      Lovelace:  91985978
+    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
 
   PaymentPubKeyHash: a96a668ed7be83e332c872f51da7925b4472ca98... (Wallet bdf8dbca0cadeb365480c6ec29ec746a2b85274f)
   Value:
@@ -261,34 +261,34 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 21927cbad33338d4eae6141407bf783b198aa7e55dd9089dc73c8d1d
+  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
   Value:
     Ada:      Lovelace:  8000000
 
 ==== Slot #3, Tx #0 ====
-TxId:       ee4d350e115107d177d6f66c3ee6f1008474b306f90cc4c5519f654b7f9ce07d
+TxId:       a77063fbc61372142a3f446a1cb670599f50d64a38b0e89f3f006393a7d5cb69
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 8d9de88fbf445b7f6c3875a14daba94caee2ffcb...
-              Signature: 58408db3d868a57af927ff3d5339f3e475ddcffb...
+              Signature: 5840a463ccb939d69d6c529c93b26ff89585c802...
 Inputs:
   ---- Input 0 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  89985820
-    9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  -
+    Ada:      Lovelace:  89985978
+    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  -
   Source:
-    Tx:     f02f6bdb4e032c86578adc0c8441b15ccb1033c9cc43cc71d17d689e5d107fd3
+    Tx:     0ce285177e6b60ea014b4b195656fd2865cf9f3f995f4219cbf738776f2aeb31
     Output #0
 
 
   ---- Input 1 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  guess:    1
+    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
     Ada:      Lovelace:  2000000
   Source:
-    Tx:     f02f6bdb4e032c86578adc0c8441b15ccb1033c9cc43cc71d17d689e5d107fd3
+    Tx:     0ce285177e6b60ea014b4b195656fd2865cf9f3f995f4219cbf738776f2aeb31
     Output #1
 
 
@@ -297,13 +297,13 @@ Outputs:
   ---- Output 0 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  89985810
-    9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  guess:    0
+    Ada:      Lovelace:  89985968
+    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    0
 
   ---- Output 1 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
-    9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  guess:    1
+    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
     Ada:      Lovelace:  2000000
 
 
@@ -319,7 +319,7 @@ Balances Carried Forward:
   PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
     Ada:      Lovelace:  102000000
-    9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  guess:    1
+    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
 
   PaymentPubKeyHash: 8952ed1aff55f5b7674b122804a3c0a96f4e2863... (Wallet 3a4778247ad35117d7c3150d194da389f3148f4a)
   Value:
@@ -331,8 +331,8 @@ Balances Carried Forward:
 
   PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  89985810
-    9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  guess:    0
+    Ada:      Lovelace:  89985968
+    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    0
 
   PaymentPubKeyHash: a96a668ed7be83e332c872f51da7925b4472ca98... (Wallet bdf8dbca0cadeb365480c6ec29ec746a2b85274f)
   Value:
@@ -350,18 +350,27 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 21927cbad33338d4eae6141407bf783b198aa7e55dd9089dc73c8d1d
+  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
   Value:
     Ada:      Lovelace:  8000000
 
 ==== Slot #4, Tx #0 ====
-TxId:       7a084925ff291d944232e98b25a0980c7349ce46f01fed961494a58ff35be4fc
-Fee:        Ada:      Lovelace:  14170
-Mint:       9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  guess:    0
+TxId:       b9fcad42cd77bb6fc50506f0677788607bf0ec6db078d55d09c1ba7699d8ea36
+Fee:        Ada:      Lovelace:  14012
+Mint:       c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    0
 Signatures  PubKey: 98c77c40ccc536e0d433874dae97d4a0787b10b3...
-              Signature: 58406192d4c5813c83877ac9ec0b688e574c41a7...
+              Signature: 5840ac93d0f93e1cd282e6a679c9aa7ffc2adf2f...
 Inputs:
   ---- Input 0 ----
+  Destination:  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
+  Value:
+    Ada:      Lovelace:  8000000
+  Source:
+    Tx:     0ce285177e6b60ea014b4b195656fd2865cf9f3f995f4219cbf738776f2aeb31
+    Output #2
+    Script: 59db500100003323232332233322233322233332...
+
+  ---- Input 1 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
     Ada:      Lovelace:  100000000
@@ -370,47 +379,38 @@ Inputs:
     Output #2
 
 
-  ---- Input 1 ----
+  ---- Input 2 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
-    9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  guess:    1
+    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
     Ada:      Lovelace:  2000000
   Source:
-    Tx:     ee4d350e115107d177d6f66c3ee6f1008474b306f90cc4c5519f654b7f9ce07d
+    Tx:     a77063fbc61372142a3f446a1cb670599f50d64a38b0e89f3f006393a7d5cb69
     Output #1
 
-
-  ---- Input 2 ----
-  Destination:  Script: 21927cbad33338d4eae6141407bf783b198aa7e55dd9089dc73c8d1d
-  Value:
-    Ada:      Lovelace:  8000000
-  Source:
-    Tx:     f02f6bdb4e032c86578adc0c8441b15ccb1033c9cc43cc71d17d689e5d107fd3
-    Output #2
-    Script: 59dba60100003323232332233322233322233332...
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
-    Ada:      Lovelace:  100985830
-    9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  guess:    0
+    Ada:      Lovelace:  100985988
+    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    0
 
   ---- Output 1 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
-    9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  -
+    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  -
     Ada:      Lovelace:  2000000
 
   ---- Output 2 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
-    9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  guess:    1
+    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
     Ada:      Lovelace:  2000000
 
   ---- Output 3 ----
-  Destination:  Script: 21927cbad33338d4eae6141407bf783b198aa7e55dd9089dc73c8d1d
+  Destination:  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
   Value:
     Ada:      Lovelace:  5000000
 
@@ -426,8 +426,8 @@ Balances Carried Forward:
 
   PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
   Value:
-    Ada:      Lovelace:  104985830
-    9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  guess:    1
+    Ada:      Lovelace:  104985988
+    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    1
 
   PaymentPubKeyHash: 8952ed1aff55f5b7674b122804a3c0a96f4e2863... (Wallet 3a4778247ad35117d7c3150d194da389f3148f4a)
   Value:
@@ -439,8 +439,8 @@ Balances Carried Forward:
 
   PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  89985810
-    9b2c45472487bc82ae575fc57a338b1fa4f6a47e536bdd57f864c46c:  guess:    0
+    Ada:      Lovelace:  89985968
+    c6e7d5e74006371612d9447d43f5b5f7f9e67610293cba7bd2578f71:  guess:    0
 
   PaymentPubKeyHash: a96a668ed7be83e332c872f51da7925b4472ca98... (Wallet bdf8dbca0cadeb365480c6ec29ec746a2b85274f)
   Value:
@@ -458,6 +458,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 21927cbad33338d4eae6141407bf783b198aa7e55dd9089dc73c8d1d
+  Script: 4e8ffc4179565156bf2f4692eee4655d96dd345e45c58f4077e810f0
   Value:
     Ada:      Lovelace:  5000000

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       d333a720c1e0789eb8bbe6334b0ba5cd5e21c12b685381f7bf5ef628aed71fe0
+TxId:       ed77a24add5d98be598f5bc36a76277c2067a3881de7f5973edeeb58eb7bd511
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 98c77c40ccc536e0d433874dae97d4a0787b10b3...
-              Signature: 58403205f4a6d3871e102ca23a6c46ede21cce10...
+              Signature: 584004aa5373edf849d8fb268d6818915fa74557...
 Inputs:
   ---- Input 0 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  39999990
 
   ---- Output 1 ----
-  Destination:  Script: c91d87cca7e2740ff193aef701a541087d510e44dfb0453f0fce007d
+  Destination:  Script: 8b12b8ed7365ac093631b0fcc7325f38379b71305c3334c46ae1de8b
   Value:
     Ada:      Lovelace:  60000000
 
@@ -170,35 +170,35 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: c91d87cca7e2740ff193aef701a541087d510e44dfb0453f0fce007d
+  Script: 8b12b8ed7365ac093631b0fcc7325f38379b71305c3334c46ae1de8b
   Value:
     Ada:      Lovelace:  60000000
 
 ==== Slot #2, Tx #0 ====
-TxId:       db67cc9b7b1e5866036da716aa56e2a238d52a68c205906a276cda059691c111
-Fee:        Ada:      Lovelace:  5905
+TxId:       0d83d6882117e6b19f8263db2256917de92f776c3707808309e85ef2d85876fc
+Fee:        Ada:      Lovelace:  5724
 Mint:       -
 Signatures  PubKey: 8d9de88fbf445b7f6c3875a14daba94caee2ffcb...
-              Signature: 584084011514a65a8509af700d2248dd22c9849f...
+              Signature: 584059e94d1bd9680e4e73237091fe07f8d4fde2...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: c91d87cca7e2740ff193aef701a541087d510e44dfb0453f0fce007d
+  Destination:  Script: 8b12b8ed7365ac093631b0fcc7325f38379b71305c3334c46ae1de8b
   Value:
     Ada:      Lovelace:  60000000
   Source:
-    Tx:     d333a720c1e0789eb8bbe6334b0ba5cd5e21c12b685381f7bf5ef628aed71fe0
+    Tx:     ed77a24add5d98be598f5bc36a76277c2067a3881de7f5973edeeb58eb7bd511
     Output #1
-    Script: 5912a10100003323322323233223233322232333...
+    Script: 59124c0100003323322323233223233322232333...
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  9994095
+    Ada:      Lovelace:  9994276
 
   ---- Output 1 ----
-  Destination:  Script: c91d87cca7e2740ff193aef701a541087d510e44dfb0453f0fce007d
+  Destination:  Script: 8b12b8ed7365ac093631b0fcc7325f38379b71305c3334c46ae1de8b
   Value:
     Ada:      Lovelace:  50000000
 
@@ -226,7 +226,7 @@ Balances Carried Forward:
 
   PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
   Value:
-    Ada:      Lovelace:  109994095
+    Ada:      Lovelace:  109994276
 
   PaymentPubKeyHash: a96a668ed7be83e332c872f51da7925b4472ca98... (Wallet bdf8dbca0cadeb365480c6ec29ec746a2b85274f)
   Value:
@@ -244,6 +244,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: c91d87cca7e2740ff193aef701a541087d510e44dfb0453f0fce007d
+  Script: 8b12b8ed7365ac093631b0fcc7325f38379b71305c3334c46ae1de8b
   Value:
     Ada:      Lovelace:  50000000

--- a/plutus-use-cases/test/Spec/vesting.pir
+++ b/plutus-use-cases/test/Spec/vesting.pir
@@ -25,16 +25,7 @@
           (termbind
             (strict)
             (vardecl thunk (con unit))
-            [
-              {
-                [
-                  Unit_match
-                  [ [ { (builtin trace) Unit } (con string "Lg") ] Unit ]
-                ]
-                (con unit)
-              }
-              (con unit ())
-            ]
+            [ { [ Unit_match Unit ] (con unit) } (con unit ()) ]
           )
           (error [ [ Tuple2 (con bytestring) ] (con bytestring) ])
         )

--- a/plutus-use-cases/test/Spec/vesting.pir
+++ b/plutus-use-cases/test/Spec/vesting.pir
@@ -2,6 +2,9 @@
   (let
     (nonrec)
     (datatypebind
+      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
+    )
+    (datatypebind
       (datatype
         (tyvardecl Tuple2 (fun (type) (fun (type) (type))))
         (tyvardecl a (type)) (tyvardecl b (type))
@@ -9,18 +12,14 @@
         (vardecl Tuple2 (fun a (fun b [ [ Tuple2 a ] b ])))
       )
     )
-    (datatypebind
-      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
-    )
     (termbind
       (strict)
       (vardecl
-        fail
-        (fun (all a (type) a) [ [ Tuple2 (con bytestring) ] (con bytestring) ])
+        fail (fun (con unit) [ [ Tuple2 (con bytestring) ] (con bytestring) ])
       )
       (lam
         ds
-        (all a (type) a)
+        (con unit)
         (let
           (nonrec)
           (termbind
@@ -51,8 +50,8 @@
     )
     (termbind
       (strict)
-      (vardecl fail (fun (all a (type) a) Ordering))
-      (lam ds (all a (type) a) (error Ordering))
+      (vardecl fail (fun (con unit) Ordering))
+      (lam ds (con unit) (error Ordering))
     )
     (datatypebind
       (datatype
@@ -3487,21 +3486,15 @@
                                                                     (vardecl
                                                                       fail
                                                                       (fun
-                                                                        (all
-                                                                          a
-                                                                          (type)
-                                                                          a
+                                                                        (con
+                                                                          unit
                                                                         )
                                                                         Ordering
                                                                       )
                                                                     )
                                                                     (lam
                                                                       ds
-                                                                      (all
-                                                                        a
-                                                                        (type)
-                                                                        a
-                                                                      )
+                                                                      (con unit)
                                                                       {
                                                                         [
                                                                           [
@@ -3609,12 +3602,9 @@
                                                                                                       (type)
                                                                                                       [
                                                                                                         fail
-                                                                                                        (abs
-                                                                                                          e
-                                                                                                          (type)
-                                                                                                          (error
-                                                                                                            e
-                                                                                                          )
+                                                                                                        (con
+                                                                                                          unit
+                                                                                                          ()
                                                                                                         )
                                                                                                       ]
                                                                                                     )
@@ -3624,12 +3614,9 @@
                                                                                                     (type)
                                                                                                     [
                                                                                                       fail
-                                                                                                      (abs
-                                                                                                        e
-                                                                                                        (type)
-                                                                                                        (error
-                                                                                                          e
-                                                                                                        )
+                                                                                                      (con
+                                                                                                        unit
+                                                                                                        ()
                                                                                                       )
                                                                                                     ]
                                                                                                   )
@@ -3648,12 +3635,9 @@
                                                                                           (type)
                                                                                           [
                                                                                             fail
-                                                                                            (abs
-                                                                                              e
-                                                                                              (type)
-                                                                                              (error
-                                                                                                e
-                                                                                              )
+                                                                                            (con
+                                                                                              unit
+                                                                                              ()
                                                                                             )
                                                                                           ]
                                                                                         )
@@ -3755,12 +3739,9 @@
                                                                                                   (type)
                                                                                                   [
                                                                                                     fail
-                                                                                                    (abs
-                                                                                                      e
-                                                                                                      (type)
-                                                                                                      (error
-                                                                                                        e
-                                                                                                      )
+                                                                                                    (con
+                                                                                                      unit
+                                                                                                      ()
                                                                                                     )
                                                                                                   ]
                                                                                                 )
@@ -3770,12 +3751,9 @@
                                                                                                 (type)
                                                                                                 [
                                                                                                   fail
-                                                                                                  (abs
-                                                                                                    e
-                                                                                                    (type)
-                                                                                                    (error
-                                                                                                      e
-                                                                                                    )
+                                                                                                  (con
+                                                                                                    unit
+                                                                                                    ()
                                                                                                   )
                                                                                                 ]
                                                                                               )
@@ -3794,12 +3772,9 @@
                                                                                       (type)
                                                                                       [
                                                                                         fail
-                                                                                        (abs
-                                                                                          e
-                                                                                          (type)
-                                                                                          (error
-                                                                                            e
-                                                                                          )
+                                                                                        (con
+                                                                                          unit
+                                                                                          ()
                                                                                         )
                                                                                       ]
                                                                                     )
@@ -3837,21 +3812,15 @@
                                                                     (vardecl
                                                                       fail
                                                                       (fun
-                                                                        (all
-                                                                          a
-                                                                          (type)
-                                                                          a
+                                                                        (con
+                                                                          unit
                                                                         )
                                                                         Ordering
                                                                       )
                                                                     )
                                                                     (lam
                                                                       ds
-                                                                      (all
-                                                                        a
-                                                                        (type)
-                                                                        a
-                                                                      )
+                                                                      (con unit)
                                                                       {
                                                                         [
                                                                           [
@@ -3959,12 +3928,9 @@
                                                                                                       (type)
                                                                                                       [
                                                                                                         fail
-                                                                                                        (abs
-                                                                                                          e
-                                                                                                          (type)
-                                                                                                          (error
-                                                                                                            e
-                                                                                                          )
+                                                                                                        (con
+                                                                                                          unit
+                                                                                                          ()
                                                                                                         )
                                                                                                       ]
                                                                                                     )
@@ -3974,12 +3940,9 @@
                                                                                                     (type)
                                                                                                     [
                                                                                                       fail
-                                                                                                      (abs
-                                                                                                        e
-                                                                                                        (type)
-                                                                                                        (error
-                                                                                                          e
-                                                                                                        )
+                                                                                                      (con
+                                                                                                        unit
+                                                                                                        ()
                                                                                                       )
                                                                                                     ]
                                                                                                   )
@@ -3998,12 +3961,9 @@
                                                                                           (type)
                                                                                           [
                                                                                             fail
-                                                                                            (abs
-                                                                                              e
-                                                                                              (type)
-                                                                                              (error
-                                                                                                e
-                                                                                              )
+                                                                                            (con
+                                                                                              unit
+                                                                                              ()
                                                                                             )
                                                                                           ]
                                                                                         )
@@ -4105,12 +4065,9 @@
                                                                                                   (type)
                                                                                                   [
                                                                                                     fail
-                                                                                                    (abs
-                                                                                                      e
-                                                                                                      (type)
-                                                                                                      (error
-                                                                                                        e
-                                                                                                      )
+                                                                                                    (con
+                                                                                                      unit
+                                                                                                      ()
                                                                                                     )
                                                                                                   ]
                                                                                                 )
@@ -4120,12 +4077,9 @@
                                                                                                 (type)
                                                                                                 [
                                                                                                   fail
-                                                                                                  (abs
-                                                                                                    e
-                                                                                                    (type)
-                                                                                                    (error
-                                                                                                      e
-                                                                                                    )
+                                                                                                  (con
+                                                                                                    unit
+                                                                                                    ()
                                                                                                   )
                                                                                                 ]
                                                                                               )
@@ -4144,12 +4098,9 @@
                                                                                       (type)
                                                                                       [
                                                                                         fail
-                                                                                        (abs
-                                                                                          e
-                                                                                          (type)
-                                                                                          (error
-                                                                                            e
-                                                                                          )
+                                                                                        (con
+                                                                                          unit
+                                                                                          ()
                                                                                         )
                                                                                       ]
                                                                                     )
@@ -4187,21 +4138,15 @@
                                                                     (vardecl
                                                                       fail
                                                                       (fun
-                                                                        (all
-                                                                          a
-                                                                          (type)
-                                                                          a
+                                                                        (con
+                                                                          unit
                                                                         )
                                                                         Ordering
                                                                       )
                                                                     )
                                                                     (lam
                                                                       ds
-                                                                      (all
-                                                                        a
-                                                                        (type)
-                                                                        a
-                                                                      )
+                                                                      (con unit)
                                                                       {
                                                                         [
                                                                           [
@@ -4309,12 +4254,9 @@
                                                                                                       (type)
                                                                                                       [
                                                                                                         fail
-                                                                                                        (abs
-                                                                                                          e
-                                                                                                          (type)
-                                                                                                          (error
-                                                                                                            e
-                                                                                                          )
+                                                                                                        (con
+                                                                                                          unit
+                                                                                                          ()
                                                                                                         )
                                                                                                       ]
                                                                                                     )
@@ -4324,12 +4266,9 @@
                                                                                                     (type)
                                                                                                     [
                                                                                                       fail
-                                                                                                      (abs
-                                                                                                        e
-                                                                                                        (type)
-                                                                                                        (error
-                                                                                                          e
-                                                                                                        )
+                                                                                                      (con
+                                                                                                        unit
+                                                                                                        ()
                                                                                                       )
                                                                                                     ]
                                                                                                   )
@@ -4348,12 +4287,9 @@
                                                                                           (type)
                                                                                           [
                                                                                             fail
-                                                                                            (abs
-                                                                                              e
-                                                                                              (type)
-                                                                                              (error
-                                                                                                e
-                                                                                              )
+                                                                                            (con
+                                                                                              unit
+                                                                                              ()
                                                                                             )
                                                                                           ]
                                                                                         )
@@ -4455,12 +4391,9 @@
                                                                                                   (type)
                                                                                                   [
                                                                                                     fail
-                                                                                                    (abs
-                                                                                                      e
-                                                                                                      (type)
-                                                                                                      (error
-                                                                                                        e
-                                                                                                      )
+                                                                                                    (con
+                                                                                                      unit
+                                                                                                      ()
                                                                                                     )
                                                                                                   ]
                                                                                                 )
@@ -4470,12 +4403,9 @@
                                                                                                 (type)
                                                                                                 [
                                                                                                   fail
-                                                                                                  (abs
-                                                                                                    e
-                                                                                                    (type)
-                                                                                                    (error
-                                                                                                      e
-                                                                                                    )
+                                                                                                  (con
+                                                                                                    unit
+                                                                                                    ()
                                                                                                   )
                                                                                                 ]
                                                                                               )
@@ -4494,12 +4424,9 @@
                                                                                       (type)
                                                                                       [
                                                                                         fail
-                                                                                        (abs
-                                                                                          e
-                                                                                          (type)
-                                                                                          (error
-                                                                                            e
-                                                                                          )
+                                                                                        (con
+                                                                                          unit
+                                                                                          ()
                                                                                         )
                                                                                       ]
                                                                                     )
@@ -4537,21 +4464,15 @@
                                                                     (vardecl
                                                                       fail
                                                                       (fun
-                                                                        (all
-                                                                          a
-                                                                          (type)
-                                                                          a
+                                                                        (con
+                                                                          unit
                                                                         )
                                                                         Ordering
                                                                       )
                                                                     )
                                                                     (lam
                                                                       ds
-                                                                      (all
-                                                                        a
-                                                                        (type)
-                                                                        a
-                                                                      )
+                                                                      (con unit)
                                                                       {
                                                                         [
                                                                           [
@@ -4659,12 +4580,9 @@
                                                                                                       (type)
                                                                                                       [
                                                                                                         fail
-                                                                                                        (abs
-                                                                                                          e
-                                                                                                          (type)
-                                                                                                          (error
-                                                                                                            e
-                                                                                                          )
+                                                                                                        (con
+                                                                                                          unit
+                                                                                                          ()
                                                                                                         )
                                                                                                       ]
                                                                                                     )
@@ -4674,12 +4592,9 @@
                                                                                                     (type)
                                                                                                     [
                                                                                                       fail
-                                                                                                      (abs
-                                                                                                        e
-                                                                                                        (type)
-                                                                                                        (error
-                                                                                                          e
-                                                                                                        )
+                                                                                                      (con
+                                                                                                        unit
+                                                                                                        ()
                                                                                                       )
                                                                                                     ]
                                                                                                   )
@@ -4698,12 +4613,9 @@
                                                                                           (type)
                                                                                           [
                                                                                             fail
-                                                                                            (abs
-                                                                                              e
-                                                                                              (type)
-                                                                                              (error
-                                                                                                e
-                                                                                              )
+                                                                                            (con
+                                                                                              unit
+                                                                                              ()
                                                                                             )
                                                                                           ]
                                                                                         )
@@ -4805,12 +4717,9 @@
                                                                                                   (type)
                                                                                                   [
                                                                                                     fail
-                                                                                                    (abs
-                                                                                                      e
-                                                                                                      (type)
-                                                                                                      (error
-                                                                                                        e
-                                                                                                      )
+                                                                                                    (con
+                                                                                                      unit
+                                                                                                      ()
                                                                                                     )
                                                                                                   ]
                                                                                                 )
@@ -4820,12 +4729,9 @@
                                                                                                 (type)
                                                                                                 [
                                                                                                   fail
-                                                                                                  (abs
-                                                                                                    e
-                                                                                                    (type)
-                                                                                                    (error
-                                                                                                      e
-                                                                                                    )
+                                                                                                  (con
+                                                                                                    unit
+                                                                                                    ()
                                                                                                   )
                                                                                                 ]
                                                                                               )
@@ -4844,12 +4750,9 @@
                                                                                       (type)
                                                                                       [
                                                                                         fail
-                                                                                        (abs
-                                                                                          e
-                                                                                          (type)
-                                                                                          (error
-                                                                                            e
-                                                                                          )
+                                                                                        (con
+                                                                                          unit
+                                                                                          ()
                                                                                         )
                                                                                       ]
                                                                                     )
@@ -4968,12 +4871,9 @@
                                                                                                       (type)
                                                                                                       [
                                                                                                         fail
-                                                                                                        (abs
-                                                                                                          e
-                                                                                                          (type)
-                                                                                                          (error
-                                                                                                            e
-                                                                                                          )
+                                                                                                        (con
+                                                                                                          unit
+                                                                                                          ()
                                                                                                         )
                                                                                                       ]
                                                                                                     )
@@ -4984,12 +4884,9 @@
                                                                                                   (type)
                                                                                                   [
                                                                                                     fail
-                                                                                                    (abs
-                                                                                                      e
-                                                                                                      (type)
-                                                                                                      (error
-                                                                                                        e
-                                                                                                      )
+                                                                                                    (con
+                                                                                                      unit
+                                                                                                      ()
                                                                                                     )
                                                                                                   ]
                                                                                                 )
@@ -5027,12 +4924,9 @@
                                                                                                             (type)
                                                                                                             [
                                                                                                               fail
-                                                                                                              (abs
-                                                                                                                e
-                                                                                                                (type)
-                                                                                                                (error
-                                                                                                                  e
-                                                                                                                )
+                                                                                                              (con
+                                                                                                                unit
+                                                                                                                ()
                                                                                                               )
                                                                                                             ]
                                                                                                           )
@@ -5043,12 +4937,9 @@
                                                                                                         (type)
                                                                                                         [
                                                                                                           fail
-                                                                                                          (abs
-                                                                                                            e
-                                                                                                            (type)
-                                                                                                            (error
-                                                                                                              e
-                                                                                                            )
+                                                                                                          (con
+                                                                                                            unit
+                                                                                                            ()
                                                                                                           )
                                                                                                         ]
                                                                                                       )
@@ -5115,12 +5006,9 @@
                                                                                                 (type)
                                                                                                 [
                                                                                                   fail
-                                                                                                  (abs
-                                                                                                    e
-                                                                                                    (type)
-                                                                                                    (error
-                                                                                                      e
-                                                                                                    )
+                                                                                                  (con
+                                                                                                    unit
+                                                                                                    ()
                                                                                                   )
                                                                                                 ]
                                                                                               )
@@ -5131,12 +5019,9 @@
                                                                                             (type)
                                                                                             [
                                                                                               fail
-                                                                                              (abs
-                                                                                                e
-                                                                                                (type)
-                                                                                                (error
-                                                                                                  e
-                                                                                                )
+                                                                                              (con
+                                                                                                unit
+                                                                                                ()
                                                                                               )
                                                                                             ]
                                                                                           )
@@ -5174,12 +5059,9 @@
                                                                                                       (type)
                                                                                                       [
                                                                                                         fail
-                                                                                                        (abs
-                                                                                                          e
-                                                                                                          (type)
-                                                                                                          (error
-                                                                                                            e
-                                                                                                          )
+                                                                                                        (con
+                                                                                                          unit
+                                                                                                          ()
                                                                                                         )
                                                                                                       ]
                                                                                                     )
@@ -5190,12 +5072,9 @@
                                                                                                   (type)
                                                                                                   [
                                                                                                     fail
-                                                                                                    (abs
-                                                                                                      e
-                                                                                                      (type)
-                                                                                                      (error
-                                                                                                        e
-                                                                                                      )
+                                                                                                    (con
+                                                                                                      unit
+                                                                                                      ()
                                                                                                     )
                                                                                                   ]
                                                                                                 )
@@ -5347,12 +5226,9 @@
                                                                                                 (type)
                                                                                                 [
                                                                                                   fail
-                                                                                                  (abs
-                                                                                                    e
-                                                                                                    (type)
-                                                                                                    (error
-                                                                                                      e
-                                                                                                    )
+                                                                                                  (con
+                                                                                                    unit
+                                                                                                    ()
                                                                                                   )
                                                                                                 ]
                                                                                               )
@@ -5363,12 +5239,9 @@
                                                                                             (type)
                                                                                             [
                                                                                               fail
-                                                                                              (abs
-                                                                                                e
-                                                                                                (type)
-                                                                                                (error
-                                                                                                  e
-                                                                                                )
+                                                                                              (con
+                                                                                                unit
+                                                                                                ()
                                                                                               )
                                                                                             ]
                                                                                           )
@@ -5406,12 +5279,9 @@
                                                                                                       (type)
                                                                                                       [
                                                                                                         fail
-                                                                                                        (abs
-                                                                                                          e
-                                                                                                          (type)
-                                                                                                          (error
-                                                                                                            e
-                                                                                                          )
+                                                                                                        (con
+                                                                                                          unit
+                                                                                                          ()
                                                                                                         )
                                                                                                       ]
                                                                                                     )
@@ -5422,12 +5292,9 @@
                                                                                                   (type)
                                                                                                   [
                                                                                                     fail
-                                                                                                    (abs
-                                                                                                      e
-                                                                                                      (type)
-                                                                                                      (error
-                                                                                                        e
-                                                                                                      )
+                                                                                                    (con
+                                                                                                      unit
+                                                                                                      ()
                                                                                                     )
                                                                                                   ]
                                                                                                 )
@@ -5494,12 +5361,9 @@
                                                                                           (type)
                                                                                           [
                                                                                             fail
-                                                                                            (abs
-                                                                                              e
-                                                                                              (type)
-                                                                                              (error
-                                                                                                e
-                                                                                              )
+                                                                                            (con
+                                                                                              unit
+                                                                                              ()
                                                                                             )
                                                                                           ]
                                                                                         )
@@ -5510,12 +5374,9 @@
                                                                                       (type)
                                                                                       [
                                                                                         fail
-                                                                                        (abs
-                                                                                          e
-                                                                                          (type)
-                                                                                          (error
-                                                                                            e
-                                                                                          )
+                                                                                        (con
+                                                                                          unit
+                                                                                          ()
                                                                                         )
                                                                                       ]
                                                                                     )
@@ -5553,12 +5414,9 @@
                                                                                                 (type)
                                                                                                 [
                                                                                                   fail
-                                                                                                  (abs
-                                                                                                    e
-                                                                                                    (type)
-                                                                                                    (error
-                                                                                                      e
-                                                                                                    )
+                                                                                                  (con
+                                                                                                    unit
+                                                                                                    ()
                                                                                                   )
                                                                                                 ]
                                                                                               )
@@ -5569,12 +5427,9 @@
                                                                                             (type)
                                                                                             [
                                                                                               fail
-                                                                                              (abs
-                                                                                                e
-                                                                                                (type)
-                                                                                                (error
-                                                                                                  e
-                                                                                                )
+                                                                                              (con
+                                                                                                unit
+                                                                                                ()
                                                                                               )
                                                                                             ]
                                                                                           )
@@ -7110,62 +6965,7 @@
                         )
                       )
                     )
-                    (datatypebind
-                      (datatype
-                        (tyvardecl Credential (type))
-
-                        Credential_match
-                        (vardecl
-                          PubKeyCredential (fun (con bytestring) Credential)
-                        )
-                        (vardecl
-                          ScriptCredential (fun (con bytestring) Credential)
-                        )
-                      )
-                    )
-                    (datatypebind
-                      (datatype
-                        (tyvardecl StakingCredential (type))
-
-                        StakingCredential_match
-                        (vardecl StakingHash (fun Credential StakingCredential))
-                        (vardecl
-                          StakingPtr
-                          (fun
-                            (con integer)
-                            (fun
-                              (con integer)
-                              (fun (con integer) StakingCredential)
-                            )
-                          )
-                        )
-                      )
-                    )
-                    (datatypebind
-                      (datatype
-                        (tyvardecl DCert (type))
-
-                        DCert_match
-                        (vardecl
-                          DCertDelegDeRegKey (fun StakingCredential DCert)
-                        )
-                        (vardecl
-                          DCertDelegDelegate
-                          (fun StakingCredential (fun (con bytestring) DCert))
-                        )
-                        (vardecl DCertDelegRegKey (fun StakingCredential DCert))
-                        (vardecl DCertGenesis DCert)
-                        (vardecl DCertMir DCert)
-                        (vardecl
-                          DCertPoolRegister
-                          (fun (con bytestring) (fun (con bytestring) DCert))
-                        )
-                        (vardecl
-                          DCertPoolRetire
-                          (fun (con bytestring) (fun (con integer) DCert))
-                        )
-                      )
-                    )
+                    (typebind (tyvardecl DCert (type)) (all a (type) (fun a a)))
                     (datatypebind
                       (datatype
                         (tyvardecl TxOutRef (type))
@@ -7176,6 +6976,10 @@
                           (fun (con bytestring) (fun (con integer) TxOutRef))
                         )
                       )
+                    )
+                    (typebind
+                      (tyvardecl StakingCredential (type))
+                      (all a (type) (fun a a))
                     )
                     (datatypebind
                       (datatype
@@ -7188,6 +6992,19 @@
                           Rewarding (fun StakingCredential ScriptPurpose)
                         )
                         (vardecl Spending (fun TxOutRef ScriptPurpose))
+                      )
+                    )
+                    (datatypebind
+                      (datatype
+                        (tyvardecl Credential (type))
+
+                        Credential_match
+                        (vardecl
+                          PubKeyCredential (fun (con bytestring) Credential)
+                        )
+                        (vardecl
+                          ScriptCredential (fun (con bytestring) Credential)
+                        )
                       )
                     )
                     (datatypebind
@@ -8072,255 +7889,131 @@
                                                                                                                     Maybe_match
                                                                                                                     TxInInfo
                                                                                                                   }
-                                                                                                                  {
+                                                                                                                  [
                                                                                                                     [
                                                                                                                       [
                                                                                                                         [
-                                                                                                                          [
-                                                                                                                            {
-                                                                                                                              [
-                                                                                                                                ScriptPurpose_match
-                                                                                                                                ww
-                                                                                                                              ]
-                                                                                                                              (all
-                                                                                                                                dead
-                                                                                                                                (type)
-                                                                                                                                [
-                                                                                                                                  Maybe
-                                                                                                                                  TxInInfo
-                                                                                                                                ]
-                                                                                                                              )
-                                                                                                                            }
-                                                                                                                            (lam
-                                                                                                                              default_arg0
-                                                                                                                              DCert
-                                                                                                                              (abs
-                                                                                                                                dead
-                                                                                                                                (type)
-                                                                                                                                {
-                                                                                                                                  Nothing
-                                                                                                                                  TxInInfo
-                                                                                                                                }
-                                                                                                                              )
-                                                                                                                            )
-                                                                                                                          ]
+                                                                                                                          {
+                                                                                                                            [
+                                                                                                                              ScriptPurpose_match
+                                                                                                                              ww
+                                                                                                                            ]
+                                                                                                                            [
+                                                                                                                              Maybe
+                                                                                                                              TxInInfo
+                                                                                                                            ]
+                                                                                                                          }
                                                                                                                           (lam
                                                                                                                             default_arg0
-                                                                                                                            (con
-                                                                                                                              bytestring
-                                                                                                                            )
-                                                                                                                            (abs
-                                                                                                                              dead
-                                                                                                                              (type)
-                                                                                                                              {
-                                                                                                                                Nothing
-                                                                                                                                TxInInfo
-                                                                                                                              }
-                                                                                                                            )
-                                                                                                                          )
-                                                                                                                        ]
-                                                                                                                        (lam
-                                                                                                                          default_arg0
-                                                                                                                          StakingCredential
-                                                                                                                          (abs
-                                                                                                                            dead
-                                                                                                                            (type)
+                                                                                                                            DCert
                                                                                                                             {
                                                                                                                               Nothing
                                                                                                                               TxInInfo
                                                                                                                             }
                                                                                                                           )
+                                                                                                                        ]
+                                                                                                                        (lam
+                                                                                                                          default_arg0
+                                                                                                                          (con
+                                                                                                                            bytestring
+                                                                                                                          )
+                                                                                                                          {
+                                                                                                                            Nothing
+                                                                                                                            TxInInfo
+                                                                                                                          }
                                                                                                                         )
                                                                                                                       ]
                                                                                                                       (lam
-                                                                                                                        txOutRef
-                                                                                                                        TxOutRef
-                                                                                                                        (abs
-                                                                                                                          dead
-                                                                                                                          (type)
+                                                                                                                        default_arg0
+                                                                                                                        StakingCredential
+                                                                                                                        {
+                                                                                                                          Nothing
+                                                                                                                          TxInInfo
+                                                                                                                        }
+                                                                                                                      )
+                                                                                                                    ]
+                                                                                                                    (lam
+                                                                                                                      txOutRef
+                                                                                                                      TxOutRef
+                                                                                                                      [
+                                                                                                                        [
                                                                                                                           [
-                                                                                                                            [
-                                                                                                                              [
-                                                                                                                                {
-                                                                                                                                  {
-                                                                                                                                    fFoldableNil_cfoldMap
-                                                                                                                                    [
-                                                                                                                                      (lam
-                                                                                                                                        a
-                                                                                                                                        (type)
-                                                                                                                                        [
-                                                                                                                                          Maybe
-                                                                                                                                          a
-                                                                                                                                        ]
-                                                                                                                                      )
-                                                                                                                                      TxInInfo
-                                                                                                                                    ]
-                                                                                                                                  }
-                                                                                                                                  TxInInfo
-                                                                                                                                }
-                                                                                                                                {
-                                                                                                                                  fMonoidFirst
-                                                                                                                                  TxInInfo
-                                                                                                                                }
-                                                                                                                              ]
-                                                                                                                              (lam
-                                                                                                                                x
-                                                                                                                                TxInInfo
+                                                                                                                            {
+                                                                                                                              {
+                                                                                                                                fFoldableNil_cfoldMap
                                                                                                                                 [
-                                                                                                                                  {
-                                                                                                                                    [
-                                                                                                                                      TxInInfo_match
-                                                                                                                                      x
-                                                                                                                                    ]
+                                                                                                                                  (lam
+                                                                                                                                    a
+                                                                                                                                    (type)
                                                                                                                                     [
                                                                                                                                       Maybe
-                                                                                                                                      TxInInfo
+                                                                                                                                      a
                                                                                                                                     ]
-                                                                                                                                  }
-                                                                                                                                  (lam
-                                                                                                                                    ds
-                                                                                                                                    TxOutRef
-                                                                                                                                    (lam
-                                                                                                                                      ds
-                                                                                                                                      TxOut
-                                                                                                                                      {
-                                                                                                                                        [
+                                                                                                                                  )
+                                                                                                                                  TxInInfo
+                                                                                                                                ]
+                                                                                                                              }
+                                                                                                                              TxInInfo
+                                                                                                                            }
+                                                                                                                            {
+                                                                                                                              fMonoidFirst
+                                                                                                                              TxInInfo
+                                                                                                                            }
+                                                                                                                          ]
+                                                                                                                          (lam
+                                                                                                                            x
+                                                                                                                            TxInInfo
+                                                                                                                            [
+                                                                                                                              {
+                                                                                                                                [
+                                                                                                                                  TxInInfo_match
+                                                                                                                                  x
+                                                                                                                                ]
+                                                                                                                                [
+                                                                                                                                  Maybe
+                                                                                                                                  TxInInfo
+                                                                                                                                ]
+                                                                                                                              }
+                                                                                                                              (lam
+                                                                                                                                ds
+                                                                                                                                TxOutRef
+                                                                                                                                (lam
+                                                                                                                                  ds
+                                                                                                                                  TxOut
+                                                                                                                                  {
+                                                                                                                                    [
+                                                                                                                                      [
+                                                                                                                                        {
                                                                                                                                           [
+                                                                                                                                            Bool_match
                                                                                                                                             {
                                                                                                                                               [
-                                                                                                                                                Bool_match
-                                                                                                                                                {
-                                                                                                                                                  [
+                                                                                                                                                [
+                                                                                                                                                  {
                                                                                                                                                     [
-                                                                                                                                                      {
+                                                                                                                                                      Bool_match
+                                                                                                                                                      [
                                                                                                                                                         [
-                                                                                                                                                          Bool_match
                                                                                                                                                           [
+                                                                                                                                                            {
+                                                                                                                                                              (builtin
+                                                                                                                                                                ifThenElse
+                                                                                                                                                              )
+                                                                                                                                                              Bool
+                                                                                                                                                            }
                                                                                                                                                             [
                                                                                                                                                               [
-                                                                                                                                                                {
-                                                                                                                                                                  (builtin
-                                                                                                                                                                    ifThenElse
-                                                                                                                                                                  )
-                                                                                                                                                                  Bool
-                                                                                                                                                                }
-                                                                                                                                                                [
-                                                                                                                                                                  [
-                                                                                                                                                                    (builtin
-                                                                                                                                                                      equalsByteString
-                                                                                                                                                                    )
-                                                                                                                                                                    [
-                                                                                                                                                                      {
-                                                                                                                                                                        [
-                                                                                                                                                                          TxOutRef_match
-                                                                                                                                                                          ds
-                                                                                                                                                                        ]
-                                                                                                                                                                        (con
-                                                                                                                                                                          bytestring
-                                                                                                                                                                        )
-                                                                                                                                                                      }
-                                                                                                                                                                      (lam
-                                                                                                                                                                        ds
-                                                                                                                                                                        (con
-                                                                                                                                                                          bytestring
-                                                                                                                                                                        )
-                                                                                                                                                                        (lam
-                                                                                                                                                                          ds
-                                                                                                                                                                          (con
-                                                                                                                                                                            integer
-                                                                                                                                                                          )
-                                                                                                                                                                          ds
-                                                                                                                                                                        )
-                                                                                                                                                                      )
-                                                                                                                                                                    ]
-                                                                                                                                                                  ]
-                                                                                                                                                                  [
-                                                                                                                                                                    {
-                                                                                                                                                                      [
-                                                                                                                                                                        TxOutRef_match
-                                                                                                                                                                        txOutRef
-                                                                                                                                                                      ]
-                                                                                                                                                                      (con
-                                                                                                                                                                        bytestring
-                                                                                                                                                                      )
-                                                                                                                                                                    }
-                                                                                                                                                                    (lam
-                                                                                                                                                                      ds
-                                                                                                                                                                      (con
-                                                                                                                                                                        bytestring
-                                                                                                                                                                      )
-                                                                                                                                                                      (lam
-                                                                                                                                                                        ds
-                                                                                                                                                                        (con
-                                                                                                                                                                          integer
-                                                                                                                                                                        )
-                                                                                                                                                                        ds
-                                                                                                                                                                      )
-                                                                                                                                                                    )
-                                                                                                                                                                  ]
-                                                                                                                                                                ]
-                                                                                                                                                              ]
-                                                                                                                                                              True
-                                                                                                                                                            ]
-                                                                                                                                                            False
-                                                                                                                                                          ]
-                                                                                                                                                        ]
-                                                                                                                                                        (all
-                                                                                                                                                          dead
-                                                                                                                                                          (type)
-                                                                                                                                                          Bool
-                                                                                                                                                        )
-                                                                                                                                                      }
-                                                                                                                                                      (abs
-                                                                                                                                                        dead
-                                                                                                                                                        (type)
-                                                                                                                                                        [
-                                                                                                                                                          [
-                                                                                                                                                            [
-                                                                                                                                                              {
                                                                                                                                                                 (builtin
-                                                                                                                                                                  ifThenElse
+                                                                                                                                                                  equalsByteString
                                                                                                                                                                 )
-                                                                                                                                                                Bool
-                                                                                                                                                              }
-                                                                                                                                                              [
-                                                                                                                                                                [
-                                                                                                                                                                  (builtin
-                                                                                                                                                                    equalsInteger
-                                                                                                                                                                  )
-                                                                                                                                                                  [
-                                                                                                                                                                    {
-                                                                                                                                                                      [
-                                                                                                                                                                        TxOutRef_match
-                                                                                                                                                                        ds
-                                                                                                                                                                      ]
-                                                                                                                                                                      (con
-                                                                                                                                                                        integer
-                                                                                                                                                                      )
-                                                                                                                                                                    }
-                                                                                                                                                                    (lam
-                                                                                                                                                                      ds
-                                                                                                                                                                      (con
-                                                                                                                                                                        bytestring
-                                                                                                                                                                      )
-                                                                                                                                                                      (lam
-                                                                                                                                                                        ds
-                                                                                                                                                                        (con
-                                                                                                                                                                          integer
-                                                                                                                                                                        )
-                                                                                                                                                                        ds
-                                                                                                                                                                      )
-                                                                                                                                                                    )
-                                                                                                                                                                  ]
-                                                                                                                                                                ]
                                                                                                                                                                 [
                                                                                                                                                                   {
                                                                                                                                                                     [
                                                                                                                                                                       TxOutRef_match
-                                                                                                                                                                      txOutRef
+                                                                                                                                                                      ds
                                                                                                                                                                     ]
                                                                                                                                                                     (con
-                                                                                                                                                                      integer
+                                                                                                                                                                      bytestring
                                                                                                                                                                     )
                                                                                                                                                                   }
                                                                                                                                                                   (lam
@@ -8338,78 +8031,175 @@
                                                                                                                                                                   )
                                                                                                                                                                 ]
                                                                                                                                                               ]
+                                                                                                                                                              [
+                                                                                                                                                                {
+                                                                                                                                                                  [
+                                                                                                                                                                    TxOutRef_match
+                                                                                                                                                                    txOutRef
+                                                                                                                                                                  ]
+                                                                                                                                                                  (con
+                                                                                                                                                                    bytestring
+                                                                                                                                                                  )
+                                                                                                                                                                }
+                                                                                                                                                                (lam
+                                                                                                                                                                  ds
+                                                                                                                                                                  (con
+                                                                                                                                                                    bytestring
+                                                                                                                                                                  )
+                                                                                                                                                                  (lam
+                                                                                                                                                                    ds
+                                                                                                                                                                    (con
+                                                                                                                                                                      integer
+                                                                                                                                                                    )
+                                                                                                                                                                    ds
+                                                                                                                                                                  )
+                                                                                                                                                                )
+                                                                                                                                                              ]
                                                                                                                                                             ]
-                                                                                                                                                            True
                                                                                                                                                           ]
-                                                                                                                                                          False
+                                                                                                                                                          True
                                                                                                                                                         ]
-                                                                                                                                                      )
+                                                                                                                                                        False
+                                                                                                                                                      ]
                                                                                                                                                     ]
-                                                                                                                                                    (abs
+                                                                                                                                                    (all
                                                                                                                                                       dead
                                                                                                                                                       (type)
-                                                                                                                                                      False
+                                                                                                                                                      Bool
                                                                                                                                                     )
-                                                                                                                                                  ]
-                                                                                                                                                  (all
+                                                                                                                                                  }
+                                                                                                                                                  (abs
                                                                                                                                                     dead
                                                                                                                                                     (type)
-                                                                                                                                                    dead
+                                                                                                                                                    [
+                                                                                                                                                      [
+                                                                                                                                                        [
+                                                                                                                                                          {
+                                                                                                                                                            (builtin
+                                                                                                                                                              ifThenElse
+                                                                                                                                                            )
+                                                                                                                                                            Bool
+                                                                                                                                                          }
+                                                                                                                                                          [
+                                                                                                                                                            [
+                                                                                                                                                              (builtin
+                                                                                                                                                                equalsInteger
+                                                                                                                                                              )
+                                                                                                                                                              [
+                                                                                                                                                                {
+                                                                                                                                                                  [
+                                                                                                                                                                    TxOutRef_match
+                                                                                                                                                                    ds
+                                                                                                                                                                  ]
+                                                                                                                                                                  (con
+                                                                                                                                                                    integer
+                                                                                                                                                                  )
+                                                                                                                                                                }
+                                                                                                                                                                (lam
+                                                                                                                                                                  ds
+                                                                                                                                                                  (con
+                                                                                                                                                                    bytestring
+                                                                                                                                                                  )
+                                                                                                                                                                  (lam
+                                                                                                                                                                    ds
+                                                                                                                                                                    (con
+                                                                                                                                                                      integer
+                                                                                                                                                                    )
+                                                                                                                                                                    ds
+                                                                                                                                                                  )
+                                                                                                                                                                )
+                                                                                                                                                              ]
+                                                                                                                                                            ]
+                                                                                                                                                            [
+                                                                                                                                                              {
+                                                                                                                                                                [
+                                                                                                                                                                  TxOutRef_match
+                                                                                                                                                                  txOutRef
+                                                                                                                                                                ]
+                                                                                                                                                                (con
+                                                                                                                                                                  integer
+                                                                                                                                                                )
+                                                                                                                                                              }
+                                                                                                                                                              (lam
+                                                                                                                                                                ds
+                                                                                                                                                                (con
+                                                                                                                                                                  bytestring
+                                                                                                                                                                )
+                                                                                                                                                                (lam
+                                                                                                                                                                  ds
+                                                                                                                                                                  (con
+                                                                                                                                                                    integer
+                                                                                                                                                                  )
+                                                                                                                                                                  ds
+                                                                                                                                                                )
+                                                                                                                                                              )
+                                                                                                                                                            ]
+                                                                                                                                                          ]
+                                                                                                                                                        ]
+                                                                                                                                                        True
+                                                                                                                                                      ]
+                                                                                                                                                      False
+                                                                                                                                                    ]
                                                                                                                                                   )
-                                                                                                                                                }
+                                                                                                                                                ]
+                                                                                                                                                (abs
+                                                                                                                                                  dead
+                                                                                                                                                  (type)
+                                                                                                                                                  False
+                                                                                                                                                )
                                                                                                                                               ]
                                                                                                                                               (all
                                                                                                                                                 dead
                                                                                                                                                 (type)
-                                                                                                                                                [
-                                                                                                                                                  Maybe
-                                                                                                                                                  TxInInfo
-                                                                                                                                                ]
+                                                                                                                                                dead
                                                                                                                                               )
                                                                                                                                             }
-                                                                                                                                            (abs
-                                                                                                                                              dead
-                                                                                                                                              (type)
-                                                                                                                                              [
-                                                                                                                                                {
-                                                                                                                                                  Just
-                                                                                                                                                  TxInInfo
-                                                                                                                                                }
-                                                                                                                                                x
-                                                                                                                                              ]
-                                                                                                                                            )
                                                                                                                                           ]
-                                                                                                                                          (abs
+                                                                                                                                          (all
                                                                                                                                             dead
                                                                                                                                             (type)
-                                                                                                                                            {
-                                                                                                                                              Nothing
+                                                                                                                                            [
+                                                                                                                                              Maybe
                                                                                                                                               TxInInfo
-                                                                                                                                            }
+                                                                                                                                            ]
                                                                                                                                           )
-                                                                                                                                        ]
-                                                                                                                                        (all
+                                                                                                                                        }
+                                                                                                                                        (abs
                                                                                                                                           dead
                                                                                                                                           (type)
-                                                                                                                                          dead
+                                                                                                                                          [
+                                                                                                                                            {
+                                                                                                                                              Just
+                                                                                                                                              TxInInfo
+                                                                                                                                            }
+                                                                                                                                            x
+                                                                                                                                          ]
                                                                                                                                         )
-                                                                                                                                      }
+                                                                                                                                      ]
+                                                                                                                                      (abs
+                                                                                                                                        dead
+                                                                                                                                        (type)
+                                                                                                                                        {
+                                                                                                                                          Nothing
+                                                                                                                                          TxInInfo
+                                                                                                                                        }
+                                                                                                                                      )
+                                                                                                                                    ]
+                                                                                                                                    (all
+                                                                                                                                      dead
+                                                                                                                                      (type)
+                                                                                                                                      dead
                                                                                                                                     )
-                                                                                                                                  )
-                                                                                                                                ]
+                                                                                                                                  }
+                                                                                                                                )
                                                                                                                               )
                                                                                                                             ]
-                                                                                                                            ww
-                                                                                                                          ]
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                    ]
-                                                                                                                    (all
-                                                                                                                      dead
-                                                                                                                      (type)
-                                                                                                                      dead
+                                                                                                                          )
+                                                                                                                        ]
+                                                                                                                        ww
+                                                                                                                      ]
                                                                                                                     )
-                                                                                                                  }
+                                                                                                                  ]
                                                                                                                 ]
                                                                                                                 (all
                                                                                                                   dead
@@ -8594,12 +8384,9 @@
                                                                                                                                             )
                                                                                                                                             [
                                                                                                                                               fail
-                                                                                                                                              (abs
-                                                                                                                                                e
-                                                                                                                                                (type)
-                                                                                                                                                (error
-                                                                                                                                                  e
-                                                                                                                                                )
+                                                                                                                                              (con
+                                                                                                                                                unit
+                                                                                                                                                ()
                                                                                                                                               )
                                                                                                                                             ]
                                                                                                                                           )
@@ -8671,12 +8458,9 @@
                                                                                                                                                 (type)
                                                                                                                                                 [
                                                                                                                                                   fail
-                                                                                                                                                  (abs
-                                                                                                                                                    e
-                                                                                                                                                    (type)
-                                                                                                                                                    (error
-                                                                                                                                                      e
-                                                                                                                                                    )
+                                                                                                                                                  (con
+                                                                                                                                                    unit
+                                                                                                                                                    ()
                                                                                                                                                   )
                                                                                                                                                 ]
                                                                                                                                               )
@@ -8707,12 +8491,9 @@
                                                                                                               (type)
                                                                                                               [
                                                                                                                 fail
-                                                                                                                (abs
-                                                                                                                  e
-                                                                                                                  (type)
-                                                                                                                  (error
-                                                                                                                    e
-                                                                                                                  )
+                                                                                                                (con
+                                                                                                                  unit
+                                                                                                                  ()
                                                                                                                 )
                                                                                                               ]
                                                                                                             )


### PR DESCRIPTION
This is just an experiment (not to be merged) on changes at the PIR level when we remove traces and inline trivial lambdas in the relevant usecase tests.

The overall diff is not interesting as it includes a huge diff from applying `plutus`'s master HEAD. The second commit portraits the actual experiment from applying https://github.com/HachiSecurity/plutus/commit/c8accb12d87de646544fd4200fa240835046a995.

Not much is inlined so improvements are very minimal, but it is also a data point showing little risk from inlining trivial lambdas (there are not that many in real scripts?).