### PR TITLE
SCP-3305 SCP-3263 fixed Ledger.Constraints.Offchain.updateUtxoIndex

### DIFF
--- a/playground-common/src/PSGenerator/Common.hs
+++ b/playground-common/src/PSGenerator/Common.hs
@@ -22,7 +22,7 @@ import Ledger (Address, BlockId, ChainIndexTxOut, DatumHash, MintingPolicy, OnCh
                PubKey, PubKeyHash, RedeemerPtr, ScriptTag, Signature, StakePubKey, StakePubKeyHash, StakeValidator, Tx,
                TxId, TxIn, TxInType, TxOut, TxOutRef, TxOutTx, UtxoIndex, ValidationPhase, Validator)
 import Ledger.Ada (Ada)
-import Ledger.Constraints.OffChain (MkTxError, ScriptOutput, UnbalancedTx)
+import Ledger.Constraints.OffChain (MkTxError, UnbalancedTx)
 import Ledger.Credential (Credential, StakingCredential)
 import Ledger.DCert (DCert)
 import Ledger.Index (ExCPU, ExMemory, ScriptType, ScriptValidationEvent, ValidationError)
@@ -405,7 +405,6 @@ ledgerTypes =
     , equal . genericShow . argonaut $ mkSumType @WriteBalancedTxResponse
     , equal . genericShow . argonaut $ mkSumType @ActiveEndpoint
     , equal . genericShow . argonaut $ mkSumType @UnbalancedTx
-    , equal . genericShow . argonaut $ mkSumType @ScriptOutput
     , order . equal . genericShow . argonaut $ mkSumType @TxValidity
     , equal . genericShow . argonaut $ mkSumType @TxOutState
     , equal . genericShow . argonaut $ mkSumType @(RollbackState A)

--- a/plutus-contract/src/Wallet/Emulator/Wallet.hs
+++ b/plutus-contract/src/Wallet/Emulator/Wallet.hs
@@ -326,7 +326,7 @@ validateTxAndAddFees feeCfg slotCfg ownTxOuts utx = do
     -- Balance and sign just for validation
     tx <- handleBalanceTx ownTxOuts utx
     signedTx <- handleAddSignature tx
-    let utxoIndex        = Ledger.UtxoIndex $ fmap Ledger.toTxOut $ (U.fromScriptOutput <$> unBalancedTxUtxoIndex utx) <> ownTxOuts
+    let utxoIndex        = Ledger.UtxoIndex $ unBalancedTxUtxoIndex utx <> fmap Ledger.toTxOut ownTxOuts
         ((e, _), events) = Ledger.runValidation (Ledger.validateTransactionOffChain signedTx) (Ledger.ValidationCtx utxoIndex slotCfg)
     for_ e $ \(phase, ve) -> do
         logWarn $ ValidationFailed phase (Ledger.txId tx) tx ve events

--- a/plutus-pab-executables/demo/pab-nami/client/generated/Ledger/Constraints/OffChain.purs
+++ b/plutus-pab-executables/demo/pab-nami/client/generated/Ledger/Constraints/OffChain.purs
@@ -23,8 +23,7 @@ import Ledger.Typed.Tx (ConnectionError)
 import Plutus.V1.Ledger.Interval (Interval)
 import Plutus.V1.Ledger.Scripts (DatumHash)
 import Plutus.V1.Ledger.Time (POSIXTime)
-import Plutus.V1.Ledger.Tx (Tx, TxOutRef)
-import Plutus.V1.Ledger.Value (Value)
+import Plutus.V1.Ledger.Tx (Tx, TxOut, TxOutRef)
 import Type.Proxy (Proxy(Proxy))
 import Data.Argonaut.Decode.Aeson as D
 import Data.Argonaut.Encode.Aeson as E
@@ -132,50 +131,10 @@ _CannotSatisfyAny = prism' (const CannotSatisfyAny) case _ of
 
 --------------------------------------------------------------------------------
 
