### PR TITLE
Allow playground to be visible on local network

### DIFF
--- a/plutus-playground-client/package.json
+++ b/plutus-playground-client/package.json
@@ -6,7 +6,7 @@
     "build:spago:watch": "spago build --purs-args \"--strict --censor-lib --stash --is-lib=generated --is-lib=.spago\" --watch --clear-screen",
     "build:webpack": "webpack-cli serve --progress --inline --hot --mode=development --node-env=development",
     "build:webpack:prod": "webpack --progress --bail --mode=production --node-env=production",
-    "build:webpack:dev": "webpack-cli serve --progress --inline --hot --mode=development --node-env=development",
+    "build:webpack:dev": "webpack-cli serve --progress --inline --hot --mode=development --node-env=development --host 0.0.0.0",
     "install:spago": "spago install",
     "docs": "spago docs",
     "repl": "spago repl",


### PR DESCRIPTION
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested

I'm in the plutus pioneers cohort 3 and a lot of students have had trouble getting plutus apps to run on their local network due to Linux's default host restrictions. Adding this simple flag to the package.json dev server makes the local dev environment much easier to work with, especially from inside of docker containers.

Kindly review / approve this minor but important change for Plutus developers