### PR TITLE
SCP-3216 psgenerator and PAB compatibility with Marlowe

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab-executables.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab-executables.nix
@@ -31,25 +31,23 @@
       extraDocFiles = [];
       };
     components = {
-      sublibs = {
-        "plutus-pab-psgenerator" = {
-          depends = [
-            (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
-            (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
-            (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
-            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
-            (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
-            (hsPkgs."servant-purescript" or (errorHandler.buildDepError "servant-purescript"))
-            (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            ];
-          buildable = true;
-          modules = [ "Plutus/PAB/Run/PSGenerator" ];
-          hsSourceDirs = [ "src" ];
-          };
+      "library" = {
+        depends = [
+          (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
+          (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
+          (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
+          (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+          (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
+          (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
+          (hsPkgs."servant-purescript" or (errorHandler.buildDepError "servant-purescript"))
+          (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          ];
+        buildable = true;
+        modules = [ "Plutus/PAB/Run/PSGenerator" ];
+        hsSourceDirs = [ "src" ];
         };
       exes = {
         "plutus-pab-setup" = {
@@ -74,7 +72,7 @@
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
             (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
@@ -107,7 +105,7 @@
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
             (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
@@ -157,7 +155,7 @@
             (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
@@ -221,7 +219,7 @@
             (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
@@ -313,7 +311,7 @@
             (hsPkgs."plutus-chain-index" or (errorHandler.buildDepError "plutus-chain-index"))
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
             (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
             (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
@@ -350,7 +348,7 @@
             (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
@@ -412,7 +410,7 @@
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -1256,6 +1256,7 @@
           "parallel".components.library.planned = lib.mkOverride 900 true;
           "uuid-types".components.library.planned = lib.mkOverride 900 true;
           "QuickCheck".components.library.planned = lib.mkOverride 900 true;
+          "plutus-pab-executables".components.library.planned = lib.mkOverride 900 true;
           "haskell-src-meta".components.library.planned = lib.mkOverride 900 true;
           "cborg".components.library.planned = lib.mkOverride 900 true;
           "time-manager".components.library.planned = lib.mkOverride 900 true;
@@ -1435,7 +1436,6 @@
           "ghc-paths".components.library.planned = lib.mkOverride 900 true;
           "plutus-playground-server".components.library.planned = lib.mkOverride 900 true;
           "witherable".components.library.planned = lib.mkOverride 900 true;
-          "plutus-pab-executables".components.sublibs."plutus-pab-psgenerator".planned = lib.mkOverride 900 true;
           "snap-core".components.library.planned = lib.mkOverride 900 true;
           "servant-websockets".components.library.planned = lib.mkOverride 900 true;
           "plutus-pab-executables".components.exes."sync-client".planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab-executables.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab-executables.nix
@@ -31,25 +31,23 @@
       extraDocFiles = [];
       };
     components = {
-      sublibs = {
-        "plutus-pab-psgenerator" = {
-          depends = [
-            (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
-            (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
-            (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
-            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
-            (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
-            (hsPkgs."servant-purescript" or (errorHandler.buildDepError "servant-purescript"))
-            (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            ];
-          buildable = true;
-          modules = [ "Plutus/PAB/Run/PSGenerator" ];
-          hsSourceDirs = [ "src" ];
-          };
+      "library" = {
+        depends = [
+          (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
+          (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
+          (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
+          (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+          (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
+          (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
+          (hsPkgs."servant-purescript" or (errorHandler.buildDepError "servant-purescript"))
+          (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          ];
+        buildable = true;
+        modules = [ "Plutus/PAB/Run/PSGenerator" ];
+        hsSourceDirs = [ "src" ];
         };
       exes = {
         "plutus-pab-setup" = {
@@ -74,7 +72,7 @@
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
             (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
@@ -107,7 +105,7 @@
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
             (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
@@ -157,7 +155,7 @@
             (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
@@ -221,7 +219,7 @@
             (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
@@ -313,7 +311,7 @@
             (hsPkgs."plutus-chain-index" or (errorHandler.buildDepError "plutus-chain-index"))
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
             (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
             (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
@@ -350,7 +348,7 @@
             (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
@@ -412,7 +410,7 @@
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -1263,6 +1263,7 @@
           "parallel".components.library.planned = lib.mkOverride 900 true;
           "uuid-types".components.library.planned = lib.mkOverride 900 true;
           "QuickCheck".components.library.planned = lib.mkOverride 900 true;
+          "plutus-pab-executables".components.library.planned = lib.mkOverride 900 true;
           "haskell-src-meta".components.library.planned = lib.mkOverride 900 true;
           "cborg".components.library.planned = lib.mkOverride 900 true;
           "time-manager".components.library.planned = lib.mkOverride 900 true;
@@ -1443,7 +1444,6 @@
           "ghc-paths".components.library.planned = lib.mkOverride 900 true;
           "plutus-playground-server".components.library.planned = lib.mkOverride 900 true;
           "witherable".components.library.planned = lib.mkOverride 900 true;
-          "plutus-pab-executables".components.sublibs."plutus-pab-psgenerator".planned = lib.mkOverride 900 true;
           "snap-core".components.library.planned = lib.mkOverride 900 true;
           "servant-websockets".components.library.planned = lib.mkOverride 900 true;
           "plutus-pab-executables".components.exes."sync-client".planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab-executables.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab-executables.nix
@@ -31,25 +31,23 @@
       extraDocFiles = [];
       };
     components = {
-      sublibs = {
-        "plutus-pab-psgenerator" = {
-          depends = [
-            (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
-            (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
-            (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
-            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
-            (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
-            (hsPkgs."servant-purescript" or (errorHandler.buildDepError "servant-purescript"))
-            (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            ];
-          buildable = true;
-          modules = [ "Plutus/PAB/Run/PSGenerator" ];
-          hsSourceDirs = [ "src" ];
-          };
+      "library" = {
+        depends = [
+          (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
+          (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
+          (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
+          (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+          (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
+          (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
+          (hsPkgs."servant-purescript" or (errorHandler.buildDepError "servant-purescript"))
+          (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          ];
+        buildable = true;
+        modules = [ "Plutus/PAB/Run/PSGenerator" ];
+        hsSourceDirs = [ "src" ];
         };
       exes = {
         "plutus-pab-setup" = {
@@ -74,7 +72,7 @@
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
             (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
@@ -107,7 +105,7 @@
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
             (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
@@ -157,7 +155,7 @@
             (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
@@ -221,7 +219,7 @@
             (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
@@ -313,7 +311,7 @@
             (hsPkgs."plutus-chain-index" or (errorHandler.buildDepError "plutus-chain-index"))
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
             (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
             (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
@@ -350,7 +348,7 @@
             (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
@@ -412,7 +410,7 @@
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))

--- a/nix/pkgs/haskell/materialized-windows/default.nix
+++ b/nix/pkgs/haskell/materialized-windows/default.nix
@@ -1237,6 +1237,7 @@
           "parallel".components.library.planned = lib.mkOverride 900 true;
           "uuid-types".components.library.planned = lib.mkOverride 900 true;
           "QuickCheck".components.library.planned = lib.mkOverride 900 true;
+          "plutus-pab-executables".components.library.planned = lib.mkOverride 900 true;
           "haskell-src-meta".components.library.planned = lib.mkOverride 900 true;
           "cborg".components.library.planned = lib.mkOverride 900 true;
           "time-manager".components.library.planned = lib.mkOverride 900 true;
@@ -1413,7 +1414,6 @@
           "either".components.library.planned = lib.mkOverride 900 true;
           "plutus-playground-server".components.library.planned = lib.mkOverride 900 true;
           "witherable".components.library.planned = lib.mkOverride 900 true;
-          "plutus-pab-executables".components.sublibs."plutus-pab-psgenerator".planned = lib.mkOverride 900 true;
           "snap-core".components.library.planned = lib.mkOverride 900 true;
           "servant-websockets".components.library.planned = lib.mkOverride 900 true;
           "plutus-pab-executables".components.exes."sync-client".planned = lib.mkOverride 900 true;

--- a/playground-common/src/PSGenerator/Common.hs
+++ b/playground-common/src/PSGenerator/Common.hs
@@ -156,6 +156,12 @@ someCardanoApiTxBridge = do
     typeModule ^== "Ledger.Tx.CardanoAPI"
     pure psJson
 
+exportTxBridge :: BridgePart
+exportTxBridge = do
+    typeName ^== "ExportTx"
+    typeModule ^== "Plutus.Contract.Wallet"
+    pure psJson
+
 miscBridge :: BridgePart
 miscBridge =
         bultinByteStringBridge
@@ -168,6 +174,7 @@ miscBridge =
     <|> satIntBridge
     <|> exBudgetBridge
     <|> someCardanoApiTxBridge
+    <|> exportTxBridge
 
 ------------------------------------------------------------
 

--- a/plutus-pab-executables/plutus-pab-executables.cabal
+++ b/plutus-pab-executables/plutus-pab-executables.cabal
@@ -50,7 +50,7 @@ common lang
     if flag(defer-plugin-errors)
         ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
 
-library plutus-pab-psgenerator
+library
     import:             lang
     ghc-options:
         -Wunused-packages
@@ -108,7 +108,7 @@ executable plutus-pab-setup
         plutus-contract -any,
         plutus-ledger -any,
         plutus-pab -any,
-        plutus-pab-psgenerator -any,
+        plutus-pab-executables -any,
         plutus-use-cases -any,
         prettyprinter         >=1.1.0.1,
         purescript-bridge -any,
@@ -153,7 +153,7 @@ executable plutus-pab-examples
         , plutus-ledger
         , plutus-ledger-constraints
         , plutus-pab
-        , plutus-pab-psgenerator
+        , plutus-pab-executables
         , plutus-use-cases
         , prettyprinter
         , purescript-bridge
@@ -219,7 +219,7 @@ executable plutus-pab-local-cluster
         , plutus-ledger-api
         , plutus-ledger-constraints
         , plutus-pab
-        , plutus-pab-psgenerator
+        , plutus-pab-executables
         , plutus-use-cases
 
     build-depends:
@@ -290,7 +290,7 @@ executable plutus-pab-test-psgenerator
         mtl -any,
         plutus-contract -any,
         plutus-pab,
-        plutus-pab-psgenerator -any,
+        plutus-pab-executables -any,
         plutus-use-cases -any,
         plutus-ledger -any,
         plutus-ledger-constraints -any,
@@ -350,7 +350,7 @@ test-suite plutus-pab-test-full
         plutus-chain-index-core -any,
         plutus-contract -any,
         plutus-pab,
-        plutus-pab-psgenerator,
+        plutus-pab-executables,
         plutus-use-cases -any,
         plutus-ledger -any,
         plutus-ledger-constraints -any,
@@ -415,7 +415,7 @@ test-suite plutus-pab-test-full-long-running
         plutus-contract -any,
         plutus-chain-index-core -any,
         plutus-pab,
-        plutus-pab-psgenerator -any,
+        plutus-pab-executables -any,
         plutus-use-cases -any,
         plutus-ledger -any,
         plutus-ledger-constraints -any,
@@ -506,7 +506,7 @@ executable plutus-pab-nami-demo
     plutus-chain-index -any,
     plutus-contract -any,
     plutus-pab -any,
-    plutus-pab-psgenerator -any,
+    plutus-pab-executables -any,
     playground-common -any,
     prettyprinter -any,
     purescript-bridge -any,


### PR DESCRIPTION
Fixes two blocking issues for Marlowe:
1. The purescript generation now includes a bridge for  `ExportTx`, which was previously omitted. The closure of purescript types was incomplete without this.
2. `pab-executables.cabal` no longer contains a non-standard named library `plutus-pab-psgenerator`. The non-standard library name had prevented external use of the library via either `cabal` or `nix-build`. (Just renaming the library seemed preferable to renaming the folder. Note that the `cabal` version constraint did not allow non-standard library names.)

These changes were tested in https://github.com/input-output-hk/marlowe-cardano/pull/57. It was not possible to test fully in `plutus-apps` because `nix-build` in the root folder previously fails there.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