-newtype ScriptOutput = ScriptOutput
-  { scriptOutputValidatorHash :: String
-  , scriptOutputValue :: Value
-  , scriptOutputDatumHash :: DatumHash
-  }
-
-derive instance Eq ScriptOutput
-
-instance Show ScriptOutput where
-  show a = genericShow a
-
-instance EncodeJson ScriptOutput where
-  encodeJson = defer \_ -> E.encode $ unwrap >$<
-    ( E.record
-        { scriptOutputValidatorHash: E.value :: _ String
-        , scriptOutputValue: E.value :: _ Value
-        , scriptOutputDatumHash: E.value :: _ DatumHash
-        }
-    )
-
-instance DecodeJson ScriptOutput where
-  decodeJson = defer \_ -> D.decode $
-    ( ScriptOutput <$> D.record "ScriptOutput"
-        { scriptOutputValidatorHash: D.value :: _ String
-        , scriptOutputValue: D.value :: _ Value
-        , scriptOutputDatumHash: D.value :: _ DatumHash
-        }
-    )
-
-derive instance Generic ScriptOutput _
-
-derive instance Newtype ScriptOutput _
-
---------------------------------------------------------------------------------
-
-_ScriptOutput :: Iso' ScriptOutput { scriptOutputValidatorHash :: String, scriptOutputValue :: Value, scriptOutputDatumHash :: DatumHash }
-_ScriptOutput = _Newtype
-
---------------------------------------------------------------------------------
-
 newtype UnbalancedTx = UnbalancedTx
   { unBalancedTxTx :: Tx
   , unBalancedTxRequiredSignatories :: Map PaymentPubKeyHash (Maybe PaymentPubKey)
-  , unBalancedTxUtxoIndex :: Map TxOutRef ScriptOutput
+  , unBalancedTxUtxoIndex :: Map TxOutRef TxOut
   , unBalancedTxValidityTimeRange :: Interval POSIXTime
   }
 
@@ -189,7 +148,7 @@ instance EncodeJson UnbalancedTx where
     ( E.record
         { unBalancedTxTx: E.value :: _ Tx
         , unBalancedTxRequiredSignatories: (E.dictionary E.value (E.maybe E.value)) :: _ (Map PaymentPubKeyHash (Maybe PaymentPubKey))
-        , unBalancedTxUtxoIndex: (E.dictionary E.value E.value) :: _ (Map TxOutRef ScriptOutput)
+        , unBalancedTxUtxoIndex: (E.dictionary E.value E.value) :: _ (Map TxOutRef TxOut)
         , unBalancedTxValidityTimeRange: E.value :: _ (Interval POSIXTime)
         }
     )
@@ -199,7 +158,7 @@ instance DecodeJson UnbalancedTx where
     ( UnbalancedTx <$> D.record "UnbalancedTx"
         { unBalancedTxTx: D.value :: _ Tx
         , unBalancedTxRequiredSignatories: (D.dictionary D.value (D.maybe D.value)) :: _ (Map PaymentPubKeyHash (Maybe PaymentPubKey))
-        , unBalancedTxUtxoIndex: (D.dictionary D.value D.value) :: _ (Map TxOutRef ScriptOutput)
+        , unBalancedTxUtxoIndex: (D.dictionary D.value D.value) :: _ (Map TxOutRef TxOut)
         , unBalancedTxValidityTimeRange: D.value :: _ (Interval POSIXTime)
         }
     )
@@ -210,5 +169,5 @@ derive instance Newtype UnbalancedTx _
 
 --------------------------------------------------------------------------------
 
-_UnbalancedTx :: Iso' UnbalancedTx { unBalancedTxTx :: Tx, unBalancedTxRequiredSignatories :: Map PaymentPubKeyHash (Maybe PaymentPubKey), unBalancedTxUtxoIndex :: Map TxOutRef ScriptOutput, unBalancedTxValidityTimeRange :: Interval POSIXTime }
+_UnbalancedTx :: Iso' UnbalancedTx { unBalancedTxTx :: Tx, unBalancedTxRequiredSignatories :: Map PaymentPubKeyHash (Maybe PaymentPubKey), unBalancedTxUtxoIndex :: Map TxOutRef TxOut, unBalancedTxValidityTimeRange :: Interval POSIXTime }
 _UnbalancedTx = _Newtype

