### PR TITLE
Fix protocol version error messages happening during synchronisation.

### DIFF
--- a/plutus-pab-executables/plutus-pab.yaml.sample
+++ b/plutus-pab-executables/plutus-pab.yaml.sample
@@ -17,22 +17,22 @@ walletServerConfig:
     baseUrl: http://localhost:9081
 
 nodeServerConfig:
-  mscBaseUrl: http://localhost:9082
-  mscSocketPath: ./node-server.sock
-  mscKeptBlocks: 100
-  mscNetworkId: "1097911063" # Testnet network ID (main net = empty string)
-  mscSlotConfig:
+  pscBaseUrl: http://localhost:9082
+  pscSocketPath: ./node-server.sock
+  pscKeptBlocks: 100
+  pscNetworkId: "1097911063" # Testnet network ID (main net = empty string)
+  pscSlotConfig:
     scSlotZeroTime: 1596059091000 # Wednesday, July 29, 2020 21:44:51 - shelley launch time in milliseconds
     scSlotLength: 1000 # In milliseconds
-  mscFeeConfig:
+  pscFeeConfig:
     fcConstantFee:
       getLovelace: 10 # Constant fee per transaction in lovelace
     fcScriptsFeeFactor: 1.0 # Factor by which to multiply size-dependent scripts fee in lovelace
-  mscInitialTxWallets:
+  pscInitialTxWallets:
     - getWallet: 1
     - getWallet: 2
     - getWallet: 3
-  mscNodeMode: MockNode
+  pscNodeMode: MockNode
 
 chainIndexConfig:
   ciBaseUrl: http://localhost:9083

--- a/plutus-pab-executables/tx-inject/config.yaml
+++ b/plutus-pab-executables/tx-inject/config.yaml
@@ -13,18 +13,18 @@ walletServerConfig:
     baseUrl: http://localhost:9081
 
 nodeServerConfig:
-  mscBaseUrl: http://localhost:9082
-  mscSocketPath: /tmp/node-server.sock
-  mscKeptBlocks: 100000
-  mscNetworkId: "1097911063"
-  mscSlotConfig:
+  pscBaseUrl: http://localhost:9082
+  pscSocketPath: /tmp/node-server.sock
+  pscKeptBlocks: 100000
+  pscNetworkId: "1097911063"
+  pscSlotConfig:
     scSlotZeroTime: 1596059091000 # Wednesday, July 29, 2020 21:44:51 - shelley launch time in milliseconds
     scSlotLength: 1000 # In milliseconds
-  mscFeeConfig:
+  pscFeeConfig:
     fcConstantFee:
       getLovelace: 10 # Constant fee per transaction in lovelace
     fcScriptsFeeFactor: 1.0 # Factor by which to multiply size-dependent scripts fee in lovelace
-  mscInitialTxWallets:
+  pscInitialTxWallets:
     - getWallet: 1
     - getWallet: 2
     - getWallet: 3
@@ -35,7 +35,7 @@ nodeServerConfig:
     - getWallet: 8
     - getWallet: 9
     - getWallet: 10
-  mscNodeMode: AlonzoNode
+  pscNodeMode: AlonzoNode
 
 chainIndexConfig:
   ciBaseUrl: http://localhost:9083

--- a/plutus-pab-executables/tx-inject/config.yaml
+++ b/plutus-pab-executables/tx-inject/config.yaml
@@ -16,7 +16,8 @@ nodeServerConfig:
   pscBaseUrl: http://localhost:9082
   pscSocketPath: /tmp/node-server.sock
   pscKeptBlocks: 100000
-  pscNetworkId: "1097911063"
+  # pscNetworkId: "1097911063"
+  pscNetworkId: "3"
   pscSlotConfig:
     scSlotZeroTime: 1596059091000 # Wednesday, July 29, 2020 21:44:51 - shelley launch time in milliseconds
     scSlotLength: 1000 # In milliseconds

--- a/plutus-pab/src/Cardano/Node/Client.hs
+++ b/plutus-pab/src/Cardano/Node/Client.hs
@@ -11,13 +11,12 @@ import Control.Monad.Freer
 import Control.Monad.Freer.Reader (Reader, ask)
 import Control.Monad.IO.Class
 import Data.Proxy (Proxy (Proxy))
-import Ledger (Block)
 import Ledger.TimeSlot (SlotConfig)
 import Servant (NoContent, (:<|>) (..))
 import Servant.Client (ClientM, client)
 
 import Cardano.Node.API (API)
