### PR TITLE
Added a `start-testnet-node` script available from the nix-shell.

### DIFF
--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -126,6 +126,32 @@ let
     });
   };
 
+  start-testnet-node = pkgs.writeShellScriptBin "start-testnet-node" ''
+    #!/usr/bin/env bash
+
+    NETWORK="testnet"
+    FILES=("config.json" "byron-genesis.json" "shelley-genesis.json" "alonzo-genesis.json" "topology.json")
+    OUTPUT_DIR="/tmp/cardano-testnet"
+
+    mkdir -p $OUTPUT_DIR
+
+    for file in "''${FILES[@]}";
+    do
+      FNAME=$NETWORK"-"$file
+      if [ ! -f $OUTPUT_DIR/"$FNAME" ]
+      then
+        curl -s https://hydra.iohk.io/build/7654130/download/1/"$FNAME" > $OUTPUT_DIR/"$FNAME"
+      fi
+    done
+
+    cardano-node run \
+        --config $OUTPUT_DIR/$NETWORK-config.json \
+        --topology $OUTPUT_DIR/$NETWORK-topology.json \
+        --database-path $OUTPUT_DIR/db \
+        --socket-path $OUTPUT_DIR/node.sock \
+        --port 3003
+  '';
+
 in
 {
   inherit sphinx-markdown-tables sphinxemoji sphinxcontrib-haddock;
@@ -136,4 +162,5 @@ in
   inherit web-ghc;
   inherit easyPS plutus-haddock-combined;
   inherit lib;
+  inherit start-testnet-node;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -119,6 +119,7 @@ let
     updateMaterialized
     updateClientDeps
     docs.build-and-serve-docs
+    start-testnet-node
   ]);
 
 in


### PR DESCRIPTION
Scripts which downloads the testnet configs, stores them in `/tmp`, and runs a testnet node locally. The node `db` is also stored in `tmp`. 

Mainly allows to start the testnet node from anywhere inside `plutus-apps` folder.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