--- a/plutus-playground-client/generated/Ledger/Constraints/OffChain.purs
+++ b/plutus-playground-client/generated/Ledger/Constraints/OffChain.purs
@@ -23,8 +23,7 @@ import Ledger.Typed.Tx (ConnectionError)
 import Plutus.V1.Ledger.Interval (Interval)
 import Plutus.V1.Ledger.Scripts (DatumHash)
 import Plutus.V1.Ledger.Time (POSIXTime)
-import Plutus.V1.Ledger.Tx (Tx, TxOutRef)
-import Plutus.V1.Ledger.Value (Value)
+import Plutus.V1.Ledger.Tx (Tx, TxOut, TxOutRef)
 import Type.Proxy (Proxy(Proxy))
 import Data.Argonaut.Decode.Aeson as D
 import Data.Argonaut.Encode.Aeson as E
@@ -132,50 +131,10 @@ _CannotSatisfyAny = prism' (const CannotSatisfyAny) case _ of
 
 --------------------------------------------------------------------------------
 
-newtype ScriptOutput = ScriptOutput
-  { scriptOutputValidatorHash :: String
-  , scriptOutputValue :: Value
-  , scriptOutputDatumHash :: DatumHash
-  }
-
-derive instance Eq ScriptOutput
-
-instance Show ScriptOutput where
-  show a = genericShow a
-
-instance EncodeJson ScriptOutput where
-  encodeJson = defer \_ -> E.encode $ unwrap >$<
-    ( E.record
-        { scriptOutputValidatorHash: E.value :: _ String
-        , scriptOutputValue: E.value :: _ Value
-        , scriptOutputDatumHash: E.value :: _ DatumHash
-        }
-    )
-
-instance DecodeJson ScriptOutput where
-  decodeJson = defer \_ -> D.decode $
-    ( ScriptOutput <$> D.record "ScriptOutput"
-        { scriptOutputValidatorHash: D.value :: _ String
-        , scriptOutputValue: D.value :: _ Value
-        , scriptOutputDatumHash: D.value :: _ DatumHash
-        }
-    )
-
-derive instance Generic ScriptOutput _
-
-derive instance Newtype ScriptOutput _
-
---------------------------------------------------------------------------------
-
-_ScriptOutput :: Iso' ScriptOutput { scriptOutputValidatorHash :: String, scriptOutputValue :: Value, scriptOutputDatumHash :: DatumHash }
-_ScriptOutput = _Newtype
-
---------------------------------------------------------------------------------
-
 newtype UnbalancedTx = UnbalancedTx
   { unBalancedTxTx :: Tx
   , unBalancedTxRequiredSignatories :: Map PaymentPubKeyHash (Maybe PaymentPubKey)
-  , unBalancedTxUtxoIndex :: Map TxOutRef ScriptOutput
+  , unBalancedTxUtxoIndex :: Map TxOutRef TxOut
   , unBalancedTxValidityTimeRange :: Interval POSIXTime
   }
 
@@ -189,7 +148,7 @@ instance EncodeJson UnbalancedTx where
     ( E.record
         { unBalancedTxTx: E.value :: _ Tx
         , unBalancedTxRequiredSignatories: (E.dictionary E.value (E.maybe E.value)) :: _ (Map PaymentPubKeyHash (Maybe PaymentPubKey))
-        , unBalancedTxUtxoIndex: (E.dictionary E.value E.value) :: _ (Map TxOutRef ScriptOutput)
+        , unBalancedTxUtxoIndex: (E.dictionary E.value E.value) :: _ (Map TxOutRef TxOut)
         , unBalancedTxValidityTimeRange: E.value :: _ (Interval POSIXTime)
         }
     )
@@ -199,7 +158,7 @@ instance DecodeJson UnbalancedTx where
     ( UnbalancedTx <$> D.record "UnbalancedTx"
         { unBalancedTxTx: D.value :: _ Tx
         , unBalancedTxRequiredSignatories: (D.dictionary D.value (D.maybe D.value)) :: _ (Map PaymentPubKeyHash (Maybe PaymentPubKey))
-        , unBalancedTxUtxoIndex: (D.dictionary D.value D.value) :: _ (Map TxOutRef ScriptOutput)
+        , unBalancedTxUtxoIndex: (D.dictionary D.value D.value) :: _ (Map TxOutRef TxOut)
         , unBalancedTxValidityTimeRange: D.value :: _ (Interval POSIXTime)
         }
     )