-import Cardano.Node.Types (PABServerLogMsg)
+import Cardano.Node.Types (ChainSyncHandle, PABServerConfig, PABServerLogMsg)
 import Cardano.Protocol.Socket.Client qualified as Client
 import Cardano.Protocol.Socket.Mock.Client qualified as MockClient
 import Control.Monad.Freer.Extras.Log (LogMessage)
@@ -52,4 +51,8 @@ handleNodeClientClient slotCfg e = do
             either (liftIO . MockClient.getCurrentSlot) (liftIO . Client.getCurrentSlot) chainSyncHandle
         GetClientSlotConfig -> pure slotCfg
 
-type ChainSyncHandle = Either (Client.ChainSyncHandle Block) (Client.ChainSyncHandle Client.ChainSyncEvent)
+runChainSyncWithCfg ::
+     PABServerConfig
+  -> IO ChainSyncHandle
+runChainSyncWithCfg = undefined
+

--- a/plutus-pab/src/Cardano/Node/Server.hs
+++ b/plutus-pab/src/Cardano/Node/Server.hs
@@ -44,7 +44,7 @@ app trace slotCfg clientHandler stateVar =
     serve (Proxy @API) $
     hoistServer
         (Proxy @API)
-        (liftIO . processChainEffects trace slotCfg clientHandler stateVar)
+        (liftIO . processChainEffects trace slotCfg (Just clientHandler) stateVar)
         (healthcheck :<|> consumeEventHistory stateVar)
 
 data Ctx = Ctx { serverHandler :: Server.ServerHandler

--- a/plutus-pab/src/Cardano/Node/Types.hs
+++ b/plutus-pab/src/Cardano/Node/Types.hs
@@ -177,6 +177,7 @@ data PABServerLogMsg =
     | ProcessingChainEvent ChainEvent
     | BlockOperation BlockEvent
     | CreatingRandomTransaction
+    | TxSendCalledWithoutMock
     deriving (Generic, Show, ToJSON, FromJSON)
 
 instance Pretty PABServerLogMsg where
@@ -193,6 +194,7 @@ instance Pretty PABServerLogMsg where
         ProcessingChainEvent e    -> "Processing chain event" <+> pretty e
         BlockOperation e          -> "Block operation" <+> pretty e
         CreatingRandomTransaction -> "Generating a random transaction"
+        TxSendCalledWithoutMock   -> "Cannot send transaction without a mocked environment."
 
 instance ToObject PABServerLogMsg where
     toObject _ = \case
@@ -205,6 +207,7 @@ instance ToObject PABServerLogMsg where
         ProcessingChainEvent e    ->  mkObjectStr "Processing chain event" (Tagged @"event" e)
         BlockOperation e          ->  mkObjectStr "Block operation" (Tagged @"event" e)
         CreatingRandomTransaction ->  mkObjectStr "Creating random transaction" ()
+        TxSendCalledWithoutMock   ->  mkObjectStr "Cannot send transaction without a mocked environment." ()
 
 data BlockEvent = NewSlot
     | NewTransaction Tx
@@ -251,7 +254,7 @@ type NodeServerEffects m
         , ChainEffect
         , State MockNodeServerChainState
         , LogMsg PABServerLogMsg
-        , Reader Client.TxSendHandle
+        , Reader (Maybe Client.TxSendHandle)
         , State AppState
         , LogMsg PABServerLogMsg
         , m]

--- a/plutus-pab/src/Cardano/Node/Types.hs
+++ b/plutus-pab/src/Cardano/Node/Types.hs
@@ -23,6 +23,7 @@ module Cardano.Node.Types
 
      -- * Effects
     , NodeServerEffects
+    , ChainSyncHandle
 
      -- *  State types
     , AppState (..)
@@ -45,6 +46,7 @@ module Cardano.Node.Types
 import Cardano.BM.Data.Tracer (ToObject (..))
 import Cardano.BM.Data.Tracer.Extras (Tagged (..), mkObjectStr)
 import Cardano.Chain (MockNodeServerChainState, fromEmulatorChainState)
+import Cardano.Protocol.Socket.Client qualified as Client
 import Cardano.Protocol.Socket.Mock.Client qualified as Client
 import Control.Lens (makeLenses, view)
 import Control.Monad.Freer.Extras.Log (LogMessage, LogMsg (..))
