### PR TITLE
SCP-3116: Remove exitWithSuccess in PAB's runWithOpts

### DIFF
--- a/plutus-pab/src/Plutus/PAB/LocalCluster/Run.hs
+++ b/plutus-pab/src/Plutus/PAB/LocalCluster/Run.hs
@@ -253,10 +253,8 @@ launchPAB userContractHandler passPhrase dir walletUrl (RunningNode socketPath _
                 , chainIndexConfig = def{PAB.CI.ciBaseUrl = PAB.CI.ChainIndexUrl $ BaseUrl Http "localhost" chainIndexPort ""}
                 , walletServerConfig = set (Wallet.Config.walletSettingsL . Wallet.Config.baseUrlL) (WalletUrl walletUrl) def
                 }
-    -- TODO: For some reason this has to be async - program terminates if it's done synchronously???
-    void . async $ PAB.Run.runWithOpts userContractHandler (Just config) opts{cmd=Migrate}
-    sleep 2
-    void . async $ PAB.Run.runWithOpts userContractHandler (Just config) opts{cmd=PABWebserver}
+    PAB.Run.runWithOpts userContractHandler (Just config) opts { cmd = Migrate }
+    PAB.Run.runWithOpts userContractHandler (Just config) opts { cmd = PABWebserver }
 
 {-| Set up wallets
 -}

--- a/plutus-pab/src/Plutus/PAB/Run.hs
+++ b/plutus-pab/src/Plutus/PAB/Run.hs
@@ -39,7 +39,7 @@ import Plutus.PAB.Run.CommandParser
 import Plutus.PAB.Types (Config (..), DevelopmentOptions (..), PABError (MissingConfigFileOption))
 import Prettyprinter (Pretty (pretty))
 import Servant qualified
-import System.Exit (ExitCode (ExitFailure), exitSuccess, exitWith)
+import System.Exit (ExitCode (ExitFailure), exitWith)
 
 -- | PAB entry point for a contract type `a`.
 runWith :: forall a.
@@ -107,7 +107,7 @@ runWithOpts userContractHandler mc AppOpts { minLogLevel, rollbackHistory, resum
 
     -- execute parsed pab command and handle errors on faliure
     result <- sequence (run <$> pabConfig)
-    either handleError (const exitSuccess) result
+    either handleError (const $ pure ()) result
 
         where
 


### PR DESCRIPTION
The `exitWithSuccess` in Plutus.PAB.Run.runWithOpts` simply stops the program, so we can't use `runWithOpts` in multiple succession unless we make the calls async.  This PR fixes that.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - x ] Useful pull request description
    - [x] Reviewer requested
