### PR TITLE
Switch `UtxoSetAtAddress` and `TxoSetAtAddress` from using `Credential` to `Address`

### DIFF
--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Api.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Api.hs
@@ -26,7 +26,6 @@ import Data.Proxy (Proxy (..))
 import GHC.Generics (Generic)
 import Ledger (Address, AssetClass, Datum, DatumHash, MintingPolicy, MintingPolicyHash, Redeemer, RedeemerHash,
                StakeValidator, StakeValidatorHash, TxId, Validator, ValidatorHash)
-import Ledger.Credential (Credential)
 import Ledger.Tx (ChainIndexTxOut, TxOutRef)
 import Plutus.ChainIndex.Tx (ChainIndexTx)
 import Plutus.ChainIndex.Types (Diagnostics, Tip)
@@ -141,8 +140,8 @@ data IsUtxoResponse = IsUtxoResponse
     deriving (Show, Eq, Generic, FromJSON, ToJSON, OpenApi.ToSchema)
 
 data TxoAtAddressRequest = TxoAtAddressRequest
-    { pageQuery  :: Maybe (PageQuery TxOutRef)
-    , credential :: Credential
+    { pageQuery :: Maybe (PageQuery TxOutRef)
+    , address   :: Address
     }
     deriving (Show, Eq, Generic, FromJSON, ToJSON, OpenApi.ToSchema)
 

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Api.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Api.hs
@@ -24,8 +24,8 @@ import Data.Aeson (FromJSON, ToJSON, Value)
 import Data.OpenApi qualified as OpenApi
 import Data.Proxy (Proxy (..))
 import GHC.Generics (Generic)
-import Ledger (AssetClass, Datum, DatumHash, MintingPolicy, MintingPolicyHash, Redeemer, RedeemerHash, StakeValidator,
-               StakeValidatorHash, TxId, Validator, ValidatorHash)
+import Ledger (Address, AssetClass, Datum, DatumHash, MintingPolicy, MintingPolicyHash, Redeemer, RedeemerHash,
+               StakeValidator, StakeValidatorHash, TxId, Validator, ValidatorHash)
 import Ledger.Credential (Credential)
 import Ledger.Tx (ChainIndexTxOut, TxOutRef)
 import Plutus.ChainIndex.Tx (ChainIndexTx)
@@ -42,11 +42,14 @@ import Servant.Swagger.UI (SwaggerSchemaUI, SwaggerSchemaUI', swaggerSchemaUISer
 -- Here's an example for requesting the first page:
 --
 -- {
---   "credential": {
---     "tag": "PubKeyCredential",
---     "contents": {
---       "getPubKeyHash": "88ff402b0522f27649ac742238c697c579beeb344eb723099d1f16ce"
---     }
+--   "address": {
+--     "addressCredential": {
+--       "tag": "PubKeyCredential",
+--       "contents": {
+--         "getPubKeyHash": "88ff402b0522f27649ac742238c697c579beeb344eb723099d1f16ce"
+--       }
+--     },
+--     "addressStakingCredential": null
 --   }
 -- }
 --
@@ -58,12 +61,15 @@ import Servant.Swagger.UI (SwaggerSchemaUI, SwaggerSchemaUI', swaggerSchemaUISer
 --       "getPageSize": 10
 --     }
 --   },
---   "credential": {
---     "tag": "PubKeyCredential",
---     "contents": {
---       "getPubKeyHash": "88ff402b0522f27649ac742238c697c579beeb344eb723099d1f16ce"
---     }
---   }
+--   "address": {
+--     "addressCredential": {
+--       "tag": "PubKeyCredential",
+--       "contents": {
+--         "getPubKeyHash": "88ff402b0522f27649ac742238c697c579beeb344eb723099d1f16ce"
+--       }
+--     },
+--     "addressStakingCredential": null
+--    }
 -- }
 --
 -- Here's an example for requesting the next page:
@@ -80,22 +86,25 @@ import Servant.Swagger.UI (SwaggerSchemaUI, SwaggerSchemaUI', swaggerSchemaUISer
 --       "txOutRefIdx": 0
 --     }
 --   },