@@ -60,7 +62,7 @@ import Data.Time.Format.ISO8601 qualified as F
 import Data.Time.Units (Millisecond)
 import Data.Time.Units.Extra ()
 import GHC.Generics (Generic)
-import Ledger (Tx, txId)
+import Ledger (Block, Tx, txId)
 import Ledger.CardanoWallet (WalletNumber (..))
 import Ledger.TimeSlot (SlotConfig)
 import Plutus.Contract.Trace qualified as Trace
@@ -156,6 +158,10 @@ defaultPABServerConfig =
 
 instance Default PABServerConfig where
   def = defaultPABServerConfig
+
+-- | The types of handles varies based on the type of clients (mocked or
+-- real nodes) and we need a generic way of handling either type of response.
+type ChainSyncHandle = Either (Client.ChainSyncHandle Block) (Client.ChainSyncHandle Client.ChainSyncEvent)
 
 -- Logging ------------------------------------------------------------------------------------------------------------
 

--- a/plutus-pab/src/Cardano/Wallet/Mock/Handlers.hs
+++ b/plutus-pab/src/Cardano/Wallet/Mock/Handlers.hs
@@ -19,6 +19,7 @@ module Cardano.Wallet.Mock.Handlers
 
 import Cardano.BM.Data.Trace (Trace)
 import Cardano.Node.Client qualified as NodeClient
+import Cardano.Node.Types (ChainSyncHandle)
 import Cardano.Protocol.Socket.Mock.Client qualified as MockClient
 import Cardano.Wallet.Mock.Types (MultiWalletEffect (..), WalletEffects, WalletInfo (..), WalletMsg (..), Wallets,
                                   fromWalletState)
@@ -149,7 +150,7 @@ processWalletEffects ::
     (MonadIO m, MonadError ServerError m)
     => Trace IO WalletMsg -- ^ trace for logging
     -> MockClient.TxSendHandle -- ^ node client
-    -> NodeClient.ChainSyncHandle -- ^ node client
+    -> ChainSyncHandle -- ^ node client
     -> ClientEnv          -- ^ chain index client
     -> MVar Wallets   -- ^ wallets state
     -> FeeConfig
@@ -178,7 +179,7 @@ processWalletEffects trace txSendHandle chainSyncHandle chainIndexEnv mVarState 
 runWalletEffects ::
     Trace IO WalletMsg -- ^ trace for logging
     -> MockClient.TxSendHandle -- ^ node client
-    -> NodeClient.ChainSyncHandle -- ^ node client
+    -> ChainSyncHandle -- ^ node client
     -> ClientEnv -- ^ chain index client
     -> Wallets -- ^ current state
     -> FeeConfig

--- a/plutus-pab/src/Cardano/Wallet/Mock/Handlers.hs
+++ b/plutus-pab/src/Cardano/Wallet/Mock/Handlers.hs
@@ -191,7 +191,7 @@ runWalletEffects trace txSendHandle chainSyncHandle chainIndexEnv wallets feeCfg
     & interpret (LM.handleLogMsgTrace trace)
     & reinterpret2 (NodeClient.handleNodeClientClient slotCfg)
     & runReader chainSyncHandle
-    & runReader txSendHandle
+    & runReader (Just txSendHandle)
     & reinterpret ChainIndex.handleChainIndexClient
     & runReader chainIndexEnv
     & runState wallets

--- a/plutus-pab/src/Cardano/Wallet/Mock/Handlers.hs
+++ b/plutus-pab/src/Cardano/Wallet/Mock/Handlers.hs
@@ -30,7 +30,7 @@ import Control.Monad.Error (MonadError)
 import Control.Monad.Except qualified as MonadError
 import Control.Monad.Freer
 import Control.Monad.Freer.Error
-import Control.Monad.Freer.Extras
+import Control.Monad.Freer.Extras hiding (Error)
 import Control.Monad.Freer.Reader (runReader)
 import Control.Monad.Freer.State (State, evalState, get, put, runState)
 import Control.Monad.IO.Class (MonadIO, liftIO)
@@ -43,7 +43,7 @@ import Data.ByteString.Lazy.Char8 qualified as BSL8
 import Data.ByteString.Lazy.Char8 qualified as Char8
 import Data.Function ((&))
 import Data.Map qualified as Map
-import Data.Text (Text)
+import Data.Text (Text, pack)
 import Data.Text.Encoding (encodeUtf8)
 import Ledger.Ada qualified as Ada
 import Ledger.Address (PaymentPubKeyHash)
