### PR TITLE
SCP-3367: PAB CLI for easing the starting of PAB + components

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -63,6 +63,10 @@ rec {
     inherit haskell;
   });
 
+  pab-cli = plutus-apps.haskell.packages.plutus-pab-executables.components.exes.pab-cli;
+
+  plutus-chain-index = plutus-apps.haskell.packages.plutus-chain-index.components.exes.plutus-chain-index;
+
   tests = import ./nix/tests/default.nix {
     inherit pkgs docs;
     inherit (plutus-apps.lib) gitignore-nix;

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab-executables.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab-executables.nix
@@ -40,9 +40,7 @@
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
           (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
-          (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
           (hsPkgs."servant-purescript" or (errorHandler.buildDepError "servant-purescript"))
-          (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           ];
         buildable = true;
@@ -272,6 +270,39 @@
           hsSourceDirs = [ "demo/pab-nami/pab/app" ];
           mainPath = [
             "Generator.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
+        "pab-cli" = {
+          depends = [
+            (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
+            (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."cardano-ledger-shelley" or (errorHandler.buildDepError "cardano-ledger-shelley"))
+            (hsPkgs."ouroboros-consensus-shelley" or (errorHandler.buildDepError "ouroboros-consensus-shelley"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."docopt" or (errorHandler.buildDepError "docopt"))
+            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+            (hsPkgs."process" or (errorHandler.buildDepError "process"))
+            (hsPkgs."req" or (errorHandler.buildDepError "req"))
+            (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
+            (hsPkgs."MissingH" or (errorHandler.buildDepError "MissingH"))
+            ];
+          buildable = true;
+          modules = [ "App" "CommandParser" "Types" ];
+          hsSourceDirs = [ "pab-cli" ];
+          mainPath = [
+            "Main.hs"
             ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
           };
         };

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -5,6 +5,8 @@
         "partial-order".revision = (((hackage."partial-order")."0.2.0.0").revisions).default;
         "partial-order".flags.extra-instances = true;
         "charset".revision = (((hackage."charset")."0.3.9").revisions).default;
+        "req".revision = (((hackage."req")."3.9.2").revisions).default;
+        "req".flags.dev = false;
         "insert-ordered-containers".revision = (((hackage."insert-ordered-containers")."0.2.5.1").revisions).default;
         "size-based".revision = (((hackage."size-based")."0.1.2.0").revisions).default;
         "wcwidth".revision = (((hackage."wcwidth")."0.0.2").revisions).default;
@@ -24,6 +26,8 @@
         "http-media".revision = (((hackage."http-media")."0.8.0.0").revisions).default;
         "tf-random".revision = (((hackage."tf-random")."0.5").revisions).default;
         "servant-client".revision = (((hackage."servant-client")."0.18.3").revisions).default;
+        "hslogger".revision = (((hackage."hslogger")."1.3.1.0").revisions).default;
+        "hslogger".flags.network--gt-3_0_0 = true;
         "mmorph".revision = (((hackage."mmorph")."1.1.5").revisions).default;
         "natural-transformation".revision = (((hackage."natural-transformation")."0.4").revisions).default;
         "blaze-textual".revision = (((hackage."blaze-textual")."0.2.2.1").revisions).default;
@@ -34,6 +38,7 @@
         "generics-sop".revision = (((hackage."generics-sop")."0.5.1.0").revisions).default;
         "abstract-deque".revision = (((hackage."abstract-deque")."0.3").revisions).default;
         "abstract-deque".flags.usecas = false;
+        "network-bsd".revision = (((hackage."network-bsd")."2.8.1.0").revisions).default;
         "streaming".revision = (((hackage."streaming")."0.2.3.1").revisions).default;
         "old-time".revision = (((hackage."old-time")."1.1.0.3").revisions).default;
         "http-conduit".revision = (((hackage."http-conduit")."2.3.8").revisions).default;
@@ -57,6 +62,8 @@
         "ghc-paths".revision = (((hackage."ghc-paths")."0.1.0.12").revisions).default;
         "servant".revision = (((hackage."servant")."0.18.3").revisions).default;
         "asn1-encoding".revision = (((hackage."asn1-encoding")."0.9.6").revisions).default;
+        "MissingH".revision = (((hackage."MissingH")."1.4.3.0").revisions).default;
+        "MissingH".flags.network--ge-3_0_0 = true;
         "pretty".revision = (((hackage."pretty")."1.1.3.6").revisions).default;
         "network-uri".revision = (((hackage."network-uri")."2.6.4.1").revisions).default;
         "haskell-src-exts".revision = (((hackage."haskell-src-exts")."1.23.1").revisions).default;
@@ -87,6 +94,7 @@
         "text".revision = (((hackage."text")."1.2.4.1").revisions).default;
         "base".revision = (((hackage."base")."4.14.1.0").revisions).default;
         "microlens-mtl".revision = (((hackage."microlens-mtl")."0.2.0.1").revisions).default;
+        "RSA".revision = (((hackage."RSA")."2.4.1").revisions).default;
         "word8".revision = (((hackage."word8")."0.1.3").revisions).default;
         "lift-type".revision = (((hackage."lift-type")."0.1.0.1").revisions).default;
         "hourglass".revision = (((hackage."hourglass")."0.2.12").revisions).default;
@@ -359,6 +367,8 @@
         "mtl-compat".flags.two-point-one = false;
         "mtl-compat".flags.two-point-two = false;
         "command".revision = (((hackage."command")."0.1.1").revisions).default;
+        "modern-uri".revision = (((hackage."modern-uri")."0.3.4.2").revisions).default;
+        "modern-uri".flags.dev = false;
         "concurrent-output".revision = (((hackage."concurrent-output")."1.10.14").revisions).default;
         "sop-core".revision = (((hackage."sop-core")."0.5.0.2").revisions).default;
         "abstract-par".revision = (((hackage."abstract-par")."0.3.3").revisions).default;
@@ -445,6 +455,7 @@
         "reflection".flags.template-haskell = true;
         "reflection".flags.slow = false;
         "hspec-discover".revision = (((hackage."hspec-discover")."2.9.4").revisions).default;
+        "authenticate-oauth".revision = (((hackage."authenticate-oauth")."1.7").revisions).default;
         "pretty-show".revision = (((hackage."pretty-show")."1.10").revisions).default;
         "template-haskell".revision = (((hackage."template-haskell")."2.16.0.0").revisions).default;
         "tasty-golden".revision = (((hackage."tasty-golden")."2.3.5").revisions).default;
@@ -489,6 +500,9 @@
         "barbies".revision = (((hackage."barbies")."2.0.3.1").revisions).default;
         "persistent-template".revision = (((hackage."persistent-template")."2.12.0.0").revisions).default;
         "syb".revision = (((hackage."syb")."0.7.2.1").revisions).default;
+        "docopt".revision = (((hackage."docopt")."0.7.0.7").revisions).default;
+        "docopt".flags.template-haskell = true;
+        "crypto-pubkey-types".revision = (((hackage."crypto-pubkey-types")."0.4.3").revisions).default;
         "zlib".revision = (((hackage."zlib")."0.6.2.3").revisions).default;
         "zlib".flags.non-blocking-ffi = false;
         "zlib".flags.pkg-config = false;
@@ -569,6 +583,8 @@
         "SHA".flags.exe = false;
         "fmlist".revision = (((hackage."fmlist")."0.9.4").revisions).default;
         "stm".revision = (((hackage."stm")."2.5.0.0").revisions).default;
+        "crypto-api".revision = (((hackage."crypto-api")."0.13.3").revisions).default;
+        "crypto-api".flags.all_cpolys = false;
         "warp".revision = (((hackage."warp")."3.3.18").revisions).default;
         "warp".flags.network-bytestring = false;
         "warp".flags.allow-sendfilefd = true;
@@ -1121,6 +1137,7 @@
           "fmlist".components.library.planned = lib.mkOverride 900 true;
           "text-conversions".components.library.planned = lib.mkOverride 900 true;
           "contravariant".components.library.planned = lib.mkOverride 900 true;
+          "crypto-pubkey-types".components.library.planned = lib.mkOverride 900 true;
           "microlens-th".components.library.planned = lib.mkOverride 900 true;
           "extra".components.library.planned = lib.mkOverride 900 true;
           "barbies".components.library.planned = lib.mkOverride 900 true;
@@ -1178,6 +1195,7 @@
           "haskell-src-exts".components.library.planned = lib.mkOverride 900 true;
           "text-short".components.library.planned = lib.mkOverride 900 true;
           "plutus-pab-executables".components.exes."plutus-uniswap".planned = lib.mkOverride 900 true;
+          "MissingH".components.library.planned = lib.mkOverride 900 true;
           "assoc".components.library.planned = lib.mkOverride 900 true;
           "process".components.library.planned = lib.mkOverride 900 true;
           "fmt".components.library.planned = lib.mkOverride 900 true;
@@ -1198,9 +1216,11 @@
           "prettyprinter".components.library.planned = lib.mkOverride 900 true;
           "plutus-chain-index-core".components.library.planned = lib.mkOverride 900 true;
           "cardano-ledger-core".components.library.planned = lib.mkOverride 900 true;
+          "docopt".components.library.planned = lib.mkOverride 900 true;
           "streaming".components.library.planned = lib.mkOverride 900 true;
           "monoidal-containers".components.library.planned = lib.mkOverride 900 true;
           "zlib".components.library.planned = lib.mkOverride 900 true;
+          "authenticate-oauth".components.library.planned = lib.mkOverride 900 true;
           "transformers-except".components.library.planned = lib.mkOverride 900 true;
           "cardano-prelude-test".components.library.planned = lib.mkOverride 900 true;
           "libyaml".components.library.planned = lib.mkOverride 900 true;
@@ -1260,6 +1280,7 @@
           "mtl-compat".components.library.planned = lib.mkOverride 900 true;
           "cardano-crypto-test".components.library.planned = lib.mkOverride 900 true;
           "erf".components.library.planned = lib.mkOverride 900 true;
+          "modern-uri".components.library.planned = lib.mkOverride 900 true;
           "set-algebra".components.library.planned = lib.mkOverride 900 true;
           "dbvar".components.library.planned = lib.mkOverride 900 true;
           "unliftio".components.library.planned = lib.mkOverride 900 true;
@@ -1283,6 +1304,7 @@
           "openapi3".components.library.planned = lib.mkOverride 900 true;
           "semigroupoids".components.setup.planned = lib.mkOverride 900 true;
           "async".components.library.planned = lib.mkOverride 900 true;
+          "hslogger".components.library.planned = lib.mkOverride 900 true;
           "microlens-mtl".components.library.planned = lib.mkOverride 900 true;
           "async-timer".components.library.planned = lib.mkOverride 900 true;
           "size-based".components.library.planned = lib.mkOverride 900 true;
@@ -1350,6 +1372,7 @@
           "wcwidth".components.library.planned = lib.mkOverride 900 true;
           "QuickCheck".components.library.planned = lib.mkOverride 900 true;
           "quickcheck-dynamic".components.library.planned = lib.mkOverride 900 true;
+          "network-bsd".components.library.planned = lib.mkOverride 900 true;
           "canonical-json".components.library.planned = lib.mkOverride 900 true;
           "ouroboros-network-framework".components.library.planned = lib.mkOverride 900 true;
           "th-extras".components.library.planned = lib.mkOverride 900 true;
@@ -1367,6 +1390,7 @@
           "monoidal-synchronisation".components.library.planned = lib.mkOverride 900 true;
           "filelock".components.library.planned = lib.mkOverride 900 true;
           "generic-arbitrary".components.library.planned = lib.mkOverride 900 true;
+          "req".components.library.planned = lib.mkOverride 900 true;
           "stm-chans".components.library.planned = lib.mkOverride 900 true;
           "compact-map".components.library.planned = lib.mkOverride 900 true;
           "tracer-transformers".components.library.planned = lib.mkOverride 900 true;
@@ -1448,6 +1472,7 @@
           "wai-websockets".components.exes."wai-websockets-example".planned = lib.mkOverride 900 true;
           "beam-migrate".components.library.planned = lib.mkOverride 900 true;
           "flat".components.library.planned = lib.mkOverride 900 true;
+          "RSA".components.library.planned = lib.mkOverride 900 true;
           "persistent-sqlite".components.library.planned = lib.mkOverride 900 true;
           "unbounded-delays".components.library.planned = lib.mkOverride 900 true;
           "web-ghc".components.exes."web-ghc-server".planned = lib.mkOverride 900 true;
@@ -1626,6 +1651,7 @@
           "websockets".components.library.planned = lib.mkOverride 900 true;
           "x509-store".components.library.planned = lib.mkOverride 900 true;
           "Win32-network".components.exes."named-pipe-demo".planned = lib.mkOverride 900 true;
+          "plutus-pab-executables".components.exes."pab-cli".planned = lib.mkOverride 900 true;
           "void".components.library.planned = lib.mkOverride 900 true;
           "beam-core".components.library.planned = lib.mkOverride 900 true;
           "text-class".components.library.planned = lib.mkOverride 900 true;
@@ -1636,6 +1662,7 @@
           "Only".components.library.planned = lib.mkOverride 900 true;
           "cryptohash-sha1".components.library.planned = lib.mkOverride 900 true;
           "exact-combinatorics".components.library.planned = lib.mkOverride 900 true;
+          "crypto-api".components.library.planned = lib.mkOverride 900 true;
           "non-integral".components.library.planned = lib.mkOverride 900 true;
           "testing-type-modifiers".components.library.planned = lib.mkOverride 900 true;
           };

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab-executables.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab-executables.nix
@@ -40,9 +40,7 @@
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
           (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
-          (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
           (hsPkgs."servant-purescript" or (errorHandler.buildDepError "servant-purescript"))
-          (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           ];
         buildable = true;
@@ -272,6 +270,39 @@
           hsSourceDirs = [ "demo/pab-nami/pab/app" ];
           mainPath = [
             "Generator.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
+        "pab-cli" = {
+          depends = [
+            (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
+            (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."cardano-ledger-shelley" or (errorHandler.buildDepError "cardano-ledger-shelley"))
+            (hsPkgs."ouroboros-consensus-shelley" or (errorHandler.buildDepError "ouroboros-consensus-shelley"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."docopt" or (errorHandler.buildDepError "docopt"))
+            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+            (hsPkgs."process" or (errorHandler.buildDepError "process"))
+            (hsPkgs."req" or (errorHandler.buildDepError "req"))
+            (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
+            (hsPkgs."MissingH" or (errorHandler.buildDepError "MissingH"))
+            ];
+          buildable = true;
+          modules = [ "App" "CommandParser" "Types" ];
+          hsSourceDirs = [ "pab-cli" ];
+          mainPath = [
+            "Main.hs"
             ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
           };
         };

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -5,6 +5,8 @@
         "partial-order".revision = (((hackage."partial-order")."0.2.0.0").revisions).default;
         "partial-order".flags.extra-instances = true;
         "charset".revision = (((hackage."charset")."0.3.9").revisions).default;
+        "req".revision = (((hackage."req")."3.9.2").revisions).default;
+        "req".flags.dev = false;
         "insert-ordered-containers".revision = (((hackage."insert-ordered-containers")."0.2.5.1").revisions).default;
         "size-based".revision = (((hackage."size-based")."0.1.2.0").revisions).default;
         "wcwidth".revision = (((hackage."wcwidth")."0.0.2").revisions).default;
@@ -24,6 +26,8 @@
         "http-media".revision = (((hackage."http-media")."0.8.0.0").revisions).default;
         "tf-random".revision = (((hackage."tf-random")."0.5").revisions).default;
         "servant-client".revision = (((hackage."servant-client")."0.18.3").revisions).default;
+        "hslogger".revision = (((hackage."hslogger")."1.3.1.0").revisions).default;
+        "hslogger".flags.network--gt-3_0_0 = true;
         "mmorph".revision = (((hackage."mmorph")."1.1.5").revisions).default;
         "natural-transformation".revision = (((hackage."natural-transformation")."0.4").revisions).default;
         "blaze-textual".revision = (((hackage."blaze-textual")."0.2.2.1").revisions).default;
@@ -34,6 +38,7 @@
         "generics-sop".revision = (((hackage."generics-sop")."0.5.1.0").revisions).default;
         "abstract-deque".revision = (((hackage."abstract-deque")."0.3").revisions).default;
         "abstract-deque".flags.usecas = false;
+        "network-bsd".revision = (((hackage."network-bsd")."2.8.1.0").revisions).default;
         "streaming".revision = (((hackage."streaming")."0.2.3.1").revisions).default;
         "old-time".revision = (((hackage."old-time")."1.1.0.3").revisions).default;
         "http-conduit".revision = (((hackage."http-conduit")."2.3.8").revisions).default;
@@ -57,6 +62,8 @@
         "ghc-paths".revision = (((hackage."ghc-paths")."0.1.0.12").revisions).default;
         "servant".revision = (((hackage."servant")."0.18.3").revisions).default;
         "asn1-encoding".revision = (((hackage."asn1-encoding")."0.9.6").revisions).default;
+        "MissingH".revision = (((hackage."MissingH")."1.4.3.0").revisions).default;
+        "MissingH".flags.network--ge-3_0_0 = true;
         "pretty".revision = (((hackage."pretty")."1.1.3.6").revisions).default;
         "network-uri".revision = (((hackage."network-uri")."2.6.4.1").revisions).default;
         "haskell-src-exts".revision = (((hackage."haskell-src-exts")."1.23.1").revisions).default;
@@ -87,6 +94,7 @@
         "text".revision = (((hackage."text")."1.2.4.1").revisions).default;
         "base".revision = (((hackage."base")."4.14.1.0").revisions).default;
         "microlens-mtl".revision = (((hackage."microlens-mtl")."0.2.0.1").revisions).default;
+        "RSA".revision = (((hackage."RSA")."2.4.1").revisions).default;
         "word8".revision = (((hackage."word8")."0.1.3").revisions).default;
         "lift-type".revision = (((hackage."lift-type")."0.1.0.1").revisions).default;
         "hourglass".revision = (((hackage."hourglass")."0.2.12").revisions).default;
@@ -359,6 +367,8 @@
         "mtl-compat".flags.two-point-one = false;
         "mtl-compat".flags.two-point-two = false;
         "command".revision = (((hackage."command")."0.1.1").revisions).default;
+        "modern-uri".revision = (((hackage."modern-uri")."0.3.4.2").revisions).default;
+        "modern-uri".flags.dev = false;
         "concurrent-output".revision = (((hackage."concurrent-output")."1.10.14").revisions).default;
         "sop-core".revision = (((hackage."sop-core")."0.5.0.2").revisions).default;
         "abstract-par".revision = (((hackage."abstract-par")."0.3.3").revisions).default;
@@ -445,6 +455,7 @@
         "reflection".flags.template-haskell = true;
         "reflection".flags.slow = false;
         "hspec-discover".revision = (((hackage."hspec-discover")."2.9.4").revisions).default;
+        "authenticate-oauth".revision = (((hackage."authenticate-oauth")."1.7").revisions).default;
         "pretty-show".revision = (((hackage."pretty-show")."1.10").revisions).default;
         "template-haskell".revision = (((hackage."template-haskell")."2.16.0.0").revisions).default;
         "tasty-golden".revision = (((hackage."tasty-golden")."2.3.5").revisions).default;
@@ -489,6 +500,9 @@
         "barbies".revision = (((hackage."barbies")."2.0.3.1").revisions).default;
         "persistent-template".revision = (((hackage."persistent-template")."2.12.0.0").revisions).default;
         "syb".revision = (((hackage."syb")."0.7.2.1").revisions).default;
+        "docopt".revision = (((hackage."docopt")."0.7.0.7").revisions).default;
+        "docopt".flags.template-haskell = true;
+        "crypto-pubkey-types".revision = (((hackage."crypto-pubkey-types")."0.4.3").revisions).default;
         "zlib".revision = (((hackage."zlib")."0.6.2.3").revisions).default;
         "zlib".flags.non-blocking-ffi = false;
         "zlib".flags.pkg-config = false;
@@ -569,6 +583,8 @@
         "SHA".flags.exe = false;
         "fmlist".revision = (((hackage."fmlist")."0.9.4").revisions).default;
         "stm".revision = (((hackage."stm")."2.5.0.0").revisions).default;
+        "crypto-api".revision = (((hackage."crypto-api")."0.13.3").revisions).default;
+        "crypto-api".flags.all_cpolys = false;
         "warp".revision = (((hackage."warp")."3.3.18").revisions).default;
         "warp".flags.network-bytestring = false;
         "warp".flags.allow-sendfilefd = true;
@@ -1121,6 +1137,7 @@
           "fmlist".components.library.planned = lib.mkOverride 900 true;
           "text-conversions".components.library.planned = lib.mkOverride 900 true;
           "contravariant".components.library.planned = lib.mkOverride 900 true;
+          "crypto-pubkey-types".components.library.planned = lib.mkOverride 900 true;
           "microlens-th".components.library.planned = lib.mkOverride 900 true;
           "extra".components.library.planned = lib.mkOverride 900 true;
           "barbies".components.library.planned = lib.mkOverride 900 true;
@@ -1178,6 +1195,7 @@
           "haskell-src-exts".components.library.planned = lib.mkOverride 900 true;
           "text-short".components.library.planned = lib.mkOverride 900 true;
           "plutus-pab-executables".components.exes."plutus-uniswap".planned = lib.mkOverride 900 true;
+          "MissingH".components.library.planned = lib.mkOverride 900 true;
           "assoc".components.library.planned = lib.mkOverride 900 true;
           "process".components.library.planned = lib.mkOverride 900 true;
           "fmt".components.library.planned = lib.mkOverride 900 true;
@@ -1198,9 +1216,11 @@
           "prettyprinter".components.library.planned = lib.mkOverride 900 true;
           "plutus-chain-index-core".components.library.planned = lib.mkOverride 900 true;
           "cardano-ledger-core".components.library.planned = lib.mkOverride 900 true;
+          "docopt".components.library.planned = lib.mkOverride 900 true;
           "streaming".components.library.planned = lib.mkOverride 900 true;
           "monoidal-containers".components.library.planned = lib.mkOverride 900 true;
           "zlib".components.library.planned = lib.mkOverride 900 true;
+          "authenticate-oauth".components.library.planned = lib.mkOverride 900 true;
           "transformers-except".components.library.planned = lib.mkOverride 900 true;
           "cardano-prelude-test".components.library.planned = lib.mkOverride 900 true;
           "libyaml".components.library.planned = lib.mkOverride 900 true;
@@ -1260,6 +1280,7 @@
           "mtl-compat".components.library.planned = lib.mkOverride 900 true;
           "cardano-crypto-test".components.library.planned = lib.mkOverride 900 true;
           "erf".components.library.planned = lib.mkOverride 900 true;
+          "modern-uri".components.library.planned = lib.mkOverride 900 true;
           "set-algebra".components.library.planned = lib.mkOverride 900 true;
           "dbvar".components.library.planned = lib.mkOverride 900 true;
           "unliftio".components.library.planned = lib.mkOverride 900 true;
@@ -1283,6 +1304,7 @@
           "openapi3".components.library.planned = lib.mkOverride 900 true;
           "semigroupoids".components.setup.planned = lib.mkOverride 900 true;
           "async".components.library.planned = lib.mkOverride 900 true;
+          "hslogger".components.library.planned = lib.mkOverride 900 true;
           "microlens-mtl".components.library.planned = lib.mkOverride 900 true;
           "async-timer".components.library.planned = lib.mkOverride 900 true;
           "size-based".components.library.planned = lib.mkOverride 900 true;
@@ -1350,6 +1372,7 @@
           "wcwidth".components.library.planned = lib.mkOverride 900 true;
           "QuickCheck".components.library.planned = lib.mkOverride 900 true;
           "quickcheck-dynamic".components.library.planned = lib.mkOverride 900 true;
+          "network-bsd".components.library.planned = lib.mkOverride 900 true;
           "canonical-json".components.library.planned = lib.mkOverride 900 true;
           "ouroboros-network-framework".components.library.planned = lib.mkOverride 900 true;
           "th-extras".components.library.planned = lib.mkOverride 900 true;
@@ -1367,6 +1390,7 @@
           "monoidal-synchronisation".components.library.planned = lib.mkOverride 900 true;
           "filelock".components.library.planned = lib.mkOverride 900 true;
           "generic-arbitrary".components.library.planned = lib.mkOverride 900 true;
+          "req".components.library.planned = lib.mkOverride 900 true;
           "stm-chans".components.library.planned = lib.mkOverride 900 true;
           "compact-map".components.library.planned = lib.mkOverride 900 true;
           "tracer-transformers".components.library.planned = lib.mkOverride 900 true;
@@ -1448,6 +1472,7 @@
           "wai-websockets".components.exes."wai-websockets-example".planned = lib.mkOverride 900 true;
           "beam-migrate".components.library.planned = lib.mkOverride 900 true;
           "flat".components.library.planned = lib.mkOverride 900 true;
+          "RSA".components.library.planned = lib.mkOverride 900 true;
           "persistent-sqlite".components.library.planned = lib.mkOverride 900 true;
           "unbounded-delays".components.library.planned = lib.mkOverride 900 true;
           "web-ghc".components.exes."web-ghc-server".planned = lib.mkOverride 900 true;
@@ -1626,6 +1651,7 @@
           "websockets".components.library.planned = lib.mkOverride 900 true;
           "x509-store".components.library.planned = lib.mkOverride 900 true;
           "Win32-network".components.exes."named-pipe-demo".planned = lib.mkOverride 900 true;
+          "plutus-pab-executables".components.exes."pab-cli".planned = lib.mkOverride 900 true;
           "void".components.library.planned = lib.mkOverride 900 true;
           "beam-core".components.library.planned = lib.mkOverride 900 true;
           "text-class".components.library.planned = lib.mkOverride 900 true;
@@ -1636,6 +1662,7 @@
           "Only".components.library.planned = lib.mkOverride 900 true;
           "cryptohash-sha1".components.library.planned = lib.mkOverride 900 true;
           "exact-combinatorics".components.library.planned = lib.mkOverride 900 true;
+          "crypto-api".components.library.planned = lib.mkOverride 900 true;
           "non-integral".components.library.planned = lib.mkOverride 900 true;
           "testing-type-modifiers".components.library.planned = lib.mkOverride 900 true;
           };

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab-executables.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab-executables.nix
@@ -40,9 +40,7 @@
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
           (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
-          (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
           (hsPkgs."servant-purescript" or (errorHandler.buildDepError "servant-purescript"))
-          (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           ];
         buildable = true;
@@ -272,6 +270,39 @@
           hsSourceDirs = [ "demo/pab-nami/pab/app" ];
           mainPath = [
             "Generator.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
+        "pab-cli" = {
+          depends = [
+            (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
+            (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."cardano-ledger-shelley" or (errorHandler.buildDepError "cardano-ledger-shelley"))
+            (hsPkgs."ouroboros-consensus-shelley" or (errorHandler.buildDepError "ouroboros-consensus-shelley"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."docopt" or (errorHandler.buildDepError "docopt"))
+            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+            (hsPkgs."process" or (errorHandler.buildDepError "process"))
+            (hsPkgs."req" or (errorHandler.buildDepError "req"))
+            (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
+            (hsPkgs."MissingH" or (errorHandler.buildDepError "MissingH"))
+            ];
+          buildable = true;
+          modules = [ "App" "CommandParser" "Types" ];
+          hsSourceDirs = [ "pab-cli" ];
+          mainPath = [
+            "Main.hs"
             ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
           };
         };

--- a/nix/pkgs/haskell/materialized-windows/default.nix
+++ b/nix/pkgs/haskell/materialized-windows/default.nix
@@ -5,6 +5,8 @@
         "partial-order".revision = (((hackage."partial-order")."0.2.0.0").revisions).default;
         "partial-order".flags.extra-instances = true;
         "charset".revision = (((hackage."charset")."0.3.9").revisions).default;
+        "req".revision = (((hackage."req")."3.9.2").revisions).default;
+        "req".flags.dev = false;
         "insert-ordered-containers".revision = (((hackage."insert-ordered-containers")."0.2.5.1").revisions).default;
         "size-based".revision = (((hackage."size-based")."0.1.2.0").revisions).default;
         "time-manager".revision = (((hackage."time-manager")."0.0.0").revisions).default;
@@ -21,6 +23,8 @@
         "http-media".revision = (((hackage."http-media")."0.8.0.0").revisions).default;
         "tf-random".revision = (((hackage."tf-random")."0.5").revisions).default;
         "servant-client".revision = (((hackage."servant-client")."0.18.3").revisions).default;
+        "hslogger".revision = (((hackage."hslogger")."1.3.1.0").revisions).default;
+        "hslogger".flags.network--gt-3_0_0 = true;
         "mmorph".revision = (((hackage."mmorph")."1.1.5").revisions).default;
         "natural-transformation".revision = (((hackage."natural-transformation")."0.4").revisions).default;
         "blaze-textual".revision = (((hackage."blaze-textual")."0.2.2.1").revisions).default;
@@ -31,6 +35,7 @@
         "generics-sop".revision = (((hackage."generics-sop")."0.5.1.0").revisions).default;
         "abstract-deque".revision = (((hackage."abstract-deque")."0.3").revisions).default;
         "abstract-deque".flags.usecas = false;
+        "network-bsd".revision = (((hackage."network-bsd")."2.8.1.0").revisions).default;
         "streaming".revision = (((hackage."streaming")."0.2.3.1").revisions).default;
         "old-time".revision = (((hackage."old-time")."1.1.0.3").revisions).default;
         "http-conduit".revision = (((hackage."http-conduit")."2.3.8").revisions).default;
@@ -54,6 +59,8 @@
         "servant".revision = (((hackage."servant")."0.18.3").revisions).default;
         "asn1-encoding".revision = (((hackage."asn1-encoding")."0.9.6").revisions).default;
         "regex-posix-clib".revision = (((hackage."regex-posix-clib")."2.7").revisions).default;
+        "MissingH".revision = (((hackage."MissingH")."1.4.3.0").revisions).default;
+        "MissingH".flags.network--ge-3_0_0 = true;
         "pretty".revision = (((hackage."pretty")."1.1.3.6").revisions).default;
         "network-uri".revision = (((hackage."network-uri")."2.6.4.1").revisions).default;
         "haskell-src-exts".revision = (((hackage."haskell-src-exts")."1.23.1").revisions).default;
@@ -84,6 +91,7 @@
         "text".revision = (((hackage."text")."1.2.4.1").revisions).default;
         "base".revision = (((hackage."base")."4.14.1.0").revisions).default;
         "microlens-mtl".revision = (((hackage."microlens-mtl")."0.2.0.1").revisions).default;
+        "RSA".revision = (((hackage."RSA")."2.4.1").revisions).default;
         "word8".revision = (((hackage."word8")."0.1.3").revisions).default;
         "lift-type".revision = (((hackage."lift-type")."0.1.0.1").revisions).default;
         "hourglass".revision = (((hackage."hourglass")."0.2.12").revisions).default;
@@ -354,6 +362,8 @@
         "mtl-compat".flags.two-point-one = false;
         "mtl-compat".flags.two-point-two = false;
         "command".revision = (((hackage."command")."0.1.1").revisions).default;
+        "modern-uri".revision = (((hackage."modern-uri")."0.3.4.2").revisions).default;
+        "modern-uri".flags.dev = false;
         "concurrent-output".revision = (((hackage."concurrent-output")."1.10.14").revisions).default;
         "sop-core".revision = (((hackage."sop-core")."0.5.0.2").revisions).default;
         "abstract-par".revision = (((hackage."abstract-par")."0.3.3").revisions).default;
@@ -441,6 +451,7 @@
         "reflection".flags.template-haskell = true;
         "reflection".flags.slow = false;
         "hspec-discover".revision = (((hackage."hspec-discover")."2.9.2").revisions).default;
+        "authenticate-oauth".revision = (((hackage."authenticate-oauth")."1.7").revisions).default;
         "pretty-show".revision = (((hackage."pretty-show")."1.10").revisions).default;
         "template-haskell".revision = (((hackage."template-haskell")."2.16.0.0").revisions).default;
         "tasty-golden".revision = (((hackage."tasty-golden")."2.3.5").revisions).default;
@@ -483,6 +494,9 @@
         "barbies".revision = (((hackage."barbies")."2.0.3.1").revisions).default;
         "persistent-template".revision = (((hackage."persistent-template")."2.12.0.0").revisions).default;
         "syb".revision = (((hackage."syb")."0.7.2.1").revisions).default;
+        "docopt".revision = (((hackage."docopt")."0.7.0.7").revisions).default;
+        "docopt".flags.template-haskell = true;
+        "crypto-pubkey-types".revision = (((hackage."crypto-pubkey-types")."0.4.3").revisions).default;
         "zlib".revision = (((hackage."zlib")."0.6.2.3").revisions).default;
         "zlib".flags.non-blocking-ffi = false;
         "zlib".flags.pkg-config = false;
@@ -562,6 +576,8 @@
         "SHA".flags.exe = false;
         "fmlist".revision = (((hackage."fmlist")."0.9.4").revisions).default;
         "stm".revision = (((hackage."stm")."2.5.0.0").revisions).default;
+        "crypto-api".revision = (((hackage."crypto-api")."0.13.3").revisions).default;
+        "crypto-api".flags.all_cpolys = false;
         "warp".revision = (((hackage."warp")."3.3.18").revisions).default;
         "warp".flags.network-bytestring = false;
         "warp".flags.allow-sendfilefd = true;
@@ -1110,6 +1126,7 @@
           "fmlist".components.library.planned = lib.mkOverride 900 true;
           "text-conversions".components.library.planned = lib.mkOverride 900 true;
           "contravariant".components.library.planned = lib.mkOverride 900 true;
+          "crypto-pubkey-types".components.library.planned = lib.mkOverride 900 true;
           "microlens-th".components.library.planned = lib.mkOverride 900 true;
           "extra".components.library.planned = lib.mkOverride 900 true;
           "barbies".components.library.planned = lib.mkOverride 900 true;
@@ -1167,6 +1184,7 @@
           "text-short".components.library.planned = lib.mkOverride 900 true;
           "regex-posix-clib".components.library.planned = lib.mkOverride 900 true;
           "plutus-pab-executables".components.exes."plutus-uniswap".planned = lib.mkOverride 900 true;
+          "MissingH".components.library.planned = lib.mkOverride 900 true;
           "assoc".components.library.planned = lib.mkOverride 900 true;
           "process".components.library.planned = lib.mkOverride 900 true;
           "fmt".components.library.planned = lib.mkOverride 900 true;
@@ -1187,10 +1205,12 @@
           "prettyprinter".components.library.planned = lib.mkOverride 900 true;
           "plutus-chain-index-core".components.library.planned = lib.mkOverride 900 true;
           "cardano-ledger-core".components.library.planned = lib.mkOverride 900 true;
+          "docopt".components.library.planned = lib.mkOverride 900 true;
           "mintty".components.library.planned = lib.mkOverride 900 true;
           "streaming".components.library.planned = lib.mkOverride 900 true;
           "monoidal-containers".components.library.planned = lib.mkOverride 900 true;
           "zlib".components.library.planned = lib.mkOverride 900 true;
+          "authenticate-oauth".components.library.planned = lib.mkOverride 900 true;
           "transformers-except".components.library.planned = lib.mkOverride 900 true;
           "cardano-prelude-test".components.library.planned = lib.mkOverride 900 true;
           "libyaml".components.library.planned = lib.mkOverride 900 true;
@@ -1249,6 +1269,7 @@
           "mtl-compat".components.library.planned = lib.mkOverride 900 true;
           "cardano-crypto-test".components.library.planned = lib.mkOverride 900 true;
           "erf".components.library.planned = lib.mkOverride 900 true;
+          "modern-uri".components.library.planned = lib.mkOverride 900 true;
           "set-algebra".components.library.planned = lib.mkOverride 900 true;
           "dbvar".components.library.planned = lib.mkOverride 900 true;
           "unliftio".components.library.planned = lib.mkOverride 900 true;
@@ -1271,6 +1292,7 @@
           "openapi3".components.library.planned = lib.mkOverride 900 true;
           "semigroupoids".components.setup.planned = lib.mkOverride 900 true;
           "async".components.library.planned = lib.mkOverride 900 true;
+          "hslogger".components.library.planned = lib.mkOverride 900 true;
           "microlens-mtl".components.library.planned = lib.mkOverride 900 true;
           "async-timer".components.library.planned = lib.mkOverride 900 true;
           "size-based".components.library.planned = lib.mkOverride 900 true;
@@ -1336,6 +1358,7 @@
           "cardano-wallet".components.exes."local-cluster".planned = lib.mkOverride 900 true;
           "QuickCheck".components.library.planned = lib.mkOverride 900 true;
           "quickcheck-dynamic".components.library.planned = lib.mkOverride 900 true;
+          "network-bsd".components.library.planned = lib.mkOverride 900 true;
           "canonical-json".components.library.planned = lib.mkOverride 900 true;
           "ouroboros-network-framework".components.library.planned = lib.mkOverride 900 true;
           "th-extras".components.library.planned = lib.mkOverride 900 true;
@@ -1353,6 +1376,7 @@
           "monoidal-synchronisation".components.library.planned = lib.mkOverride 900 true;
           "filelock".components.library.planned = lib.mkOverride 900 true;
           "generic-arbitrary".components.library.planned = lib.mkOverride 900 true;
+          "req".components.library.planned = lib.mkOverride 900 true;
           "stm-chans".components.library.planned = lib.mkOverride 900 true;
           "compact-map".components.library.planned = lib.mkOverride 900 true;
           "tracer-transformers".components.library.planned = lib.mkOverride 900 true;
@@ -1432,6 +1456,7 @@
           "wai-websockets".components.exes."wai-websockets-example".planned = lib.mkOverride 900 true;
           "beam-migrate".components.library.planned = lib.mkOverride 900 true;
           "flat".components.library.planned = lib.mkOverride 900 true;
+          "RSA".components.library.planned = lib.mkOverride 900 true;
           "persistent-sqlite".components.library.planned = lib.mkOverride 900 true;
           "unbounded-delays".components.library.planned = lib.mkOverride 900 true;
           "web-ghc".components.exes."web-ghc-server".planned = lib.mkOverride 900 true;
@@ -1604,6 +1629,7 @@
           "websockets".components.library.planned = lib.mkOverride 900 true;
           "x509-store".components.library.planned = lib.mkOverride 900 true;
           "Win32-network".components.exes."named-pipe-demo".planned = lib.mkOverride 900 true;
+          "plutus-pab-executables".components.exes."pab-cli".planned = lib.mkOverride 900 true;
           "void".components.library.planned = lib.mkOverride 900 true;
           "beam-core".components.library.planned = lib.mkOverride 900 true;
           "text-class".components.library.planned = lib.mkOverride 900 true;
@@ -1613,6 +1639,7 @@
           "Only".components.library.planned = lib.mkOverride 900 true;
           "cryptohash-sha1".components.library.planned = lib.mkOverride 900 true;
           "exact-combinatorics".components.library.planned = lib.mkOverride 900 true;
+          "crypto-api".components.library.planned = lib.mkOverride 900 true;
           "non-integral".components.library.planned = lib.mkOverride 900 true;
           "testing-type-modifiers".components.library.planned = lib.mkOverride 900 true;
           };

--- a/plutus-pab-executables/examples/ContractExample/PayToWallet.hs
+++ b/plutus-pab-executables/examples/ContractExample/PayToWallet.hs
@@ -20,7 +20,7 @@ import Schema (ToSchema)
 
 import Ledger (PaymentPubKeyHash, Value)
 import Ledger.Constraints (adjustUnbalancedTx, mustPayToPubKey)
-import Plutus.Contract (ContractError, Endpoint, Promise, endpoint, mkTxConstraints, yieldUnbalancedTx)
+import Plutus.Contract (ContractError, Endpoint, Promise, endpoint, logInfo, mkTxConstraints, yieldUnbalancedTx)
 
 data PayToWalletParams =
     PayToWalletParams
@@ -34,5 +34,8 @@ type PayToWalletSchema = Endpoint "PayToWallet" PayToWalletParams
 
 payToWallet :: Promise () PayToWalletSchema ContractError ()
 payToWallet = endpoint @"PayToWallet" $ \PayToWalletParams{amount, pkh} -> do
-  utx <- mkTxConstraints @Void mempty (mustPayToPubKey pkh amount)
-  yieldUnbalancedTx $ adjustUnbalancedTx utx
+    logInfo @String "Calling PayToWallet endpoint"
+    utx <- mkTxConstraints @Void mempty (mustPayToPubKey pkh amount)
+    logInfo @String $ "Yielding the unbalanced transaction " <> show utx
+    yieldUnbalancedTx $ adjustUnbalancedTx utx
+

--- a/plutus-pab-executables/pab-cli/App.hs
+++ b/plutus-pab-executables/pab-cli/App.hs
@@ -1,0 +1,433 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE MonoLocalBinds    #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+
+module App where
+
+import Control.Concurrent.Async (Concurrently (Concurrently, runConcurrently))
+import Control.Monad (forM_, unless)
+import Control.Monad.Freer (Eff, LastMember, Member)
+import Control.Monad.Freer.Reader (Reader, ask)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.Aeson qualified as Aeson
+import Data.ByteString qualified as BS
+import Data.Char (toLower)
+import Data.Default (def)
+import Data.Text qualified as Text
+import Data.Time.Clock (nominalDiffTimeToSeconds)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import Data.Yaml (encodeFile)
+import Network.HTTP.Req (GET (GET), NoReqBody (NoReqBody), bsResponse, defaultHttpConfig, https, req, responseBody,
+                         runReq, (/:))
+import Servant.Client (BaseUrl (BaseUrl), Scheme (Http))
+import System.Directory (createDirectoryIfMissing, doesFileExist)
+import System.Exit (exitFailure)
+import System.FilePath ((</>))
+import System.Process (callCommand)
+
+import Cardano.Api qualified as C
+import Cardano.Api.NetworkId.Extra (NetworkIdWrapper (NetworkIdWrapper, unNetworkIdWrapper))
+import Cardano.ChainIndex.Types (ChainIndexConfig (ciBaseUrl), ChainIndexUrl (ChainIndexUrl))
+import Cardano.Ledger.Shelley.Genesis (ShelleyGenesis (sgNetworkMagic, sgSecurityParam, sgSlotLength, sgSystemStart))
+import Cardano.Node.Types (NodeMode (AlonzoNode),
+                           PABServerConfig (pscBaseUrl, pscKeptBlocks, pscNetworkId, pscNodeMode, pscSlotConfig, pscSocketPath))
+import Cardano.Wallet.Types (LocalWalletSettings (LocalWalletSettings),
+                             WalletConfig (LocalWalletConfig, RemoteWalletConfig), WalletUrl (WalletUrl))
+import Ledger (POSIXTime (POSIXTime))
+import Ledger.TimeSlot (SlotConfig (SlotConfig))
+import Ouroboros.Consensus.Shelley.Eras (StandardShelley)
+import Plutus.PAB.Types (Config (chainIndexConfig, dbConfig, developmentOptions, nodeServerConfig, pabWebserverConfig, walletServerConfig),
+                         DbConfig (dbConfigFile, dbConfigPoolSize),
+                         DevelopmentOptions (DevelopmentOptions, pabResumeFrom, pabRollbackHistory),
+                         WebserverConfig (baseUrl))
+
+import Data.Monoid (Alt (Alt, getAlt))
+import Types (AppOpts (AppOpts, appOptsChainIndexOpts, appOptsCommand, appOptsNodeOpts),
+              ChainIndexOpts (ChainIndexOpts, chainIndexOptsPort), ChainIndexPort (ChainIndexPort, unChainIndexPort),
+              ConfigCommand (MockNetCommand, NodeRemoteWalletCommand, NodeWBECommand), NetworkName (Mainnet, Testnet),
+              NodeDirectory (NodeDirectory, unNodeDirectory), NodeOpts (NodeOpts, nodeOptsOutputDir, nodeOptsPort),
+              NodePort (NodePort, unNodePort), NodeSocketPath (NodeSocketPath), PABExe (unPABExe),
+              PABOpts (PABOpts, pabOptsDbPoolSize, pabOptsExe, pabOptsOutputDir, pabOptsPassphrase, pabOptsPort, pabOptsResumeFromPoint, pabOptsRollbackHistory),
+              PABPort (PABPort), WalletPort (WalletPort), createChainIndexDbPath, createNodeDbDirPath,
+              createNodeSocketFilePath, createPABDirectory, createPabConfigFilePath, createPabDbFilePath,
+              createWbeDatabaseDir, createWbeDatabaseDirPath, getChainIndexDbPath, getNodeDbDirPath,
+              getNodeSocketFilePath, getPabConfigFilePath, getPabDbFilePath, getWbeDatabaseDirPath, removeNodeSocket,
+              waitUntilNodeSocketExists)
+
+cardanoNodeCmd :: String
+cardanoNodeCmd = "cardano-node"
+
+cardanoWalletCmd :: String
+cardanoWalletCmd = "cardano-wallet"
+
+plutusChainIndexCmd :: String
+plutusChainIndexCmd = "plutus-chain-index"
+
+-- | These file names come from: https://hydra.iohk.io/build/7654130/download/1/index.html
+nodeConfigFilenames :: [String]
+nodeConfigFilenames =
+    [ "config.json"
+    , "byron-genesis.json"
+    , "shelley-genesis.json"
+    , "alonzo-genesis.json"
+    , "topology.json"
+    ]
+
+runApp ::
+    ( Member (Reader AppOpts) effs
+    , MonadIO m
+    , LastMember m effs
+    )
+    => Eff effs ()
+runApp = do
+    appOpts <- ask @AppOpts
+
+    -- Create node base output directory
+    let nodeDir@(NodeDirectory nd) = nodeOptsOutputDir $ appOptsNodeOpts appOpts
+    liftIO $ createDirectoryIfMissing False nd
+
+    -- Remote old node socket file
+    liftIO $ removeNodeSocket $ createNodeSocketFilePath nodeDir
+
+    runAppCommand (appOptsCommand appOpts)
+
+runAppCommand ::
+    ( Member (Reader AppOpts) effs
+    , MonadIO m
+    , LastMember m effs
+    )
+    => ConfigCommand
+    -> Eff effs ()
+runAppCommand (MockNetCommand pabOpts (WalletPort walletPort)) = do
+    AppOpts { appOptsNodeOpts = NodeOpts { nodeOptsOutputDir
+                                         , nodeOptsPort = NodePort nodePort
+                                         }
+            , appOptsChainIndexOpts
+            } <- ask @AppOpts
+
+    let nodeServerConfig =
+            def { pscBaseUrl = BaseUrl Http "localhost" (fromIntegral nodePort) ""
+                , pscSocketPath = getNodeSocketFilePath $ createNodeSocketFilePath nodeOptsOutputDir
+                }
+        walletConfig = LocalWalletConfig
+                     $ LocalWalletSettings
+                     $ WalletUrl
+                     $ BaseUrl Http "localhost" (fromIntegral walletPort) ""
+        pabServerConfig =
+            (pabWebserverBaseConfig nodeServerConfig pabOpts appOptsChainIndexOpts)
+                { walletServerConfig = walletConfig
+                , nodeServerConfig = nodeServerConfig
+                }
+
+    liftIO $ startPabWebserverAndMockServers pabOpts pabServerConfig
+
+runAppCommand (NodeWBECommand networkName pabOptsM walletPort@(WalletPort wp)) = do
+    appOpts@AppOpts { appOptsNodeOpts = NodeOpts { nodeOptsOutputDir }
+            , appOptsChainIndexOpts
+            } <- ask @AppOpts
+    -- Fetch node config files depending on network and save to node output directory.
+    liftIO $ fetchNodeConfigFiles networkName nodeOptsOutputDir
+
+    nodeServerConfig <- getCardanoNodeConfig networkName nodeOptsOutputDir
+    let networkId = unNetworkIdWrapper $ pscNetworkId nodeServerConfig
+    let startChainIndexAction =
+            startChainIndex networkId appOptsChainIndexOpts (appOptsNodeOpts appOpts)
+        startCardanoNodeAction = startCardanoNode networkName (appOptsNodeOpts appOpts)
+        startCardanoWalletAction = startCardanoWallet networkName walletPort nodeOptsOutputDir
+
+    let walletConfig = LocalWalletConfig
+                     $ LocalWalletSettings
+                     $ WalletUrl
+                     $ BaseUrl Http "localhost" (fromIntegral wp) ""
+    case pabOptsM of
+        Nothing ->
+            liftIO $ runAsyncActions [ startChainIndexAction
+                                     , startCardanoNodeAction
+                                     , startCardanoWalletAction
+                                     ]
+        Just pabOpts -> do
+            -- Generate base PAB configuration and modify the node and wallet
+            -- server config
+            let pabServerConfig = (pabWebserverBaseConfig nodeServerConfig pabOpts appOptsChainIndexOpts)
+                    { walletServerConfig = walletConfig
+                    , nodeServerConfig = nodeServerConfig
+                    }
+
+            let startPabWebserverAction = startPabWebserver pabOpts pabServerConfig
+
+            liftIO $ runAsyncActions [ startChainIndexAction
+                                     , startCardanoNodeAction
+                                     , startPabWebserverAction
+                                     , startCardanoWalletAction
+                                     ]
+
+runAppCommand (NodeRemoteWalletCommand network pabOptsM) = do
+    appOpts@AppOpts { appOptsNodeOpts = NodeOpts { nodeOptsOutputDir }
+            , appOptsChainIndexOpts
+            } <- ask @AppOpts
+    -- Fetch node config files depending on network and save to node output directory.
+    liftIO $ fetchNodeConfigFiles network nodeOptsOutputDir
+
+    nodeServerConfig <- getCardanoNodeConfig network nodeOptsOutputDir
+    let networkId = unNetworkIdWrapper $ pscNetworkId nodeServerConfig
+        networkName = getNetworkName networkId
+        startChainIndexAction =
+            startChainIndex networkId appOptsChainIndexOpts (appOptsNodeOpts appOpts)
+        startCardanoNodeAction = startCardanoNode networkName (appOptsNodeOpts appOpts)
+
+    case pabOptsM of
+        Nothing ->
+            liftIO $ runAsyncActions [ startChainIndexAction
+                                     , startCardanoNodeAction
+                                     ]
+        Just pabOpts -> do
+            let pabServerConfig = (pabWebserverBaseConfig nodeServerConfig pabOpts appOptsChainIndexOpts)
+                    { walletServerConfig = RemoteWalletConfig
+                    , nodeServerConfig = nodeServerConfig
+                    }
+
+            let startPabWebserverAction = startPabWebserver pabOpts pabServerConfig
+
+            liftIO $ runAsyncActions [ startChainIndexAction
+                                     , startCardanoNodeAction
+                                     , startPabWebserverAction
+                                     ]
+
+-- | Run list of actions asynchroniously and wait until any one of them finishes.
+runAsyncActions :: [IO ()] -> IO ()
+runAsyncActions = runConcurrently . getAlt . foldMap (Alt . Concurrently)
+
+-- | Fetch cardano node config files from Hydra CI given a network.
+fetchNodeConfigFiles
+    :: NetworkName -- ^ The supported Cardano networks: Mainnet and Testnet
+    -> NodeDirectory -- ^ Directory to store the config files
+    -> IO ()
+fetchNodeConfigFiles networkName (NodeDirectory nodeDir) = do
+    forM_ nodeConfigFilenames $ \partialFname -> do
+        let configFname = map toLower (show networkName) <> "-" <> partialFname
+            configFpath = nodeDir </> configFname
+        configFpathExists <- doesFileExist configFpath
+        unless configFpathExists $ do
+            r <- runReq defaultHttpConfig $ req GET
+                     (    https
+                          "hydra.iohk.io"
+                       /: "build"
+                       /: "7654130"
+                       /: "download"
+                       /: "1"
+                       /: Text.pack configFname
+                     )
+                     NoReqBody
+                     bsResponse
+                     mempty
+            BS.writeFile configFpath $ responseBody r
+
+-- | Generates a base PAB configuration with sensible default values.
+pabWebserverBaseConfig
+    :: PABServerConfig -- ^ Node configuration inside the PAB configuration
+    -> PABOpts -- ^ PAB command line arguments
+    -> ChainIndexOpts -- ^ Chain index command line arguments
+    -> Config -- ^ PAB configuration
+pabWebserverBaseConfig
+        nodeServerConfig
+        PABOpts { pabOptsOutputDir
+                , pabOptsPort = PABPort pabPort
+                , pabOptsDbPoolSize
+                , pabOptsRollbackHistory
+                , pabOptsResumeFromPoint
+                }
+        ChainIndexOpts { chainIndexOptsPort = ChainIndexPort chainIndexPort } = do
+    let pabDbConfigFile = createPabDbFilePath pabOptsOutputDir
+        chainIndexUrl = ChainIndexUrl $ BaseUrl Http "localhost" (fromIntegral chainIndexPort) ""
+        pabWebserverConfig =
+            def { baseUrl = BaseUrl Http "localhost" (fromIntegral pabPort) "" }
+    def { dbConfig = def { dbConfigFile = Text.pack $ getPabDbFilePath pabDbConfigFile
+                         , dbConfigPoolSize = pabOptsDbPoolSize
+                         }
+        , chainIndexConfig = def { ciBaseUrl = chainIndexUrl }
+        , nodeServerConfig = nodeServerConfig
+        , pabWebserverConfig = pabWebserverConfig
+        , developmentOptions =
+            DevelopmentOptions
+                { pabRollbackHistory = pabOptsRollbackHistory
+                , pabResumeFrom = pabOptsResumeFromPoint
+                }
+        }
+
+-- | Starts the PAB webserver.
+--
+-- The server won't start until the socket file is available.
+startPabWebserver
+    :: PABOpts -- ^ PAB command line arguments
+    -> Config -- ^ PAB configuration
+    -> IO ()
+startPabWebserver PABOpts { pabOptsOutputDir, pabOptsExe, pabOptsPassphrase } pabServerConfig = do
+    waitUntilNodeSocketExists
+        $ NodeSocketPath $ pscSocketPath $ nodeServerConfig pabServerConfig
+
+    createPABDirectory pabOptsOutputDir
+
+    let pabConfigFpath = getPabConfigFilePath $ createPabConfigFilePath pabOptsOutputDir
+    encodeFile pabConfigFpath pabServerConfig
+
+    let passphraseCliOption = maybe "" (" --passphrase " <>) pabOptsPassphrase
+    callCommand $ unPABExe pabOptsExe <> " migrate --config " <> pabConfigFpath
+    callCommand $ unPABExe pabOptsExe <> " webserver --config " <> pabConfigFpath
+                                      <> passphraseCliOption
+
+-- | Starts the PAB webserver.
+--
+-- The server won't start until the socket file is available.
+startPabWebserverAndMockServers
+    :: PABOpts -- ^ PAB command line arguments
+    -> Config -- ^ PAB configuration
+    -> IO ()
+startPabWebserverAndMockServers
+  PABOpts { pabOptsOutputDir, pabOptsExe } pabServerConfig = do
+    createPABDirectory pabOptsOutputDir
+
+    let pabConfigFpath = getPabConfigFilePath $ createPabConfigFilePath pabOptsOutputDir
+    encodeFile pabConfigFpath pabServerConfig
+
+    callCommand $ unPABExe pabOptsExe <> " migrate --config " <> pabConfigFpath
+    callCommand $ unPABExe pabOptsExe <> " all-servers --config " <> pabConfigFpath
+
+-- | Starts the 'cardano-node'.
+startCardanoNode
+    :: NetworkName -- ^ The supported Cardano networks: Mainnet and Testnet
+    -> NodeOpts -- ^ Node command line arguments
+    -> IO ()
+startCardanoNode networkName NodeOpts { nodeOptsOutputDir, nodeOptsPort } = do
+    let nodeConfigFpath = unNodeDirectory nodeOptsOutputDir
+                      </> map toLower (show networkName)
+                      <> "-config.json"
+        topologyFpath = unNodeDirectory nodeOptsOutputDir
+                    </> map toLower (show networkName)
+                    <> "-topology.json"
+        databaseFpath = getNodeDbDirPath (createNodeDbDirPath nodeOptsOutputDir)
+        socketPath = getNodeSocketFilePath (createNodeSocketFilePath nodeOptsOutputDir)
+    callCommand $ cardanoNodeCmd
+               <> " run"
+               <> " --config " <> nodeConfigFpath
+               <> " --topology " <> topologyFpath
+               <> " --database-path " <> databaseFpath
+               <> " --socket-path " <> socketPath
+               <> " --port " <> show (unNodePort nodeOptsPort)
+
+-- | Starts the 'chain-index' server
+--
+-- The server won't start until the socket file is available.
+startChainIndex
+    :: C.NetworkId -- ^ The supported Cardano networks: Mainnet and Testnet
+    -> ChainIndexOpts -- ^ Chain index command line arguments
+    -> NodeOpts -- ^ Node command line arguments
+    -> IO ()
+startChainIndex networkId
+                ChainIndexOpts { chainIndexOptsPort }
+                NodeOpts { nodeOptsOutputDir } = do
+    let socketPath = createNodeSocketFilePath nodeOptsOutputDir
+    waitUntilNodeSocketExists socketPath
+    callCommand $ plutusChainIndexCmd
+               <> " --socket-path " <> getNodeSocketFilePath socketPath
+               <> " --db-path " <> getChainIndexDbPath (createChainIndexDbPath nodeOptsOutputDir)
+               <> " --port " <> show (unChainIndexPort chainIndexOptsPort)
+               <> " --network-id " <> show (C.unNetworkMagic $ C.toNetworkMagic networkId)
+               <> " start-index"
+
+-- | Starts the `cardano-wallet` server from a specific network (mainnet or
+-- testnet) given the node directory which contains the socket file and config
+-- files.
+--
+-- The server won't start until the socket file is available.
+startCardanoWallet
+    :: NetworkName -- ^ The supported Cardano networks: Mainnet and Testnet
+    -> WalletPort -- ^ Port number
+    -> NodeDirectory
+    -- ^ Directory containing the `cardano node` socket file and config files
+    -> IO ()
+startCardanoWallet network (WalletPort walletPort) nodeDir@(NodeDirectory nd) = do
+    waitUntilNodeSocketExists $ createNodeSocketFilePath nodeDir
+
+    let wbeDbDir = createWbeDatabaseDirPath nodeDir
+    createWbeDatabaseDir wbeDbDir
+    case network of
+        Mainnet ->
+            callCommand $ cardanoWalletCmd
+                       <> " serve"
+                       <> " --mainnet"
+                       <> " --node-socket " <> getNodeSocketFilePath (createNodeSocketFilePath nodeDir)
+                       <> " --database " <> getWbeDatabaseDirPath wbeDbDir
+                       <> " --port " <> show walletPort
+        Testnet -> do
+            let byronGenesisFilePath = nd
+                                   </> fmap toLower (show network)
+                                    <> "-byron-genesis.json"
+            callCommand $ cardanoWalletCmd
+                       <> " serve"
+                       <> " --testnet " <> byronGenesisFilePath
+                       <> " --node-socket " <> getNodeSocketFilePath (createNodeSocketFilePath nodeDir)
+                       <> " --database " <> getWbeDatabaseDirPath wbeDbDir
+                       <> " --port " <> show walletPort
+
+-- | Creates a node config for the PAB configuration using the values in the
+-- '(mainnet|testnet)-shelley-genesis.json' file in the given node directory.
+--
+-- The name is misleading, but 'PABServerConfig' actually refers to the cardano
+-- node configuration in the PAB. Needs to be changed.
+--
+-- A precondition of this function is that the cardano node config files were
+-- successfully fetched and put in the given node directory.
+getCardanoNodeConfig
+    :: (MonadIO m)
+    => NetworkName -- ^ The supported Cardano networks: Mainnet and Testnet
+    -> NodeDirectory -- ^ Directory containing the Cardano node configuration files
+    -> m PABServerConfig -- ^ Node configuration inside the PAB configuration
+getCardanoNodeConfig network nodeDir@(NodeDirectory nd) = do
+    -- Read full '<NETWORK>-shelley-genesis.json' config file.
+    let shelleyConfigFpath =
+             nd
+         </> (map toLower $ show network)
+          <> "-shelley-genesis.json"
+    shelleyGenesisConfigM <- readShelleyGenesis shelleyConfigFpath
+    shelleyGenesisConfig <-
+        maybe (liftIO $ putStrLn ("Could not parse " <> shelleyConfigFpath) >> exitFailure)
+              pure
+              shelleyGenesisConfigM
+
+    let networkMagic = sgNetworkMagic shelleyGenesisConfig
+    let networkId =
+            case network of
+                Mainnet -> C.Mainnet
+                Testnet -> C.Testnet $ C.NetworkMagic networkMagic
+
+    let securityParam = sgSecurityParam shelleyGenesisConfig
+
+    let slotLength = floor
+                   $ (1e3 *)
+                   $ nominalDiffTimeToSeconds
+                   $ sgSlotLength shelleyGenesisConfig
+
+    let systemStartPosix = floor
+                    $ (1e3 *)
+                    $ nominalDiffTimeToSeconds
+                    $ utcTimeToPOSIXSeconds
+                    $ sgSystemStart shelleyGenesisConfig
+
+    pure $ def { pscSocketPath = getNodeSocketFilePath $ createNodeSocketFilePath nodeDir
+               , pscKeptBlocks = fromIntegral securityParam
+               , pscSlotConfig = SlotConfig slotLength (POSIXTime systemStartPosix)
+               , pscNetworkId = NetworkIdWrapper networkId
+               , pscNodeMode = AlonzoNode
+               }
+  where
+    readShelleyGenesis
+        :: (MonadIO m) => FilePath -> m (Maybe (ShelleyGenesis StandardShelley))
+    readShelleyGenesis = liftIO . Aeson.decodeFileStrict
+
+getNetworkName :: C.NetworkId -> NetworkName
+getNetworkName C.Mainnet    = Mainnet
+getNetworkName C.Testnet {} = Testnet
+

--- a/plutus-pab-executables/pab-cli/CommandParser.hs
+++ b/plutus-pab-executables/pab-cli/CommandParser.hs
@@ -1,0 +1,264 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# OPTIONS_GHC -Wno-deferred-out-of-scope-variables #-}
+
+module CommandParser where
+
+import Control.Monad (unless)
+import Control.Monad.Catch (MonadThrow (throwM))
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.ByteString.Char8 qualified as BSC
+import Data.Char (toLower)
+import Data.List (isPrefixOf)
+import Ledger (Slot (Slot))
+import Ledger.Blockchain (BlockId (BlockId))
+import Plutus.ChainIndex.Types (Point (Point, PointAtGenesis))
+import System.Console.Docopt (Arguments, Docopt, Option, command, docopt, exitWithUsage, getArg, getArgOrExitWith,
+                              isPresent, longOption)
+import System.Directory (Permissions (executable), doesDirectoryExist, doesFileExist, getHomeDirectory, getPermissions)
+import System.FilePath (addTrailingPathSeparator, normalise, (</>))
+import System.Path.NameManip (absolute_path, guess_dotdot)
+import Text.Read (readMaybe)
+import Types (AppError (ChainIndexPortError, DirectoryDoesNotExistError, NodePortError, PABDBPoolSizeError, PABExeDoesNotExistError, PABExeNotExecutableError, PABExeNotProvidedError, PABPortError, PABResumeFromBlockIdNotSpecifiedError, PABResumeFromSlotNotANumberError, PABResumeFromSlotNotSpecifiedError, PABRollbackHistoryNotNumberError, UnspecifiedNodeNetworkError, WalletPortError),
+              AppOpts (AppOpts), ChainIndexOpts (ChainIndexOpts), ChainIndexPort (ChainIndexPort),
+              ConfigCommand (MockNetCommand, NodeRemoteWalletCommand, NodeWBECommand), NetworkName (Mainnet, Testnet),
+              NodeDirectory (NodeDirectory), NodeOpts (NodeOpts, nodeOptsOutputDir), NodePort (NodePort),
+              PABDirectory (PABDirectory), PABExe (PABExe), PABOpts (PABOpts), PABPort (PABPort),
+              WalletPort (WalletPort))
+
+-- | WARNING: IF YOU MODIFY THIS, DON'T FORGET TO UPDATE THE REAMDE.
+patterns :: Docopt
+patterns = [docopt|
+PAB CLI. This script allows the user to run the PAB in a hosted scenario, and provides good defaults for common usecases.
+
+THIS IS AN EXPERIMENT! DO NOT USE IN A PRODUCTION ENVIRONMENT.
+
+For any possible enhancements and suggestions, submit an issue on https://github.com/input-output-hk/plutus-apps/issues.
+
+Usage: pab-cli
+    pab-cli mocknet --pab-exe=<exe> [--pab-dir=<dir>] [--pab-db-pool-size=<size>] [--pab-port=<port>] [--pab-passphrase=<passphrase>] [--pab-rollback-history=<n>] ([--pab-resume-from-block-id=<blockid> --pab-resume-from-slot=<slot>]) [--chain-index-port=<port>] [--node-dir=<dir>] [--node-port=<port>] [--wallet-port=<port>]
+    pab-cli (mainnet | testnet) wbe [(--pab-exe=<exe> [--pab-dir=<dir>] [--pab-db-pool-size=<size>] [--pab-port=<port>] [--pab-passphrase=<passphrase>] [--pab-rollback-history=<n>] ([--pab-resume-from-block-id=<blockid> --pab-resume-from-slot=<slot>]))] [--chain-index-port=<port>] [--node-dir=<dir>] [--node-port=<port>] [--wallet-port=<port>]
+    pab-cli (mainnet | testnet) remotewallet [(--pab-exe=<exe> [--pab-dir=<dir>] [--pab-db-pool-size=<size>] [--pab-port=<port>] [--pab-passphrase=<passphrase>] [--pab-rollback-history=<n>] ([--pab-resume-from-block-id=<blockid> --pab-resume-from-slot=<slot>]))] [--chain-index-port=<port>] [--node-dir=<dir>] [--node-port=<port>]
+    pab-cli -h|--help
+
+Options:
+    -h --help                             show this
+    --pab-exe <exe>                       PAB executable with builtin contracts. Ex. "$(cabal list-bin plutus-pab-examples)"
+    --pab-dir <dir>                       PAB output directory for config, logs, db, etc. If don't specify it, the pab directory will reside in '--node-dir'.
+    --pab-db-pool-size <size>             PAB database pool size
+                                          [default: 20]
+    --pab-port <port>                     PAB webserver port number
+                                          [default: 9080]
+    --pab-passphrase <passphrase>         PAB wallet passphrase
+    --pab-rollback-history <n>            PAB rollback history
+    --pab-resume-from-block-id <blockid>  Block number to resume syncing from
+    --pab-resume-from-slot <slot>         Slot number to resume syncing from
+    --chain-index-port <port>             chain index port number
+                                          [default: 9083]
+    --node-dir <ndir>                     node output directory config, logs, db, etc.
+                                          [default: /tmp/cardano-node]
+    --node-port <port>                    node port number
+                                          [default:9082]
+    --wallet-port <port>                  wallet server port number
+                                          [default:9081]
+|]
+
+getArgOrExit :: Arguments -> Option -> IO String
+getArgOrExit = getArgOrExitWith patterns
+
+argsToAppOpts :: (MonadIO m, MonadThrow m) => Arguments -> m AppOpts
+argsToAppOpts args = do
+    if args `isPresent` longOption "help"
+    then
+        liftIO $ exitWithUsage patterns
+    else do
+        chainIndexOpts <- parseChainIndexOpts args
+
+        if args `isPresent` command "mocknet"
+        then do
+            nodeOpts <- parseNodeOpts "mock" args
+            pabOpts <- parsePABOpts (nodeOptsOutputDir nodeOpts) "mock" args
+                   >>= maybe (throwM PABExeNotProvidedError) pure
+            walletPort <- parseWalletPort args
+            pure $ AppOpts (MockNetCommand pabOpts walletPort)
+                           nodeOpts
+                           chainIndexOpts
+        else if args `isPresent` command "wbe"
+        then do
+            network <- parseNetworkArgs args
+            nodeOpts <- parseNodeOpts (map toLower $ show network) args
+            pabOpts <- parsePABOpts (nodeOptsOutputDir nodeOpts)
+                                    (map toLower $ show network)
+                                    args
+            walletPort <- parseWalletPort args
+            pure $ AppOpts (NodeWBECommand network pabOpts walletPort)
+                           nodeOpts
+                           chainIndexOpts
+        else if args `isPresent` command "remotewallet"
+        then do
+            network <- parseNetworkArgs args
+            nodeOpts <- parseNodeOpts (map toLower $ show network) args
+            pabOpts <- parsePABOpts (nodeOptsOutputDir nodeOpts)
+                                    (map toLower $ show network)
+                                    args
+            pure $ AppOpts (NodeRemoteWalletCommand network pabOpts)
+                           nodeOpts
+                           chainIndexOpts
+        else liftIO $ exitWithUsage patterns
+
+parsePABOpts
+    :: (MonadIO m, MonadThrow m)
+    => NodeDirectory
+    -> String
+    -> Arguments
+    -> m (Maybe PABOpts)
+parsePABOpts nodeDir subdir args = do
+    pabExeM <- parsePABExe args
+    case pabExeM of
+      Nothing -> pure Nothing
+      Just pabExe -> do
+          fmap Just
+          $ PABOpts pabExe <$> parsePABOutputDir nodeDir subdir args
+                           <*> parsePABPort args
+                           <*> parsePABDbPoolSize args
+                           <*> parsePABRollbackHistory args
+                           <*> pure (parsePABPassphrase args)
+                           <*> parsePABResumeFromPoint args
+
+parsePABExe :: (MonadIO m, MonadThrow m) => Arguments -> m (Maybe PABExe)
+parsePABExe args = do
+    if args `isPresent` longOption "pab-exe"
+    then do
+        pabExe@(PABExe pe) <- PABExe <$> liftIO (args `getArgOrExit` longOption "pab-exe")
+        liftIO (doesFileExist pe)
+            >>= \fileExists -> unless fileExists $ throwM PABExeDoesNotExistError
+        liftIO (getPermissions pe)
+            >>= \filePermissions -> unless (executable filePermissions)
+                                           $ throwM PABExeNotExecutableError
+        pure $ Just pabExe
+    else
+        pure Nothing
+
+parsePABOutputDir
+    :: (MonadIO m, MonadThrow m)
+    => NodeDirectory
+    -> String
+    -> Arguments
+    -> m PABDirectory
+parsePABOutputDir (NodeDirectory nd) subdir args = do
+    let pabDirM = args `getArg` longOption "pab-dir"
+    case pabDirM of
+      Just pabDir -> do
+          liftIO (doesDirectoryExist pabDir)
+              >>= \dirExists -> unless dirExists $ throwM $ DirectoryDoesNotExistError pabDir
+          pabDirAbsPath <- liftIO $ absolutize $ pabDir </> subdir
+          pure $ PABDirectory pabDirAbsPath
+      Nothing -> do
+          pabDirAbsPath <- liftIO $ absolutize $ nd </> "pab"
+          pure $ PABDirectory pabDirAbsPath
+
+parsePABPort :: (MonadIO m, MonadThrow m) => Arguments -> m PABPort
+parsePABPort args = do
+    pabPortStr <- liftIO $ args `getArgOrExit` longOption "pab-port"
+    maybe (throwM PABPortError) (pure . PABPort) $ readMaybe pabPortStr
+
+parsePABDbPoolSize :: (MonadIO m, MonadThrow m) => Arguments -> m Int
+parsePABDbPoolSize args = do
+    pabDbPoolSizeStr <- liftIO $ args `getArgOrExit` longOption "pab-db-pool-size"
+    maybe (throwM PABDBPoolSizeError) pure $ readMaybe pabDbPoolSizeStr
+
+parsePABRollbackHistory :: (MonadIO m, MonadThrow m) => Arguments -> m (Maybe Int)
+parsePABRollbackHistory args = do
+    if args `isPresent` longOption "pab-rollback-history"
+    then do
+        pabRollbackHistory <-
+            maybe (throwM PABRollbackHistoryNotNumberError)
+                  pure
+                  $ args `getArg` longOption "pab-rollback-history" >>= readMaybe
+        pure $ Just pabRollbackHistory
+    else
+        pure Nothing
+
+parsePABPassphrase :: Arguments -> Maybe String
+parsePABPassphrase args = args `getArg` longOption "pab-passphrase"
+
+parsePABResumeFromPoint :: (MonadIO m, MonadThrow m) => Arguments -> m Point
+parsePABResumeFromPoint args = do
+    if args `isPresent` longOption "pab-resume-from-block-id" && args `isPresent` longOption "pab-resume-from-slot"
+    then do
+        pabResumeFromBlockId <-
+            maybe (throwM PABResumeFromBlockIdNotSpecifiedError)
+                  (pure . BlockId . BSC.pack)
+                  $ args `getArg` longOption "pab-resume-from-block-id"
+        pabResumeFromSlotStr <-
+            maybe (throwM PABResumeFromSlotNotSpecifiedError)
+                  pure
+                  $ args `getArg` longOption "pab-resume-from-slot"
+        pabResumeFromSlot <-
+            maybe (throwM PABResumeFromSlotNotANumberError)
+                  (pure . Slot)
+                  $ readMaybe pabResumeFromSlotStr
+        pure $ Point pabResumeFromSlot pabResumeFromBlockId
+
+    else
+        pure PointAtGenesis
+
+parseChainIndexOpts :: (MonadIO m, MonadThrow m) => Arguments -> m ChainIndexOpts
+parseChainIndexOpts args = do
+    chainIndexPortStr <- liftIO $ args `getArgOrExit` longOption "chain-index-port"
+    port <- maybe (throwM ChainIndexPortError) (pure . ChainIndexPort) $ readMaybe chainIndexPortStr
+    pure $ ChainIndexOpts port
+
+parseNodeOpts :: (MonadIO m, MonadThrow m) => String -> Arguments -> m NodeOpts
+parseNodeOpts subdir args = NodeOpts <$> parseNodeOutputDir subdir args <*> parseNodePort args
+
+parseNodeOutputDir
+    :: (MonadIO m, MonadThrow m)
+    => String
+    -> Arguments
+    -> m NodeDirectory
+parseNodeOutputDir subdir args = do
+    nodeDir <- liftIO (args `getArgOrExit` longOption "node-dir")
+    liftIO (doesDirectoryExist nodeDir)
+        >>= \dirExists -> unless dirExists $ throwM $ DirectoryDoesNotExistError nodeDir
+    nodeDirAbsPath <- liftIO $ absolutize $ nodeDir </> subdir
+    pure $ NodeDirectory nodeDirAbsPath
+
+parseNodePort :: (MonadIO m, MonadThrow m) => Arguments -> m NodePort
+parseNodePort args = do
+    nodePortStr <- liftIO $ args `getArgOrExit` longOption "node-port"
+    maybe (throwM NodePortError) (pure . NodePort) $ readMaybe nodePortStr
+
+parseWalletPort :: (MonadIO m, MonadThrow m) => Arguments -> m WalletPort
+parseWalletPort args = do
+    walletPortStr <- liftIO $ args `getArgOrExit` longOption "wallet-port"
+    maybe (throwM WalletPortError) (pure . WalletPort) $ readMaybe walletPortStr
+
+parseNetworkArgs :: (MonadIO m, MonadThrow m) => Arguments -> m NetworkName
+parseNetworkArgs args
+  | args `isPresent` command "mainnet" = pure Mainnet
+  | args `isPresent` command "testnet" = pure Testnet
+  | otherwise = throwM UnspecifiedNodeNetworkError
+
+-- | Code copied from [https://www.schoolofhaskell.com/user/dshevchenko/cookbook/transform-relative-path-to-an-absolute-path].
+--
+-- Eventually, maybe using `completer (bashCompleter "file")` in
+-- optparse-application will do the same thing?
+--
+-- >>> absolutize ~/dev/env
+-- /home/username/dev/env
+--
+-- >>> absolutize /home/username/~/dev/env
+-- /home/username/~/dev/env
+--
+-- >>> absolutize dev/../dev/env -- Currenth path is /home/username/documents
+-- /home/username/documents/dev/env
+absolutize :: FilePath -> IO FilePath
+absolutize aPath
+    | "~" `isPrefixOf` aPath = do
+        homePath <- getHomeDirectory
+        return $ normalise $ addTrailingPathSeparator homePath ++ tail aPath
+    | otherwise = do
+        pathMaybeWithDots <- absolute_path aPath
+        pure $ maybe pathMaybeWithDots id $ guess_dotdot pathMaybeWithDots

--- a/plutus-pab-executables/pab-cli/Main.hs
+++ b/plutus-pab-executables/pab-cli/Main.hs
@@ -1,0 +1,38 @@
+module Main (main) where
+
+import Control.Monad (filterM, unless)
+import Control.Monad.Catch (catch)
+import Control.Monad.Freer (runM)
+import Control.Monad.Freer.Reader (runReader)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import System.Console.Docopt (exitWithUsageMessage, parseArgsOrExit)
+import System.Directory (doesFileExist)
+import System.Environment (getArgs)
+import System.Exit (exitFailure)
+
+
+import App (cardanoNodeCmd, cardanoWalletCmd, plutusChainIndexCmd, runApp)
+import CommandParser (argsToAppOpts, patterns)
+import Types (AppError)
+
+main :: IO ()
+main = do
+    -- TODO: Temporary until we call the underlying Haskell functions instead
+    -- of relying on the commands to be available in the current PATH.
+    missingExecs <- missingExecutables [plutusChainIndexCmd, cardanoWalletCmd, cardanoNodeCmd]
+    unless (null missingExecs) $ do
+        putStrLn $ "The following executables are missing from your PATH: "
+                <> show missingExecs
+        exitFailure
+
+    -- Parse command line arguments
+    args <- parseArgsOrExit patterns =<< getArgs
+    appOpts <- argsToAppOpts args `catch` \(e :: AppError) ->
+        exitWithUsageMessage patterns (show e)
+
+    runM $ runReader appOpts runApp
+
+missingExecutables :: (MonadIO m) => [String] -> m [String]
+missingExecutables = filterM isExecutableMissing
+  where
+    isExecutableMissing exec = liftIO (doesFileExist exec)

--- a/plutus-pab-executables/pab-cli/README.md
+++ b/plutus-pab-executables/pab-cli/README.md
@@ -1,0 +1,58 @@
+# PAB deployment CLI
+
+This CLI provides dApp developpers a way to run their PAB webserver, which contain the builtin contracts, alongside the required components (mock or real).
+
+The tool generates the correct configuration for each required component and ensures they are in sync.
+
+## Usage
+
+```
+PAB CLI. This script allows the user to run the PAB in a hosted scenario, and provides good defaults for common usecases.
+
+THIS IS AN EXPERIMENT! DO NOT USE IN A PRODUCTION ENVIRONMENT.
+
+For any possible enhancements and suggestions, submit an issue on https://github.com/input-output-hk/plutus-apps/issues.
+
+Usage: pab-cli
+    pab-cli mocknet --pab-exe=<exe> [--pab-dir=<dir>] [--pab-db-pool-size=<size>] [--pab-port=<port>] [--pab-rollback-history=<n>] [--pab-passphrase] ([--pab-resume-from-block-id=<blockid> --pab-resume-fr
+om-slot=<slot>]) [--chain-index-port=<port>] [--node-dir=<dir>] [--node-port=<port>] [--wallet-port=<port>]
+    pab-cli (mainnet | testnet) wbe [(--pab-exe=<exe> [--pab-dir=<dir>] [--pab-db-pool-size=<size>] [--pab-port=<port>] [--pab-rollback-history=<n>] [--pab-passphrase] ([--pab-resume-from-block-id=<blocki
+d> --pab-resume-from-slot=<slot>]))] [--chain-index-port=<port>] [--node-dir=<dir>] [--node-port=<port>] [--wallet-port=<port>]
+    pab-cli (mainnet | testnet) remotewallet [(--pab-exe=<exe> [--pab-dir=<dir>] [--pab-db-pool-size=<size>] [--pab-port=<port>] [--pab-rollback-history=<n>] [--pab-passphrase] ([--pab-resume-from-block-i
+d=<blockid> --pab-resume-from-slot=<slot>]))] [--chain-index-port=<port>] [--node-dir=<dir>] [--node-port=<port>]
+    pab-cli -h|--help
+
+Options:
+    -h --help                             show this
+    --pab-exe <exe>                       PAB executable with builtin contracts. Ex. "$(cabal list-bin plutus-pab-examples)"
+    --pab-dir <dir>                       PAB output directory for config, logs, db, etc.
+                                          [default: /tmp/pab]
+    --pab-db-pool-size <size>             PAB database pool size
+                                          [default: 20]
+    --pab-port <port>                     PAB webserver port number
+                                          [default: 9080]
+    --pab-passphrase                      PAB wallet passphrase
+    --pab-rollback-history <n>            PAB rollback history
+    --pab-resume-from-block-id <blockid>  Block number to resume syncing from
+    --pab-resume-from-slot <slot>         Slot number to resume syncing from
+    --chain-index-port <port>             chain index port number
+                                          [default: 9083]
+    --node-dir <ndir>                     node output directory config, logs, db, etc.
+                                          [default: /tmp/cardano-node]
+    --node-port <port>                    node port number
+                                          [default:9082]
+    --wallet-port <port>                  wallet server port number
+                                          [default:9081]
+```
+
+The tool currently supports the following three scenarios:
+
+1- You want to run your PAB webserver with mocked components (node, wallet and chain-index).
+
+2- You want to run the cardano-wallet backend, cardano node, chain-index and (optionally) your PAB webserver on the Cardano mainnet or testnet.
+
+3- You want to run the cardano node, chain-index and (optionally) your PAB webserver on the Cardano mainnet or testnet.
+
+## Contribution
+
+If you see a potential enhancement (or problem), please submit an issue on [https://github.com/input-output-hk/plutus-apps/issues](https://github.com/input-output-hk/plutus-apps/issues).

--- a/plutus-pab-executables/pab-cli/Types.hs
+++ b/plutus-pab-executables/pab-cli/Types.hs
@@ -1,0 +1,231 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Types
+    (
+    -- * Generate config types
+      AppOpts(..)
+    , ConfigCommand(..)
+    , NetworkName(..)
+    -- * Node config types
+    , NodeOpts(..)
+    , NodeDirectory(..)
+    , NodeDbPath
+    , createNodeDbDirPath
+    , getNodeDbDirPath
+    , NodeSocketPath(..)
+    , createNodeSocketFilePath
+    , getNodeSocketFilePath
+    , removeNodeSocket
+    , waitUntilNodeSocketExists
+    , NodePort(..)
+    -- * Chain index config types
+    , ChainIndexOpts(..)
+    , ChainIndexDbPath
+    , createChainIndexDbPath
+    , getChainIndexDbPath
+    , ChainIndexPort(..)
+    -- * PAB config types
+    , PABOpts(..)
+    , PABDirectory(..)
+    , createPABDirectory
+    , PABExe(..)
+    , PABConfigPath
+    , createPabConfigFilePath
+    , getPabConfigFilePath
+    , PABDbPath
+    , createPabDbFilePath
+    , getPabDbFilePath
+    , PABPort(..)
+    -- * WBE config types
+    , WBEDbDirectory
+    , createWbeDatabaseDir
+    , createWbeDatabaseDirPath
+    , getWbeDatabaseDirPath
+    , WalletPort(..)
+    -- * Other types
+    , AppError(..)
+    ) where
+
+import Control.Concurrent (threadDelay)
+import Control.Exception (Exception)
+import Control.Monad (unless)
+import Control.Monad.Catch (catch)
+import Data.Word (Word32)
+import Plutus.ChainIndex.Types (Point)
+import System.Directory (createDirectoryIfMissing, doesFileExist, removeFile)
+import System.FilePath ((</>))
+
+data AppOpts =
+    AppOpts { appOptsCommand        :: ConfigCommand
+            , appOptsNodeOpts       :: NodeOpts
+            , appOptsChainIndexOpts :: ChainIndexOpts
+            } deriving (Show)
+
+data PABOpts =
+    PABOpts { pabOptsExe             :: PABExe
+            , pabOptsOutputDir       :: PABDirectory
+            , pabOptsPort            :: PABPort
+            , pabOptsDbPoolSize      :: Int
+            , pabOptsRollbackHistory :: Maybe Int
+            , pabOptsPassphrase      :: Maybe String
+            , pabOptsResumeFromPoint :: Point
+            } deriving (Show)
+
+newtype ChainIndexOpts =
+    ChainIndexOpts { chainIndexOptsPort :: ChainIndexPort
+                   } deriving (Show)
+
+data NodeOpts =
+    NodeOpts { nodeOptsOutputDir :: NodeDirectory
+             , nodeOptsPort      :: NodePort
+             } deriving (Show)
+
+data ConfigCommand =
+    MockNetCommand PABOpts WalletPort
+  | NodeWBECommand NetworkName (Maybe PABOpts) WalletPort
+  | NodeRemoteWalletCommand NetworkName (Maybe PABOpts)
+    deriving (Show)
+
+newtype NodeDirectory = NodeDirectory { unNodeDirectory :: FilePath }
+    deriving (Show)
+
+newtype NodeSocketPath = NodeSocketPath { unNodeSocketPath :: FilePath }
+    deriving (Show)
+
+-- | Smart constructor for 'NodeSocketPath'.
+createNodeSocketFilePath :: NodeDirectory -> NodeSocketPath
+createNodeSocketFilePath (NodeDirectory nd) = NodeSocketPath $ nd </> "node.sock"
+
+getNodeSocketFilePath :: NodeSocketPath -> FilePath
+getNodeSocketFilePath = unNodeSocketPath
+
+removeNodeSocket :: NodeSocketPath -> IO ()
+removeNodeSocket (NodeSocketPath p) =
+    -- All kinds of possible exceptions here such as
+    -- `isDoesNotExistError`, `isPermissionError`, etc.
+    catch (removeFile p) $ \(_ :: IOError) -> pure ()
+
+-- | Waits until the given node socket path finally exists by polling the
+-- filesystem.
+waitUntilNodeSocketExists :: NodeSocketPath -> IO ()
+waitUntilNodeSocketExists (NodeSocketPath np) = go
+  where
+      go = do
+          nodeSocketExists <- doesFileExist np
+          unless nodeSocketExists $ threadDelay 5000000 >> go
+
+newtype NodeDbPath = NodeDbPath { unNodeDbPath :: FilePath }
+    deriving (Show)
+
+-- | Smart constructor for NodeDbPath'.
+createNodeDbDirPath :: NodeDirectory -> NodeDbPath
+createNodeDbDirPath (NodeDirectory d) = NodeDbPath $ d </> "db"
+
+getNodeDbDirPath :: NodeDbPath -> FilePath
+getNodeDbDirPath = unNodeDbPath
+
+newtype NodePort = NodePort { unNodePort :: Word32 }
+    deriving (Show)
+
+newtype PABExe = PABExe { unPABExe :: FilePath }
+    deriving (Show)
+
+newtype PABConfigPath = PABConfigPath { unPABConfigPath :: FilePath }
+    deriving (Show)
+
+createPabConfigFilePath :: PABDirectory -> PABConfigPath
+createPabConfigFilePath (PABDirectory d) =
+    PABConfigPath $ d </> "plutus-pab.yaml"
+
+getPabConfigFilePath :: PABConfigPath -> FilePath
+getPabConfigFilePath = unPABConfigPath
+
+newtype PABPort = PABPort { unPABPort :: Word32 }
+    deriving (Show)
+
+newtype PABDirectory = PABDirectory { unPABDirectory :: FilePath }
+    deriving (Show)
+
+createPABDirectory :: PABDirectory -> IO ()
+createPABDirectory (PABDirectory d) =
+    createDirectoryIfMissing False d
+
+newtype PABDbPath = PABDbPath { unPABDbPath :: FilePath }
+    deriving (Show)
+
+-- | Smart constructor for 'PABDbPath.
+createPabDbFilePath :: PABDirectory -> PABDbPath
+createPabDbFilePath (PABDirectory pd) = PABDbPath $ pd </> "pab-core.db"
+
+getPabDbFilePath :: PABDbPath -> FilePath
+getPabDbFilePath = unPABDbPath
+
+-- The show instance should output 'Testnet' and 'Mainnet'. Used in 'fetchNodeConfigFiles'.
+data NetworkName = Testnet | Mainnet
+    deriving (Show)
+
+newtype ChainIndexPort = ChainIndexPort { unChainIndexPort :: Word32 }
+    deriving (Show)
+
+newtype ChainIndexDbPath = ChainIndexDbPath { unChainIndexDbPath :: FilePath }
+    deriving (Show)
+
+-- | Smart constructor for NodeDbPath'.
+createChainIndexDbPath :: NodeDirectory -> ChainIndexDbPath
+createChainIndexDbPath (NodeDirectory d) = ChainIndexDbPath $ d </> "chain-index.db"
+
+getChainIndexDbPath :: ChainIndexDbPath -> FilePath
+getChainIndexDbPath = unChainIndexDbPath
+
+newtype WalletPort = WalletPort { unWalletPort :: Word32 }
+    deriving (Show)
+
+newtype WBEDbDirectory = WBEDbDirectory { unWBEDbDirectory :: FilePath }
+    deriving (Show)
+
+-- | Smart constructor for NodeDbPath'.
+createWbeDatabaseDirPath :: NodeDirectory -> WBEDbDirectory
+createWbeDatabaseDirPath (NodeDirectory d) = WBEDbDirectory $ d </> "wbe"
+
+createWbeDatabaseDir :: WBEDbDirectory -> IO ()
+createWbeDatabaseDir (WBEDbDirectory d)= do
+    createDirectoryIfMissing False d
+
+getWbeDatabaseDirPath :: WBEDbDirectory -> FilePath
+getWbeDatabaseDirPath = unWBEDbDirectory
+
+data AppError = ChainIndexPortError
+              | PABPortError
+              | PABExeNotProvidedError
+              | PABExeDoesNotExistError
+              | PABExeNotExecutableError
+              | PABDBPoolSizeError
+              | PABRollbackHistoryNotNumberError
+              | PABResumeFromBlockIdNotSpecifiedError
+              | PABResumeFromSlotNotSpecifiedError
+              | PABResumeFromSlotNotANumberError
+              | NodePortError
+              | UnspecifiedNodeNetworkError
+              | WalletPortError
+              | DirectoryDoesNotExistError FilePath
+
+instance Exception AppError
+
+instance Show AppError where
+    show ChainIndexPortError = "Option --chain-index-port should be a positive number"
+    show PABPortError = "Option --pab-port should be a positive number"
+    show PABExeNotProvidedError = "Option --pab-exe should be provided"
+    show PABExeDoesNotExistError = "Executable specified in --pab-exe is not available in the current PATH"
+    show PABExeNotExecutableError = "Current user does not have executable permissions for the executable specified in --pab-exe."
+    show PABDBPoolSizeError = "Option --pab-db-pool-size should be a positive number"
+
+    show PABRollbackHistoryNotNumberError = "Option --pab-rollback-history is not a number"
+    show PABResumeFromBlockIdNotSpecifiedError = "Option --pab-resume-from-block-id is not specified"
+    show PABResumeFromSlotNotSpecifiedError = "Option --pab-resume-from-slot is not specified"
+    show PABResumeFromSlotNotANumberError = "Option --pab-resume-from-slot should be positive number"
+
+    show NodePortError = "Option --node-port should be a positive number"
+    show UnspecifiedNodeNetworkError = "Unspecified cardano network"
+    show WalletPortError = "Option --wallet-port should be a positive number"
+    show (DirectoryDoesNotExistError fp) = "The following directory does not exist: " <> fp

--- a/plutus-pab-executables/plutus-pab-executables.cabal
+++ b/plutus-pab-executables/plutus-pab-executables.cabal
@@ -67,9 +67,7 @@ library
         lens -any,
         playground-common -any,
         purescript-bridge -any,
-        servant -any,
         servant-purescript -any,
-        servant-server -any,
         text -any,
 
 executable plutus-pab-setup
@@ -448,3 +446,43 @@ executable plutus-pab-nami-demo-generator
     purescript-bridge -any,
     plutus-ledger -any,
     plutus-ledger-constraints -any,
+
+executable pab-cli
+  import: lang
+  main-is: Main.hs
+  hs-source-dirs: pab-cli
+  other-modules:
+      App
+      CommandParser
+      Types
+  ghc-options:
+    -threaded
+    -Wmissing-import-lists
+    -Wunused-packages
+  build-depends:
+    plutus-chain-index-core -any,
+    plutus-ledger -any,
+    plutus-pab -any,
+  build-depends:
+    cardano-api -any,
+    cardano-ledger-shelley -any,
+    ouroboros-consensus-shelley -any,
+  build-depends:
+    aeson -any,
+    async -any,
+    base >= 4.9 && < 5,
+    bytestring -any,
+    cardano-api -any,
+    data-default -any,
+    directory -any,
+    docopt -any,
+    exceptions -any,
+    filepath -any,
+    freer-simple -any,
+    process -any,
+    req -any,
+    servant-client -any,
+    text -any,
+    time -any,
+    yaml -any,
+    MissingH -any,

--- a/plutus-pab/src/Cardano/Node/Types.hs
+++ b/plutus-pab/src/Cardano/Node/Types.hs
@@ -133,7 +133,7 @@ data PABServerConfig =
         -- ^ Whether to connect to an Alonzo node or a mock node
         }
     deriving stock (Show, Eq, Generic)
-    deriving anyclass (FromJSON)
+    deriving anyclass (FromJSON, ToJSON)
 
 
 defaultPABServerConfig :: PABServerConfig

--- a/plutus-pab/src/Plutus/PAB/Types.hs
+++ b/plutus-pab/src/Plutus/PAB/Types.hs
@@ -123,7 +123,7 @@ data Config =
         , requestProcessingConfig :: RequestProcessingConfig
         , developmentOptions      :: DevelopmentOptions
         }
-    deriving (Show, Eq, Generic, FromJSON)
+    deriving (Show, Eq, Generic, FromJSON, ToJSON)
 
 defaultConfig :: Config
 defaultConfig =
@@ -145,7 +145,7 @@ newtype RequestProcessingConfig =
         { requestProcessingInterval :: Second -- ^ How many seconds to wait between calls to 'Plutus.PAB.Core.ContractInstance.processAllContractOutboxes'
         }
     deriving (Show, Eq, Generic)
-    deriving anyclass (FromJSON)
+    deriving anyclass (FromJSON, ToJSON)
 
 defaultRequestProcessingConfig :: RequestProcessingConfig
 defaultRequestProcessingConfig =

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@
 , packages ? import ./. { inherit system enableHaskellProfiling; }
 }:
 let
-  inherit (packages) pkgs plutus-apps plutus-playground pab-nami-demo docs webCommon;
+  inherit (packages) pkgs plutus-apps plutus-playground pab-nami-demo plutus-chain-index pab-cli docs webCommon;
   inherit (pkgs) stdenv lib utillinux python3 nixpkgs-fmt;
   inherit (plutus-apps) haskell stylish-haskell sphinxcontrib-haddock sphinx-markdown-tables sphinxemoji nix-pre-commit-hooks;
 
@@ -114,6 +114,8 @@ let
     pab-nami-demo.start-backend
     plutus-playground.generate-purescript
     plutus-playground.start-backend
+    plutus-chain-index
+    pab-cli
     psa
     purescript-language-server
     purs


### PR DESCRIPTION
PAB CLI for easing the starting of components based on supported scenarios/use-cases.

Provides a `pab-cli` command line app in the `nix-shell`. This CLI can start the PAB in the currently supported scenarios (with mocked components, real components on mainnet or testnet, and optionally the cardano-wallet).

Also provides the `plutus-chain-index` executable in the `nix-shell`.

Next step is to integrate this tool in `plutus-starter`.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
