### PR TITLE
Remove note about Nix sandbox on Macos

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -170,19 +170,6 @@ nix = {
 };
 ----
 
-
-=== Nix on macOS
-
-Nix on macOS can be a bit tricky. In particular, sandboxing is disabled by default, which can lead to strange failures.
-
-These days it should be safe to turn on sandboxing on macOS with a few exceptions. Consider setting the following Nix settings, in the same way as in xref:iohk-binary-cache[previous section]:
-
-----
-sandbox = true
-extra-sandbox-paths = /System/Library/Frameworks /System/Library/PrivateFrameworks /usr/lib /private/tmp /private/var/tmp /usr/bin/env
-----
-
-
 [[nix-build-attributes]]
 === Which attributes to use to build different artifacts
 


### PR DESCRIPTION
According to Moritz this is bad advice and it's better to leave things
with the default settings (sandbox off).