@@ -56,6 +56,7 @@ import Plutus.ChainIndex (ChainIndexQueryEffect)
 import Plutus.ChainIndex.Client qualified as ChainIndex
 import Plutus.PAB.Arbitrary ()
 import Plutus.PAB.Monitoring.Monitoring qualified as LM
+import Plutus.PAB.Types (PABError)
 import Prettyprinter (pretty)
 import Servant (ServerError (..), err400, err401, err404)
 import Servant.Client (ClientEnv)
@@ -195,6 +196,8 @@ runWalletEffects trace txSendHandle chainSyncHandle chainIndexEnv wallets feeCfg
     & reinterpret ChainIndex.handleChainIndexClient
     & runReader chainIndexEnv
     & runState wallets
+    & flip catchError logPabErrorAndRethrow
+    & handlePrettyErrors
     & interpret (LM.handleLogMsgTrace (toWalletMsg trace))
     & handleWalletApiErrors
     & handleClientErrors
@@ -203,7 +206,11 @@ runWalletEffects trace txSendHandle chainSyncHandle chainIndexEnv wallets feeCfg
         where
             handleWalletApiErrors = flip handleError (throwError . fromWalletAPIError)
             handleClientErrors = flip handleError (\e -> throwError $ err500 { errBody = Char8.pack (show e) })
+            handlePrettyErrors = flip handleError (\e -> throwError $ err500 { errBody = Char8.pack (show $ pretty e) })
             toWalletMsg = LM.convertLog ChainClientMsg
+            logPabErrorAndRethrow (e :: PABError) = do
+                logError (pack $ show $ pretty e)
+                throwError e
 
 -- | Convert Wallet errors to Servant error responses
 fromWalletAPIError :: WalletAPIError -> ServerError

--- a/plutus-pab/src/Cardano/Wallet/Mock/Server.hs
+++ b/plutus-pab/src/Cardano/Wallet/Mock/Server.hs
@@ -14,7 +14,7 @@ module Cardano.Wallet.Mock.Server
 
 import Cardano.BM.Data.Trace (Trace)
 import Cardano.ChainIndex.Types (ChainIndexUrl (ChainIndexUrl))
-import Cardano.Node.Client qualified as NodeClient
+import Cardano.Node.Types (ChainSyncHandle)
 import Cardano.Protocol.Socket.Mock.Client qualified as MockClient
 import Cardano.Wallet.Mock.API (API)
 import Cardano.Wallet.Mock.Handlers (processWalletEffects)
@@ -47,7 +47,7 @@ import Wallet.Emulator.Wallet qualified as Wallet
 
 app :: Trace IO WalletMsg
     -> MockClient.TxSendHandle
-    -> NodeClient.ChainSyncHandle
+    -> ChainSyncHandle
     -> ClientEnv
     -> MVar Wallets
     -> FeeConfig

--- a/plutus-pab/src/Cardano/Wallet/Mock/Types.hs
+++ b/plutus-pab/src/Cardano/Wallet/Mock/Types.hs
@@ -49,6 +49,7 @@ import GHC.Generics (Generic)
 import Ledger (PaymentPubKeyHash)
 import Plutus.ChainIndex (ChainIndexQueryEffect)
 import Plutus.PAB.Arbitrary ()
+import Plutus.PAB.Types (PABError)
 import Prettyprinter (Pretty (pretty), (<+>))
 import Servant (ServerError)
 import Servant.Client (ClientError)
@@ -85,6 +86,7 @@ type WalletEffects m = '[ MultiWalletEffect
                         , NodeClientEffect
                         , ChainIndexQueryEffect
                         , State Wallets
+                        , Error PABError
                         , LogMsg Text
                         , Error WalletAPIError
                         , Error ClientError

--- a/plutus-pab/src/Plutus/PAB/App.hs
+++ b/plutus-pab/src/Plutus/PAB/App.hs
@@ -34,8 +34,7 @@ import Cardano.Api.Shelley (ProtocolParameters)
 import Cardano.BM.Trace (Trace, logDebug)
 import Cardano.ChainIndex.Types qualified as ChainIndex
 import Cardano.Node.Client (handleNodeClientClient)
