### PR TITLE
Fix the problem with pab-nami-demo psapigenerator #235

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -56,7 +56,7 @@ rec {
     inherit (pkgs.callPackage ./plutus-pab-executables/demo/pab-nami/client {
       inherit pkgs haskell webCommon;
       inherit (plutus-apps.lib) buildPursPackage buildNodeModules filterNpm gitignore-nix;
-    }) client pab-setup-invoker pab-nami-demo-invoker generate-purescript generated-purescript start-backend;
+    }) client pab-setup-invoker pab-nami-demo-invoker pab-nami-demo-generator generate-purescript generated-purescript start-backend;
   };
 
   plutus-use-cases = pkgs.recurseIntoAttrs (pkgs.callPackage ./plutus-use-cases {

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab-executables.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab-executables.nix
@@ -342,7 +342,7 @@
             (hsPkgs."plutus-chain-index" or (errorHandler.buildDepError "plutus-chain-index"))
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
             (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
             (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab-executables.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab-executables.nix
@@ -327,6 +327,37 @@
             "Main.hs"
             ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
           };
+        "plutus-pab-nami-demo-generator" = {
+          depends = [
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
+            (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+            (hsPkgs."openapi3" or (errorHandler.buildDepError "openapi3"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."plutus-chain-index" or (errorHandler.buildDepError "plutus-chain-index"))
+            (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
+            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
+            (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+            (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
+            (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
+            (hsPkgs."row-types" or (errorHandler.buildDepError "row-types"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            ];
+          buildable = true;
+          modules = [ "DemoContract" ];
+          hsSourceDirs = [ "demo/pab-nami/pab/app" ];
+          mainPath = [
+            "Generator.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
         };
       tests = {
         "plutus-pab-test-full" = {

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -1442,6 +1442,7 @@
           "aeson-casing".components.library.planned = lib.mkOverride 900 true;
           "cardano-crypto-tests".components.library.planned = lib.mkOverride 900 true;
           "cardano-wallet".components.exes."cardano-wallet".planned = lib.mkOverride 900 true;
+          "plutus-pab-executables".components.exes."plutus-pab-nami-demo-generator".planned = lib.mkOverride 900 true;
           "servant-foreign".components.library.planned = lib.mkOverride 900 true;
           "contravariant".components.library.planned = lib.mkOverride 900 true;
           "optparse-generic".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab-executables.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab-executables.nix
@@ -342,7 +342,7 @@
             (hsPkgs."plutus-chain-index" or (errorHandler.buildDepError "plutus-chain-index"))
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
             (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
             (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab-executables.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab-executables.nix
@@ -327,6 +327,37 @@
             "Main.hs"
             ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
           };
+        "plutus-pab-nami-demo-generator" = {
+          depends = [
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
+            (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+            (hsPkgs."openapi3" or (errorHandler.buildDepError "openapi3"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."plutus-chain-index" or (errorHandler.buildDepError "plutus-chain-index"))
+            (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
+            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
+            (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+            (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
+            (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
+            (hsPkgs."row-types" or (errorHandler.buildDepError "row-types"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            ];
+          buildable = true;
+          modules = [ "DemoContract" ];
+          hsSourceDirs = [ "demo/pab-nami/pab/app" ];
+          mainPath = [
+            "Generator.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
         };
       tests = {
         "plutus-pab-test-full" = {

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -1450,6 +1450,7 @@
           "aeson-casing".components.library.planned = lib.mkOverride 900 true;
           "cardano-crypto-tests".components.library.planned = lib.mkOverride 900 true;
           "cardano-wallet".components.exes."cardano-wallet".planned = lib.mkOverride 900 true;
+          "plutus-pab-executables".components.exes."plutus-pab-nami-demo-generator".planned = lib.mkOverride 900 true;
           "servant-foreign".components.library.planned = lib.mkOverride 900 true;
           "contravariant".components.library.planned = lib.mkOverride 900 true;
           "optparse-generic".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab-executables.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab-executables.nix
@@ -342,7 +342,7 @@
             (hsPkgs."plutus-chain-index" or (errorHandler.buildDepError "plutus-chain-index"))
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
-            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."plutus-pab-executables" or (errorHandler.buildDepError "plutus-pab-executables"))
             (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
             (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
             (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab-executables.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab-executables.nix
@@ -327,6 +327,37 @@
             "Main.hs"
             ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
           };
+        "plutus-pab-nami-demo-generator" = {
+          depends = [
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
+            (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+            (hsPkgs."openapi3" or (errorHandler.buildDepError "openapi3"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."plutus-chain-index" or (errorHandler.buildDepError "plutus-chain-index"))
+            (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
+            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+            (hsPkgs."plutus-pab-executables".components.sublibs.plutus-pab-psgenerator or (errorHandler.buildDepError "plutus-pab-executables:plutus-pab-psgenerator"))
+            (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
+            (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+            (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
+            (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-ledger-constraints" or (errorHandler.buildDepError "plutus-ledger-constraints"))
+            (hsPkgs."row-types" or (errorHandler.buildDepError "row-types"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            ];
+          buildable = true;
+          modules = [ "DemoContract" ];
+          hsSourceDirs = [ "demo/pab-nami/pab/app" ];
+          mainPath = [
+            "Generator.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
         };
       tests = {
         "plutus-pab-test-full" = {

--- a/nix/pkgs/haskell/materialized-windows/default.nix
+++ b/nix/pkgs/haskell/materialized-windows/default.nix
@@ -1420,6 +1420,7 @@
           "aeson-casing".components.library.planned = lib.mkOverride 900 true;
           "cardano-crypto-tests".components.library.planned = lib.mkOverride 900 true;
           "cardano-wallet".components.exes."cardano-wallet".planned = lib.mkOverride 900 true;
+          "plutus-pab-executables".components.exes."plutus-pab-nami-demo-generator".planned = lib.mkOverride 900 true;
           "servant-foreign".components.library.planned = lib.mkOverride 900 true;
           "contravariant".components.library.planned = lib.mkOverride 900 true;
           "optparse-generic".components.library.planned = lib.mkOverride 900 true;

--- a/plutus-pab-executables/README.md
+++ b/plutus-pab-executables/README.md
@@ -89,6 +89,8 @@ $ cabal exec plutus-pab-setup -- psgenerator generated
 
 Generates the purescript bridge code.
 
+`psgenerator` generates only default types. If you want to generate types for your contracts you have to write your own small generator. Take a look at `plutus-pab-nami-demo-generator` for an example. It's a small executable that calls `PSGenerator.generateAPIModule` and `PSGenerator.generateWith` with a custom contract type.
+
 #### Source
 
 - [src/Plutus/PAB/Run/PSGenerator.hs](https://github.com/input-output-hk/plutus-apps/blob/main/plutus-pab/src/Plutus/PAB/Run/PSGenerator.hs)

--- a/plutus-pab-executables/demo/pab-nami/client/default.nix
+++ b/plutus-pab-executables/demo/pab-nami/client/default.nix
@@ -1,6 +1,7 @@
 { pkgs, gitignore-nix, haskell, webCommon, buildPursPackage, buildNodeModules, filterNpm }:
 let
   pab-nami-demo-invoker = haskell.packages.plutus-pab-executables.components.exes.plutus-pab-nami-demo;
+  pab-nami-demo-generator = haskell.packages.plutus-pab-executables.components.exes.plutus-pab-nami-demo-generator;
 
   pab-setup-invoker = haskell.packages.plutus-pab-executables.components.exes.plutus-pab-setup;
 
@@ -8,15 +9,14 @@ let
   generated-purescript = pkgs.runCommand "pab-nami-demo-purescript" { } ''
     mkdir $out
     ${pab-setup-invoker}/bin/plutus-pab-setup psgenerator $out
-    ln -s ${../pab/plutus-pab.yaml} plutus-pab.yaml
-    ${pab-nami-demo-invoker}/bin/plutus-pab-nami-demo --config ../pab/plutus-pab.yaml psapigenerator $out
+    ${pab-nami-demo-generator}/bin/plutus-pab-nami-demo-generator --output-dir $out
   '';
 
   generate-purescript = pkgs.writeShellScriptBin "pab-nami-demo-generate-purs" ''
     generatedDir=./generated
     rm -rf $generatedDir
     $(nix-build ../../../../default.nix -A pab-nami-demo.pab-setup-invoker)/bin/plutus-pab-setup psgenerator $generatedDir
-    $(nix-build ../../../../default.nix -A pab-nami-demo.pab-nami-demo-invoker)/bin/plutus-pab-nami-demo --config ../pab/plutus-pab.yaml psapigenerator $generatedDir
+    $(nix-build ../../../../default.nix -A pab-nami-demo.pab-nami-demo-generator)/bin/plutus-pab-nami-demo-generator --output-dir $generatedDir
   '';
 
   start-backend = pkgs.writeShellScriptBin "pab-nami-demo-server" ''
@@ -53,5 +53,5 @@ let
     });
 in
 {
-  inherit client pab-nami-demo-invoker pab-setup-invoker generate-purescript generated-purescript start-backend;
+  inherit client pab-nami-demo-invoker pab-nami-demo-generator pab-setup-invoker generate-purescript generated-purescript start-backend;
 }

--- a/plutus-pab-executables/demo/pab-nami/pab/app/Generator.hs
+++ b/plutus-pab-executables/demo/pab-nami/pab/app/Generator.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+
+module Main
+    ( main
+    ) where
+
+import Data.Proxy
+import DemoContract (DemoContract)
+import Options.Applicative
+import Plutus.PAB.Run.PSGenerator qualified as PSGenerator
+
+parseOptions :: IO FilePath
+parseOptions = customExecParser
+    (prefs $ disambiguate <> showHelpOnEmpty <> showHelpOnError)
+    (info (helper <*> psGenOutputDirParser) idm)
+
+psGenOutputDirParser :: Parser FilePath
+psGenOutputDirParser = option str
+    (long "output-dir" <>
+     metavar "OUTPUT_DIR" <>
+     help "Output directory to write PureScript files to.")
+
+main :: IO ()
+main = do
+    psGenOutputDir <- parseOptions
+    PSGenerator.generateAPIModule (Proxy :: Proxy DemoContract) psGenOutputDir
+    PSGenerator.generateWith @DemoContract psGenOutputDir

--- a/plutus-pab-executables/plutus-pab-executables.cabal
+++ b/plutus-pab-executables/plutus-pab-executables.cabal
@@ -514,3 +514,34 @@ executable plutus-pab-nami-demo
     plutus-ledger-constraints -any,
     row-types -any,
     text -any,
+
+executable plutus-pab-nami-demo-generator
+  import: lang
+  main-is: Generator.hs
+  hs-source-dirs: demo/pab-nami/pab/app
+  other-modules:
+    DemoContract
+  ghc-options:
+    -threaded
+  build-depends:
+    aeson -any,
+    async -any,
+    base >= 4.9 && < 5,
+    cardano-api -any,
+    data-default -any,
+    filepath -any,
+    freer-extras -any,
+    freer-simple -any,
+    openapi3 -any,
+    optparse-applicative -any,
+    plutus-chain-index -any,
+    plutus-contract -any,
+    plutus-pab -any,
+    plutus-pab-psgenerator -any,
+    playground-common -any,
+    prettyprinter -any,
+    purescript-bridge -any,
+    plutus-ledger -any,
+    plutus-ledger-constraints -any,
+    row-types -any,
+    text -any,

--- a/plutus-pab-executables/plutus-pab-executables.cabal
+++ b/plutus-pab-executables/plutus-pab-executables.cabal
@@ -537,7 +537,7 @@ executable plutus-pab-nami-demo-generator
     plutus-chain-index -any,
     plutus-contract -any,
     plutus-pab -any,
-    plutus-pab-psgenerator -any,
+    plutus-pab-executables -any,
     playground-common -any,
     prettyprinter -any,
     purescript-bridge -any,


### PR DESCRIPTION
Fix #235.

Instead of providing a builtin PAB's psapigenerator, with #216 we encourage users to create their own small psapigenerators.

`pab-nami-demo-generator` is a small executable with only one purpose — to generate ps types for the `DemoContract`.

---

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