---   "credential": {
---     "tag": "PubKeyCredential",
---     "contents": {
---       "getPubKeyHash": "88ff402b0522f27649ac742238c697c579beeb344eb723099d1f16ce"
---     }
+--   "address": {
+--     "addressCredential": {
+--       "tag": "PubKeyCredential",
+--       "contents": {
+--         "getPubKeyHash": "88ff402b0522f27649ac742238c697c579beeb344eb723099d1f16ce"
+--       }
+--     },
+--     "addressStakingCredential": null
 --   }
 -- }
 data UtxoAtAddressRequest = UtxoAtAddressRequest
-    { pageQuery  :: Maybe (PageQuery TxOutRef)
-    , credential :: Credential
+    { pageQuery :: Maybe (PageQuery TxOutRef)
+    , address   :: Address
     }
     deriving (Show, Eq, Generic, FromJSON, ToJSON, OpenApi.ToSchema)
 
 -- | See the comment on 'UtxoAtAddressRequest'.
 --
--- The difference is using @currency@ field instead of @credential@.
+-- The difference is using @currency@ field instead of @address@.
 -- {
 --   "pageQuery": {
 --     ...

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Effects.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Effects.hs
@@ -32,7 +32,6 @@ import Control.Monad.Freer.Extras.Pagination (PageQuery)
 import Control.Monad.Freer.TH (makeEffect)
 import Ledger (Address, AssetClass, Datum, DatumHash, MintingPolicy, MintingPolicyHash, Redeemer, RedeemerHash,
                StakeValidator, StakeValidatorHash, TxId, Validator, ValidatorHash)
-import Ledger.Credential (Credential)
 import Ledger.Tx (ChainIndexTxOut, TxOutRef)
 import Plutus.ChainIndex.Api (IsUtxoResponse, TxosResponse, UtxosResponse)
 import Plutus.ChainIndex.Tx (ChainIndexTx)
@@ -77,7 +76,7 @@ data ChainIndexQueryEffect r where
     TxsFromTxIds :: [TxId] -> ChainIndexQueryEffect [ChainIndexTx]
 
     -- | Outputs located at addresses with the given credential.
-    TxoSetAtAddress :: PageQuery TxOutRef -> Credential -> ChainIndexQueryEffect TxosResponse
+    TxoSetAtAddress :: PageQuery TxOutRef -> Address -> ChainIndexQueryEffect TxosResponse
 
     -- | Get the tip of the chain index
     GetTip :: ChainIndexQueryEffect Tip

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Effects.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Effects.hs
@@ -30,8 +30,8 @@ module Plutus.ChainIndex.Effects(
 
 import Control.Monad.Freer.Extras.Pagination (PageQuery)
 import Control.Monad.Freer.TH (makeEffect)
-import Ledger (AssetClass, Datum, DatumHash, MintingPolicy, MintingPolicyHash, Redeemer, RedeemerHash, StakeValidator,
-               StakeValidatorHash, TxId, Validator, ValidatorHash)
+import Ledger (Address, AssetClass, Datum, DatumHash, MintingPolicy, MintingPolicyHash, Redeemer, RedeemerHash,
+               StakeValidator, StakeValidatorHash, TxId, Validator, ValidatorHash)
 import Ledger.Credential (Credential)
 import Ledger.Tx (ChainIndexTxOut, TxOutRef)
 import Plutus.ChainIndex.Api (IsUtxoResponse, TxosResponse, UtxosResponse)
@@ -65,7 +65,7 @@ data ChainIndexQueryEffect r where
     UtxoSetMembership :: TxOutRef -> ChainIndexQueryEffect IsUtxoResponse
 
     -- | Unspent outputs located at addresses with the given credential.
-    UtxoSetAtAddress :: PageQuery TxOutRef -> Credential -> ChainIndexQueryEffect UtxosResponse
+    UtxoSetAtAddress :: PageQuery TxOutRef -> Address -> ChainIndexQueryEffect UtxosResponse
 
     -- | Unspent outputs containing a specific currency ('AssetClass').
     --

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Emulator/Handlers.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Emulator/Handlers.hs
@@ -127,7 +127,8 @@ handleQuery = \case
         case tip utxo of
             TipAtGenesis -> throwError QueryFailedNoTip
             tp           -> pure (IsUtxoResponse tp (TxUtxoBalance.isUnspentOutput r utxo))
-    UtxoSetAtAddress pageQuery cred -> do
+    UtxoSetAtAddress pageQuery addr -> do
+        let cred = addressCredential addr
         state <- get
         let outRefs = view (diskState . addressMap . at cred) state
             utxo = view (utxoIndex . to utxoState) state

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Emulator/Handlers.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Emulator/Handlers.hs
@@ -152,7 +152,8 @@ handleQuery = \case
                 pure (UtxosResponse TipAtGenesis (pageOf pageQuery Set.empty))
             tp           -> pure (UtxosResponse tp page)
     TxsFromTxIds is -> catMaybes <$> mapM getTxFromTxId is
-    TxoSetAtAddress pageQuery cred -> do
+    TxoSetAtAddress pageQuery addr -> do
+        let cred = addressCredential addr
         state <- get
         let outRefs = view (diskState . addressMap . at cred) state
             txoRefs = fromMaybe mempty outRefs

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
@@ -92,7 +92,7 @@ handleQuery = \case
     UtxoSetAtAddress pageQuery addr -> getUtxoSetAtAddress pageQuery addr
     UtxoSetWithCurrency pageQuery assetClass ->
       getUtxoSetWithCurrency pageQuery assetClass
-    TxoSetAtAddress pageQuery cred -> getTxoSetAtAddress pageQuery cred
+    TxoSetAtAddress pageQuery addr -> getTxoSetAtAddress pageQuery addr
     TxsFromTxIds txids             -> getTxsFromTxIds txids
     GetTip -> getTip
 
@@ -267,9 +267,9 @@ getTxoSetAtAddress
     , Member (LogMsg ChainIndexLog) effs
     )
   => PageQuery TxOutRef
-  -> Credential
+  -> Address
   -> Eff effs TxosResponse
-getTxoSetAtAddress pageQuery (toDbValue -> cred) = do
+getTxoSetAtAddress pageQuery (toDbValue . addressCredential -> cred) = do
   utxoState <- gets @ChainIndexState UtxoState.utxoState
   case UtxoState.tip utxoState of
       TipAtGenesis -> do

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
@@ -89,7 +89,7 @@ handleQuery = \case
         case UtxoState.tip utxoState of
             TipAtGenesis -> throwError QueryFailedNoTip
             tp           -> pure (IsUtxoResponse tp (TxUtxoBalance.isUnspentOutput r utxoState))
-    UtxoSetAtAddress pageQuery cred -> getUtxoSetAtAddress pageQuery cred
+    UtxoSetAtAddress pageQuery addr -> getUtxoSetAtAddress pageQuery addr
     UtxoSetWithCurrency pageQuery assetClass ->
       getUtxoSetWithCurrency pageQuery assetClass
     TxoSetAtAddress pageQuery cred -> getTxoSetAtAddress pageQuery cred
@@ -188,9 +188,9 @@ getUtxoSetAtAddress
     , Member (LogMsg ChainIndexLog) effs
     )
   => PageQuery TxOutRef
-  -> Credential
+  -> Address
   -> Eff effs UtxosResponse
-getUtxoSetAtAddress pageQuery (toDbValue -> cred) = do
+getUtxoSetAtAddress pageQuery (toDbValue . addressCredential -> cred) = do
   utxoState <- gets @ChainIndexState UtxoState.utxoState
 
   case UtxoState.tip utxoState of

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Server.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Server.hs
@@ -67,7 +67,7 @@ serveChainIndex =
     :<|> (\(UtxoAtAddressRequest pq c) -> E.utxoSetAtAddress (fromMaybe def pq) c)
     :<|> (\(UtxoWithCurrencyRequest pq c) -> E.utxoSetWithCurrency (fromMaybe def pq) c)
     :<|> E.txsFromTxIds
-    :<|> (\(TxoAtAddressRequest pq c) -> E.txoSetAtAddress (fromMaybe def pq) c)
+    :<|> (\(TxoAtAddressRequest pq a) -> E.txoSetAtAddress (fromMaybe def pq) a)
     :<|> E.getTip
     :<|> E.collectGarbage *> pure NoContent
     :<|> E.getDiagnostics

--- a/plutus-chain-index-core/test/Util.hs
+++ b/plutus-chain-index-core/test/Util.hs
@@ -7,18 +7,16 @@ module Util where
 import Control.Lens (view)
 import Control.Monad (forM)
 import Control.Monad.Freer (Eff, Member)
-import Ledger (Address (Address, addressCredential), TxOut (TxOut, txOutAddress), TxOutRef)
-import Ledger.Credential (Credential)
+import Ledger (Address, TxOut (txOutAddress), TxOutRef)
 import Plutus.ChainIndex (Page (pageItems), PageQuery (PageQuery), citxOutputs, utxoSetAtAddress)
 import Plutus.ChainIndex.Api (UtxosResponse (UtxosResponse))
 import Plutus.ChainIndex.Effects (ChainIndexQueryEffect)
 import Plutus.ChainIndex.Tx (ChainIndexTx, _ValidTx)
 
 -- | Get all address credentials from a block.
-addrCredsFromBlock :: [ChainIndexTx] -> [Credential]
+addrCredsFromBlock :: [ChainIndexTx] -> [Address]
 addrCredsFromBlock =
-  fmap (\TxOut { txOutAddress = Address { addressCredential }} -> addressCredential)
-  . view (traverse . citxOutputs . _ValidTx)
+  fmap txOutAddress . view (traverse . citxOutputs . _ValidTx)
 
 -- | Get the UTxO set from a block.
 utxoSetFromBlockAddrs :: Member ChainIndexQueryEffect effs => [ChainIndexTx] -> Eff effs [[TxOutRef]]

--- a/plutus-contract/src/Plutus/Contract/Effects.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects.hs
@@ -234,7 +234,7 @@ data ChainIndexQuery =
   | TxOutFromRef TxOutRef
   | TxFromTxId TxId
   | UtxoSetMembership TxOutRef
-  | UtxoSetAtAddress (PageQuery TxOutRef) Credential
+  | UtxoSetAtAddress (PageQuery TxOutRef) Address
   | UtxoSetWithCurrency (PageQuery TxOutRef) AssetClass
   | TxsFromTxIds [TxId]
   | TxoSetAtAddress (PageQuery TxOutRef) Credential
@@ -252,7 +252,7 @@ instance Pretty ChainIndexQuery where
         TxOutFromRef r             -> "requesting utxo from utxo reference" <+> pretty r
         TxFromTxId i               -> "requesting chain index tx from id" <+> pretty i
         UtxoSetMembership txOutRef -> "whether tx output is part of the utxo set" <+> pretty txOutRef
-        UtxoSetAtAddress _ c       -> "requesting utxos located at addresses with the credential" <+> pretty c
+        UtxoSetAtAddress _ a       -> "requesting utxos located at addresses" <+> pretty a
         UtxoSetWithCurrency _ ac   -> "requesting utxos containing the asset class" <+> pretty ac
         TxsFromTxIds i             -> "requesting chain index txs from ids" <+> pretty i
         TxoSetAtAddress _ c        -> "requesting txos located at addresses with the credential" <+> pretty c

--- a/plutus-contract/src/Plutus/Contract/Effects.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects.hs
@@ -89,7 +89,6 @@ import GHC.Generics (Generic)
 import Ledger (Address, AssetClass, Datum, DatumHash, MintingPolicy, MintingPolicyHash, PaymentPubKeyHash, Redeemer,
                RedeemerHash, StakeValidator, StakeValidatorHash, TxId, TxOutRef, ValidatorHash)
 import Ledger.Constraints.OffChain (UnbalancedTx)
-import Ledger.Credential (Credential)
 import Ledger.Scripts (Validator)
 import Ledger.Slot (Slot, SlotRange)
 import Ledger.Time (POSIXTime, POSIXTimeRange)
@@ -237,7 +236,7 @@ data ChainIndexQuery =
   | UtxoSetAtAddress (PageQuery TxOutRef) Address
   | UtxoSetWithCurrency (PageQuery TxOutRef) AssetClass
   | TxsFromTxIds [TxId]
-  | TxoSetAtAddress (PageQuery TxOutRef) Credential
+  | TxoSetAtAddress (PageQuery TxOutRef) Address
   | GetTip
     deriving stock (Eq, Show, Generic)
     deriving anyclass (ToJSON, FromJSON, OpenApi.ToSchema)
@@ -255,7 +254,7 @@ instance Pretty ChainIndexQuery where
         UtxoSetAtAddress _ a       -> "requesting utxos located at addresses" <+> pretty a
         UtxoSetWithCurrency _ ac   -> "requesting utxos containing the asset class" <+> pretty ac
         TxsFromTxIds i             -> "requesting chain index txs from ids" <+> pretty i
-        TxoSetAtAddress _ c        -> "requesting txos located at addresses with the credential" <+> pretty c
+        TxoSetAtAddress _ a        -> "requesting txos located at addresses" <+> pretty a
         GetTip                     -> "requesting the tip of the chain index"
 
 -- | Represents all possible responses to chain index queries. Each constructor

--- a/plutus-contract/src/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Plutus/Contract/Request.hs
@@ -116,7 +116,7 @@ import GHC.Natural (Natural)
 import GHC.TypeLits (Symbol, symbolVal)
 import Ledger (Address, AssetClass, Datum, DatumHash, DiffMilliSeconds, MintingPolicy, MintingPolicyHash, POSIXTime,
                PaymentPubKeyHash, Redeemer, RedeemerHash, Slot, StakeValidator, StakeValidatorHash, TxId,
-               TxOutRef (txOutRefId), Validator, ValidatorHash, Value, addressCredential, fromMilliSeconds)
+               TxOutRef (txOutRefId), Validator, ValidatorHash, Value, fromMilliSeconds)
 import Ledger.Constraints (TxConstraints)
 import Ledger.Constraints.OffChain (ScriptLookups, UnbalancedTx)
 import Ledger.Constraints.OffChain qualified as Constraints
@@ -514,7 +514,7 @@ txoRefsAt ::
     -> Address
     -> Contract w s e TxosResponse
 txoRefsAt pq addr = do
-  cir <- pabReq (ChainIndexQueryReq $ E.TxoSetAtAddress pq $ addressCredential addr) E._ChainIndexQueryResp
+  cir <- pabReq (ChainIndexQueryReq $ E.TxoSetAtAddress pq addr) E._ChainIndexQueryResp
   case cir of
     E.TxoSetAtResponse r -> pure r
     _ -> throwError $ review _OtherError

--- a/plutus-contract/src/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Plutus/Contract/Request.hs
@@ -365,7 +365,7 @@ utxoRefsAt ::
     -> Address
     -> Contract w s e UtxosResponse
 utxoRefsAt pq addr = do
-  cir <- pabReq (ChainIndexQueryReq $ E.UtxoSetAtAddress pq $ addressCredential addr) E._ChainIndexQueryResp
+  cir <- pabReq (ChainIndexQueryReq $ E.UtxoSetAtAddress pq addr) E._ChainIndexQueryResp
   case cir of
     E.UtxoSetAtResponse r -> pure r
     _ -> throwError $ review _OtherError

--- a/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
+++ b/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
@@ -231,7 +231,7 @@ handleChainIndexQueries = RequestHandler $ \chainIndexQuery ->
         TxOutFromRef txOutRef      -> TxOutRefResponse <$> ChainIndexEff.txOutFromRef txOutRef
         TxFromTxId txid            -> TxIdResponse <$> ChainIndexEff.txFromTxId txid
         UtxoSetMembership txOutRef -> UtxoSetMembershipResponse <$> ChainIndexEff.utxoSetMembership txOutRef
-        UtxoSetAtAddress pq c      -> UtxoSetAtResponse <$> ChainIndexEff.utxoSetAtAddress pq c
+        UtxoSetAtAddress pq a      -> UtxoSetAtResponse <$> ChainIndexEff.utxoSetAtAddress pq a
         UtxoSetWithCurrency pq ac  -> UtxoSetWithCurrencyResponse <$> ChainIndexEff.utxoSetWithCurrency pq ac
         TxsFromTxIds txids         -> TxIdsResponse <$> ChainIndexEff.txsFromTxIds txids
         TxoSetAtAddress pq c       -> TxoSetAtResponse <$> ChainIndexEff.txoSetAtAddress pq c

--- a/plutus-pab-executables/demo/pab-nami/client/generated/Plutus/Contract/Effects.purs
+++ b/plutus-pab-executables/demo/pab-nami/client/generated/Plutus/Contract/Effects.purs
@@ -29,7 +29,6 @@ import Plutus.ChainIndex.Api (IsUtxoResponse, TxosResponse, UtxosResponse)
 import Plutus.ChainIndex.Tx (ChainIndexTx)
 import Plutus.ChainIndex.Types (RollbackState, Tip, TxOutState)
 import Plutus.V1.Ledger.Address (Address)
-import Plutus.V1.Ledger.Credential (Credential)
 import Plutus.V1.Ledger.Interval (Interval)
 import Plutus.V1.Ledger.Scripts (DatumHash, MintingPolicy, StakeValidator, Validator)
 import Plutus.V1.Ledger.Slot (Slot)
@@ -131,7 +130,7 @@ data ChainIndexQuery
   | UtxoSetAtAddress (PageQuery TxOutRef) Address
   | UtxoSetWithCurrency (PageQuery TxOutRef) AssetClass
   | TxsFromTxIds (Array TxId)
-  | TxoSetAtAddress (PageQuery TxOutRef) Credential
+  | TxoSetAtAddress (PageQuery TxOutRef) Address
   | GetTip
 
 derive instance Eq ChainIndexQuery
@@ -233,7 +232,7 @@ _TxsFromTxIds = prism' TxsFromTxIds case _ of
   (TxsFromTxIds a) -> Just a
   _ -> Nothing
 
-_TxoSetAtAddress :: Prism' ChainIndexQuery { a :: PageQuery TxOutRef, b :: Credential }
+_TxoSetAtAddress :: Prism' ChainIndexQuery { a :: PageQuery TxOutRef, b :: Address }
 _TxoSetAtAddress = prism' (\{ a, b } -> (TxoSetAtAddress a b)) case _ of
   (TxoSetAtAddress a b) -> Just { a, b }
   _ -> Nothing

--- a/plutus-pab-executables/demo/pab-nami/client/generated/Plutus/Contract/Effects.purs
+++ b/plutus-pab-executables/demo/pab-nami/client/generated/Plutus/Contract/Effects.purs
@@ -128,7 +128,7 @@ data ChainIndexQuery
   | TxOutFromRef TxOutRef
   | TxFromTxId TxId
   | UtxoSetMembership TxOutRef
-  | UtxoSetAtAddress (PageQuery TxOutRef) Credential
+  | UtxoSetAtAddress (PageQuery TxOutRef) Address
   | UtxoSetWithCurrency (PageQuery TxOutRef) AssetClass
   | TxsFromTxIds (Array TxId)
   | TxoSetAtAddress (PageQuery TxOutRef) Credential
@@ -218,7 +218,7 @@ _UtxoSetMembership = prism' UtxoSetMembership case _ of
   (UtxoSetMembership a) -> Just a
   _ -> Nothing
 
-_UtxoSetAtAddress :: Prism' ChainIndexQuery { a :: PageQuery TxOutRef, b :: Credential }
+_UtxoSetAtAddress :: Prism' ChainIndexQuery { a :: PageQuery TxOutRef, b :: Address }
 _UtxoSetAtAddress = prism' (\{ a, b } -> (UtxoSetAtAddress a b)) case _ of
   (UtxoSetAtAddress a b) -> Just { a, b }
   _ -> Nothing

--- a/plutus-pab/src/Plutus/PAB/Core.hs
+++ b/plutus-pab/src/Plutus/PAB/Core.hs
@@ -104,7 +104,7 @@ import Data.Maybe (catMaybes)
 import Data.Proxy (Proxy (Proxy))
 import Data.Set (Set)
 import Data.Text (Text)
-import Ledger (Address (addressCredential), TxOutRef)
+import Ledger (TxOutRef)
 import Ledger.Address (PaymentPubKeyHash)
 import Ledger.Tx (CardanoTx, ciTxOutValue)
 import Ledger.TxId (TxId)
@@ -587,9 +587,9 @@ valueAt wallet = do
     txOutsM <- traverse ChainIndex.txOutFromRef utxoRefs
     pure $ foldMap (view ciTxOutValue) $ catMaybes txOutsM
   where
-    cred = addressCredential $ mockWalletAddress wallet
+    addr = mockWalletAddress wallet
     getAllUtxoRefs pq = do
-      utxoRefsPage <- page <$> ChainIndex.utxoSetAtAddress pq cred
+      utxoRefsPage <- page <$> ChainIndex.utxoSetAtAddress pq addr
       case ChainIndex.nextPageQuery utxoRefsPage of
         Nothing -> pure $ ChainIndex.pageItems utxoRefsPage
         Just newPageQuery -> do

--- a/plutus-playground-client/generated/Plutus/Contract/Effects.purs
+++ b/plutus-playground-client/generated/Plutus/Contract/Effects.purs
@@ -29,7 +29,6 @@ import Plutus.ChainIndex.Api (IsUtxoResponse, TxosResponse, UtxosResponse)
 import Plutus.ChainIndex.Tx (ChainIndexTx)
 import Plutus.ChainIndex.Types (RollbackState, Tip, TxOutState)
 import Plutus.V1.Ledger.Address (Address)
-import Plutus.V1.Ledger.Credential (Credential)
 import Plutus.V1.Ledger.Interval (Interval)
 import Plutus.V1.Ledger.Scripts (DatumHash, MintingPolicy, StakeValidator, Validator)
 import Plutus.V1.Ledger.Slot (Slot)
@@ -131,7 +130,7 @@ data ChainIndexQuery
   | UtxoSetAtAddress (PageQuery TxOutRef) Address
   | UtxoSetWithCurrency (PageQuery TxOutRef) AssetClass
   | TxsFromTxIds (Array TxId)
-  | TxoSetAtAddress (PageQuery TxOutRef) Credential
+  | TxoSetAtAddress (PageQuery TxOutRef) Address
   | GetTip
 
 derive instance Eq ChainIndexQuery
@@ -233,7 +232,7 @@ _TxsFromTxIds = prism' TxsFromTxIds case _ of
   (TxsFromTxIds a) -> Just a
   _ -> Nothing
 
-_TxoSetAtAddress :: Prism' ChainIndexQuery { a :: PageQuery TxOutRef, b :: Credential }
+_TxoSetAtAddress :: Prism' ChainIndexQuery { a :: PageQuery TxOutRef, b :: Address }
 _TxoSetAtAddress = prism' (\{ a, b } -> (TxoSetAtAddress a b)) case _ of
   (TxoSetAtAddress a b) -> Just { a, b }
   _ -> Nothing

--- a/plutus-playground-client/generated/Plutus/Contract/Effects.purs
+++ b/plutus-playground-client/generated/Plutus/Contract/Effects.purs
@@ -128,7 +128,7 @@ data ChainIndexQuery
   | TxOutFromRef TxOutRef
   | TxFromTxId TxId
   | UtxoSetMembership TxOutRef
-  | UtxoSetAtAddress (PageQuery TxOutRef) Credential
+  | UtxoSetAtAddress (PageQuery TxOutRef) Address
   | UtxoSetWithCurrency (PageQuery TxOutRef) AssetClass
   | TxsFromTxIds (Array TxId)
   | TxoSetAtAddress (PageQuery TxOutRef) Credential
@@ -218,7 +218,7 @@ _UtxoSetMembership = prism' UtxoSetMembership case _ of
   (UtxoSetMembership a) -> Just a
   _ -> Nothing
 
-_UtxoSetAtAddress :: Prism' ChainIndexQuery { a :: PageQuery TxOutRef, b :: Credential }
+_UtxoSetAtAddress :: Prism' ChainIndexQuery { a :: PageQuery TxOutRef, b :: Address }
 _UtxoSetAtAddress = prism' (\{ a, b } -> (UtxoSetAtAddress a b)) case _ of
   (UtxoSetAtAddress a b) -> Just { a, b }
   _ -> Nothing


### PR DESCRIPTION
Mostly cosmetic fix with no functionality changes. This allows handler to work with full address if staking credential is provided which is required when querying utxos from e.g. db-sync which uses `bech32` encoded address with staking credential. Current beam handler just grabs `Credential` from `addressCredential` which is now an implementation detail.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