@@ -210,5 +169,5 @@ derive instance Newtype UnbalancedTx _
 
 --------------------------------------------------------------------------------
 
-_UnbalancedTx :: Iso' UnbalancedTx { unBalancedTxTx :: Tx, unBalancedTxRequiredSignatories :: Map PaymentPubKeyHash (Maybe PaymentPubKey), unBalancedTxUtxoIndex :: Map TxOutRef ScriptOutput, unBalancedTxValidityTimeRange :: Interval POSIXTime }
+_UnbalancedTx :: Iso' UnbalancedTx { unBalancedTxTx :: Tx, unBalancedTxRequiredSignatories :: Map PaymentPubKeyHash (Maybe PaymentPubKey), unBalancedTxUtxoIndex :: Map TxOutRef TxOut, unBalancedTxValidityTimeRange :: Interval POSIXTime }
 _UnbalancedTx = _Newtype

--- a/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
@@ -176,13 +176,13 @@ Slot 20: W872cb83: Balancing an unbalanced transaction:
                      Utxo index:
                        ( 1dc8c21dc6a9ae5cecd57646a344745dba3d2d9929e30498c7da36f0a8ff0c78!1
                        , - Value (Map [(,Map [("",10000000)])]) addressed to
-                           9fe341a3110281ecdbcf3d79ce1c2d95f6afa1452377e318e610b586 )
+                           ScriptCredential: 9fe341a3110281ecdbcf3d79ce1c2d95f6afa1452377e318e610b586 (no staking credential) )
                        ( 3885731ef1d31f92492628bdb6982c22de9af5eb4286c4cde47c6f2f62156eea!1
                        , - Value (Map [(,Map [("",10000000)])]) addressed to
-                           9fe341a3110281ecdbcf3d79ce1c2d95f6afa1452377e318e610b586 )
+                           ScriptCredential: 9fe341a3110281ecdbcf3d79ce1c2d95f6afa1452377e318e610b586 (no staking credential) )
                        ( d90b088b39ea27cd845200fc4242f7aa048eaba5dd5f33ff0757ee5bb22d0ff9!1
                        , - Value (Map [(,Map [("",2500000)])]) addressed to
-                           9fe341a3110281ecdbcf3d79ce1c2d95f6afa1452377e318e610b586 )
+                           ScriptCredential: 9fe341a3110281ecdbcf3d79ce1c2d95f6afa1452377e318e610b586 (no staking credential) )
                      Validity range:
                        [ POSIXTime 1596059111000 , POSIXTime 1596059120999 ]
 Slot 20: W872cb83: Finished balancing:


### PR DESCRIPTION
Prior to this commit, `Ledger.Constraints.Offchain.updateUtxoIndex` would discard lookups for inputs that aren't script outputs. However, sometimes it is necessary to include particular public-key `TxIn`s in a transaction, via `Plutus.Contract.Wallet.ExportTx.lookups`: a good example of this is when a `Plutus.Contract.Currency.OneShotCurrency` needs to consume a specified `UTxO` in its minting policy. Even though `Plutus.Constraints.Tx.mustSpendPubKeyOutput` adds a public-key input to the lookups, `updateUtxoIndex` discards that, with the result that it is only by chance that `cardano-wallet` would select that necessary input for the balanced transaction and provide it to Plutus validators. (Note that `cardano-wallet` does not automatically provide the `TxIn` in the partially constructed transaction to validators: it only provides `Cardano.Wallet.PartialTx.inputs` and the inputs it has semi-randomly chosen.) The consequence of all of this is that scripts that require a particular input will randomly fail during balancing in wallets with more than one UTxO.

This fix simply adds public-key inputs to the type `Ledger.Constraints.OffChain.ScriptOutput` so that it can also hold public-key inputs. (There might be a more descriptive name than `ScriptOutput` now.) It makes minor adjustments to the chain of functions that pass this into an unbalanced transaction before it is sent to `cardano-wallet`.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