-import Cardano.Node.Client qualified as NodeClient
-import Cardano.Node.Types (NodeMode (AlonzoNode, MockNode),
+import Cardano.Node.Types (ChainSyncHandle, NodeMode (AlonzoNode, MockNode),
                            PABServerConfig (PABServerConfig, pscBaseUrl, pscNetworkId, pscNodeMode, pscProtocolParametersJsonPath, pscSlotConfig, pscSocketPath))
 import Cardano.Protocol.Socket.Mock.Client qualified as MockClient
 import Cardano.Wallet.LocalClient qualified as LocalWalletClient
@@ -100,7 +99,7 @@ data AppEnv a =
         , nodeClientEnv         :: ClientEnv
         , chainIndexEnv         :: ClientEnv
         , txSendHandle          :: MockClient.TxSendHandle
-        , chainSyncHandle       :: NodeClient.ChainSyncHandle
+        , chainSyncHandle       :: ChainSyncHandle
         , appConfig             :: Config
         , appTrace              :: Trace IO (PABLogMsg (Builtin a))
         , appInMemContractStore :: InMemInstances (Builtin a)
@@ -166,7 +165,7 @@ appEffectHandlers storageBackend config trace BuiltinHandler{contractHandler} =
             -- handle 'NodeClientEffect'
             flip handleError (throwError . NodeClientError)
             . interpret (Core.handleUserEnvReader @(Builtin a) @(AppEnv a))
-            . reinterpret (Core.handleMappedReader @(AppEnv a) @NodeClient.ChainSyncHandle chainSyncHandle)
+            . reinterpret (Core.handleMappedReader @(AppEnv a) @ChainSyncHandle chainSyncHandle)
             . interpret (Core.handleUserEnvReader @(Builtin a) @(AppEnv a))
             . reinterpret (Core.handleMappedReader @(AppEnv a) @MockClient.TxSendHandle txSendHandle)
             . interpret (Core.handleUserEnvReader @(Builtin a) @(AppEnv a))

--- a/plutus-pab/src/Plutus/PAB/Run/Cli.hs
+++ b/plutus-pab/src/Plutus/PAB/Run/Cli.hs
@@ -205,12 +205,13 @@ runConfigCommand contractHandler c@ConfigCommandArgs{ccaAvailability, ccaPABConf
       pure asyncId
 
 -- Run the chain-index service
-runConfigCommand _ ConfigCommandArgs{ccaTrace, ccaPABConfig=Config { nodeServerConfig, chainIndexConfig }} ChainIndex =
+runConfigCommand _ ConfigCommandArgs{ccaAvailability, ccaTrace, ccaPABConfig=Config { nodeServerConfig, chainIndexConfig }} ChainIndex =
     ChainIndex.main
         (toChainIndexLog ccaTrace)
         chainIndexConfig
         (pscSocketPath nodeServerConfig)
         (pscSlotConfig nodeServerConfig)
+        ccaAvailability
 
 -- Get the state of a contract
 runConfigCommand _ ConfigCommandArgs{ccaTrace, ccaPABConfig=Config{dbConfig}} (ContractState contractInstanceId) = do

--- a/plutus-pab/src/Plutus/PAB/Run/Cli.hs
+++ b/plutus-pab/src/Plutus/PAB/Run/Cli.hs
@@ -29,11 +29,11 @@ import Cardano.Node.Types (NodeMode (AlonzoNode, MockNode),
 import Cardano.Wallet.Mock.Server qualified as WalletServer
 import Cardano.Wallet.Mock.Types (WalletMsg)
 import Cardano.Wallet.Types (WalletConfig (LocalWalletConfig, RemoteWalletConfig))
-import Control.Concurrent (takeMVar)
+import Control.Concurrent (takeMVar, threadDelay)
 import Control.Concurrent.Async (Async, async, waitAny)
 import Control.Concurrent.Availability (Availability, available, starting)
 import Control.Concurrent.STM qualified as STM
-import Control.Monad (forM, forM_, void)
+import Control.Monad (forM, forM_, forever, void)
 import Control.Monad.Freer (Eff, LastMember, Member, interpret, runM)
 import Control.Monad.Freer.Delay (DelayEffect, delayThread, handleDelayEffect)
 import Control.Monad.Freer.Error (throwError)
@@ -133,7 +133,10 @@ runConfigCommand _ ConfigCommandArgs{ccaTrace, ccaPABConfig = Config {nodeServer
                 $ logInfo @(LM.AppMsg (Builtin a))
                 $ LM.PABMsg
                 $ LM.SCoreMsg LM.ConnectingToAlonzoNode
-            pure () -- TODO: Log message that we're connecting to the real Alonzo node
+            -- The semantics of Command(s) is that once a set of commands are
+            -- started if any finishes the entire application is terminated. We want
+            -- to prevent that by keeping the thread suspended.
+            forever $ threadDelay 1000000000
 
 -- Run PAB webserver
 runConfigCommand contractHandler ConfigCommandArgs{ccaTrace, ccaPABConfig=config@Config{pabWebserverConfig, dbConfig}, ccaAvailability, ccaStorageBackend} PABWebserver =
@@ -182,10 +185,11 @@ runConfigCommand contractHandler c@ConfigCommandArgs{ccaAvailability, ccaPABConf
     let shouldStartMocks = case pscNodeMode nodeServerConfig of
                              MockNode   -> True
                              AlonzoNode -> False
+        startedCommands  = filter (mockedServices shouldStartMocks) commands
      in void $ do
-          threads <- traverse forkCommand
-                   $ filter (mockedServices shouldStartMocks) commands
-          putStrLn "Started all commands."
+          putStrLn $ "Starting all commands (" <> show startedCommands <> ")."
+          threads <- traverse forkCommand startedCommands
+          putStrLn $ "Started all commands (" <> show startedCommands <> ")."
           waitAny threads
   where
     mockedServices :: Bool -> ConfigCommand -> Bool

--- a/plutus-pab/src/Plutus/PAB/Types.hs
+++ b/plutus-pab/src/Plutus/PAB/Types.hs
@@ -59,6 +59,7 @@ data PABError
     | AesonDecodingError Text Text
     | MigrationNotDoneError Text
     | RemoteWalletWithMockNodeError
+    | TxSenderNotAvailable
     deriving stock (Show, Eq, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
@@ -88,6 +89,7 @@ instance Pretty PABError where
                                    <> "Did you forget to run the 'migrate' command ?"
                                    <+> "(ex. 'plutus-pab-migrate' or 'plutus-pab-examples --config <CONFIG_FILE> migrate')"
         RemoteWalletWithMockNodeError   -> "The remote wallet can't be used with the mock node."
+        TxSenderNotAvailable         -> "Cannot send a transaction when connected to the real node."
 
 data DbConfig =
     DbConfig


### PR DESCRIPTION
This fixes a couple of issues:

A. When starting all servers the mocked chain index and wallet are also started. However, they can only use the mocked versions of the client which requires a mocked server running. When these clients try to connect to the Alonzo node the versions don't match causing errors.

* Solution: I removed the mocked services from the list of commands to run if we are connecting to an alonzo node and added a list of services started to the command's output (to point out that we are not even trying to start those services in those circumstances).

B. When starting the PAB server the mocked chain is always used to synchronise the slot number, which causes the same connection errors when trying to connect to the alonzo node.

* Solution: I wrote a function that runs chain sync with the proper client according to the way the PAB is configured.
* Note: This *does not* support resuming right now. It's not clear what a solution to this problem is (and indeed, if it even is a problem). 

C. The `StartNode` command, when using the Alonzo node, exists after logging some information. The semantics of commands is that if any command exits, they all do, which caused the PAB to always exit early. This bug was not found, due to bug (E) but became apparent once I stoped running the chain index.

* Solution: Make the `StartNode` command wait indefinitely when using the Alonzo node.

D. The `TxSender` thread is always started even though it is only used when the mock node is running. Even though nobody sent any transactions if the real node was configured the thread would still try to connect to the node and fail due to wrong versioning (again, mocked vs real versioning missmatch).

* Solution: Make it optional and only start it when in mocked mode. Note that while the `TxSender` is optional in the code running the executable, it should not be in the mocked node server and wallet where it is required. This is why i had to inject some `Just txHandler`s here and there.

** At this point we are not getting any more connection errors, and everything runs smoothly. However... **

E. The PAB commands infrastructure uses a `MVar` based semaphore that ensures that two commands are not ran at the same time by using the `ccaAvailability` field which is filled when a command has finished processing and is cleared by the `ForkCommand` (thus waiting for completion of the previous command). However, the ChainIndex command never places that `MVar` back blocking the execution of the rest of the commands. As long as the ChainIndex is the last command ran this is not apparent (as it was supposed to block anyway), but when I skipped this command the PAB would exit early (due to (C)).

* Solution: Make ChainIndex set `ccaAvailability` when it finished initializing.

Some refactoring:
* Moved ChainSyncHandle from Cardano.Node.Client to Cardano.Node.Types

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
