### PR TITLE
Bump plutus dep to allow building with cabal

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -242,7 +242,7 @@ source-repository-package
 source-repository-package
  type: git
  location: https://github.com/input-output-hk/plutus
- tag: 2721c59fd2302b75c4138456c29fd5b509e8340a
+ tag: 4710dff2e30ce131191a6a1ccbe43595b2e3af24
  subdir:
    plutus-ledger-api
    word-array


### PR DESCRIPTION
Currently building `plutus-apps` with cabal results in the following compile error:
```
[13 of 14] Compiling PlutusTx.Compiler.Expr ( src/PlutusTx/Compiler/Expr.hs, dist/build/PlutusTx/Compiler/Expr.o, dist/build/PlutusTx/Compiler/Expr.dyn_o )

src/PlutusTx/Compiler/Expr.hs:775:41: error:
    Not in scope: type constructor or class ‘GHC.GenTickish’
    Perhaps you meant one of these:
      ‘GHC.Tickish’ (imported from GhcPlugins),
      ‘GHC.Tickish’ (imported from CoreSyn)
    Neither ‘Class’, ‘CoreSyn’, ‘CostCentre’, ‘FV’, ‘GhcPlugins’,
            ‘MkId’ nor ‘PrelNames’ exports ‘GenTickish’.
    |
775 | getSourceSpan :: Maybe GHC.ModBreaks -> GHC.GenTickish pass -> Maybe GHC.RealSrcSpan
```
Bumping the `plutus` dep fixes this.
