### PR TITLE
plutus-use-cases-uniswap : validateRemove doesn't check real outA and outB

### DIFF
--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/OnChain.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/OnChain.hs
@@ -179,8 +179,9 @@ validateRemove c lp liquidity ctx =
     traceIfFalse "pool state coin missing"             (isUnity inVal c)                              &&
     traceIfFalse "wrong liquidity pool output"         (fst lpLiquidity == lp)                        &&
     traceIfFalse "pool state coin missing from output" (isUnity outVal c)                             &&
-    traceIfFalse "liquidity tokens not burnt"          (txInfoMint info == negate (valueOf lC diff)) &&
-    traceIfFalse "non-positive liquidity"              (outA > 0 && outB > 0)
+    traceIfFalse "liquidity tokens not burnt"          (txInfoMint info == negate (valueOf lC diff))  &&
+    traceIfFalse "non-positive liquidity"              (outA > 0 && outB > 0)                         &&
+    traceIfFalse "removal of invalid amount of tokens" (outA' == outA && outB' == outB)
   where
     info :: TxInfo
     info = scriptContextTxInfo ctx
@@ -208,6 +209,8 @@ validateRemove c lp liquidity ctx =
     diff         = liquidity - snd lpLiquidity
     inA          = amountOf inVal $ lpCoinA lp
     inB          = amountOf inVal $ lpCoinB lp
+    outA'        = amountOf outVal $ lpCoinA lp
+    outB'        = amountOf outVal $ lpCoinB lp
     (outA, outB) = calculateRemoval inA inB liquidity diff
 
 {-# INLINABLE validateAdd #-}


### PR DESCRIPTION
I've verified that **validateRemove** doesn't check the real **outA** and **outB**. It computes **outA** and **outB** with **calculateRemoval** and then check that both are greater than 0. The issue is that it doesn't check the real values of A and B in the output.

I've run the tests using the following malicious offchain code and the new constraint in **validateRemove**, resulting in a test failure (wallet balances don't match) due to a validator failure:  "_removal of invalid amount of tokens_".

```
-- | Removes some liquidity from a liquidity pool in exchange for liquidity tokens.
remove :: forall w s. Uniswap -> RemoveParams -> Contract w s Text ()
remove us RemoveParams{..} = do
    (_, (oref, o, lp, liquidity)) <- findUniswapFactoryAndPool us rpCoinA rpCoinB
    pkh                           <- Contract.ownPaymentPubKeyHash
    when (rpDiff < 1 || rpDiff >= liquidity) $ throwError "removed liquidity must be positive and less than total liquidity"
    let usInst       = uniswapInstance us
        usScript     = uniswapScript us
        dat          = Pool lp $ liquidity - rpDiff
        psC          = poolStateCoin us
        lC           = mkCoin (liquidityCurrency us) $ lpTicker lp
        psVal        = unitValue psC
        lVal         = valueOf lC rpDiff
        inVal        = view ciTxOutValue o
        inA          = amountOf inVal rpCoinA
        inB          = amountOf inVal rpCoinB
        (outA, outB) = calculateRemoval inA inB liquidity rpDiff
        -- val          = psVal <> valueOf rpCoinA outA <> valueOf rpCoinB outB
        val          = psVal <> valueOf rpCoinA (outA - Amount 1) <> valueOf rpCoinB outB  -- This malicious code tries to get 1 token A more. 
        redeemer     = Redeemer $ PlutusTx.toBuiltinData Remove

        lookups  = Constraints.typedValidatorLookups usInst          <>
                   Constraints.otherScript usScript                  <>
                   Constraints.mintingPolicy (liquidityPolicy us)   <>
                   Constraints.unspentOutputs (Map.singleton oref o) <>
                   Constraints.ownPaymentPubKeyHash pkh

        tx       = Constraints.mustPayToTheScript dat val          <>
                   Constraints.mustMintValue (negate lVal)        <>
                   Constraints.mustSpendScriptOutput oref redeemer

    mkTxConstraints lookups tx >>= submitTxConfirmed . adjustUnbalancedTx

    logInfo $ "removed liquidity from pool: " ++ show lp
```
