### PR TITLE
SCP-3431: Better syncing logging in the chain-index.

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-chain-index.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-chain-index.nix
@@ -38,6 +38,7 @@
           (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
           (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."async" or (errorHandler.buildDepError "async"))
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."beam-sqlite" or (errorHandler.buildDepError "beam-sqlite"))
           (hsPkgs."beam-migrate" or (errorHandler.buildDepError "beam-migrate"))
@@ -47,11 +48,13 @@
           (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
           (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
+          (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+          (hsPkgs."time-units" or (errorHandler.buildDepError "time-units"))
           (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
-          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
           ];
         buildable = true;
         modules = [
@@ -60,6 +63,7 @@
           "Plutus/ChainIndex/Config"
           "Plutus/ChainIndex/Lib"
           "Plutus/ChainIndex/Logging"
+          "Plutus/ChainIndex/SyncStats"
           ];
         hsSourceDirs = [ "src" ];
         };

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-chain-index.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-chain-index.nix
@@ -38,6 +38,7 @@
           (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
           (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."async" or (errorHandler.buildDepError "async"))
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."beam-sqlite" or (errorHandler.buildDepError "beam-sqlite"))
           (hsPkgs."beam-migrate" or (errorHandler.buildDepError "beam-migrate"))
@@ -47,11 +48,13 @@
           (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
           (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
+          (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+          (hsPkgs."time-units" or (errorHandler.buildDepError "time-units"))
           (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
-          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
           ];
         buildable = true;
         modules = [
@@ -60,6 +63,7 @@
           "Plutus/ChainIndex/Config"
           "Plutus/ChainIndex/Lib"
           "Plutus/ChainIndex/Logging"
+          "Plutus/ChainIndex/SyncStats"
           ];
         hsSourceDirs = [ "src" ];
         };

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-chain-index.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-chain-index.nix
@@ -38,6 +38,7 @@
           (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
           (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."async" or (errorHandler.buildDepError "async"))
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."beam-sqlite" or (errorHandler.buildDepError "beam-sqlite"))
           (hsPkgs."beam-migrate" or (errorHandler.buildDepError "beam-migrate"))
@@ -47,11 +48,13 @@
           (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
           (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
+          (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+          (hsPkgs."time-units" or (errorHandler.buildDepError "time-units"))
           (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
-          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
           ];
         buildable = true;
         modules = [
@@ -60,6 +63,7 @@
           "Plutus/ChainIndex/Config"
           "Plutus/ChainIndex/Lib"
           "Plutus/ChainIndex/Logging"
+          "Plutus/ChainIndex/SyncStats"
           ];
         hsSourceDirs = [ "src" ];
         };

--- a/plutus-chain-index/plutus-chain-index.cabal
+++ b/plutus-chain-index/plutus-chain-index.cabal
@@ -25,7 +25,7 @@ common lang
                         DeriveTraversable ImportQualifiedPost
     ghc-options: -Wall -Wnoncanonical-monad-instances -Wunused-packages
                  -Wincomplete-uni-patterns -Wincomplete-record-updates
-                 -Wredundant-constraints -Widentities
+                 -Wredundant-constraints -Widentities -Wmissing-import-lists
 
 library
     import: lang
@@ -35,6 +35,7 @@ library
         Plutus.ChainIndex.Config
         Plutus.ChainIndex.Lib
         Plutus.ChainIndex.Logging
+        Plutus.ChainIndex.SyncStats
     hs-source-dirs: src
     build-depends:
         plutus-ledger -any,
@@ -43,6 +44,7 @@ library
         freer-extras -any
     build-depends:
         aeson -any,
+        async -any,
         base >=4.7 && <5,
         beam-sqlite -any,
         beam-migrate -any,
@@ -52,11 +54,13 @@ library
         freer-simple -any,
         iohk-monitoring -any,
         lens -any,
+        optparse-applicative -any,
         ouroboros-network -any,
         prettyprinter >=1.1.0.1,
         sqlite-simple -any,
+        stm -any,
+        time-units -any,
         yaml -any,
-        optparse-applicative -any
 
 executable plutus-chain-index
   main-is: Main.hs

--- a/plutus-chain-index/src/Plutus/ChainIndex/App.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/App.hs
@@ -1,13 +1,9 @@
 {-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE GADTs               #-}
-{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
 
 {-| Main entry points to the chain index.
 -}
@@ -19,17 +15,25 @@ import Data.Foldable (for_)
 import Data.Function ((&))
 import Data.Yaml qualified as Y
 import Options.Applicative (execParser)
-import Prettyprinter (Pretty (..))
+import Prettyprinter (Pretty (pretty))
 
 import Cardano.BM.Configuration.Model qualified as CM
 
-import Plutus.ChainIndex.CommandLine (AppConfig (..), Command (..), applyOverrides, cmdWithHelpParser)
+import Cardano.BM.Setup (setupTrace_)
+import Cardano.BM.Trace (Trace)
+import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.STM.TChan (newBroadcastTChanIO)
+import Plutus.ChainIndex.CommandLine (AppConfig (AppConfig, acCLIConfigOverrides, acCommand, acConfigPath, acLogConfigPath, acMinLogLevel),
+                                      Command (DumpDefaultConfig, DumpDefaultLoggingConfig, StartChainIndex),
+                                      applyOverrides, cmdWithHelpParser)
 import Plutus.ChainIndex.Compatibility (fromCardanoBlockNo)
 import Plutus.ChainIndex.Config qualified as Config
-import Plutus.ChainIndex.Lib (defaultChainSyncHandler, getTipSlot, showingProgress, storeFromBlockNo, syncChainIndex,
-                              withRunRequirements)
+import Plutus.ChainIndex.Lib (defaultChainSyncHandler, getTipSlot, storeFromBlockNo, syncChainIndex,
+                              withRunRequirements, writeChainSyncEventToChan)
 import Plutus.ChainIndex.Logging qualified as Logging
 import Plutus.ChainIndex.Server qualified as Server
+import Plutus.ChainIndex.SyncStats (SyncLog, convertEventToSyncStats, logProgress)
+import Plutus.Monitoring.Util (PrettyObject (PrettyObject), convertLog, runLogEffects)
 
 main :: IO ()
 main = do
@@ -43,7 +47,7 @@ main = do
     DumpDefaultLoggingConfig path ->
       Logging.defaultConfig >>= CM.toRepresentation >>= Y.encodeFile path
 
-    StartChainIndex{} -> do
+    StartChainIndex {} -> do
       -- Initialise logging
       logConfig <- maybe Logging.defaultConfig Logging.loadConfig acLogConfigPath
       for_ acMinLogLevel $ \ll -> CM.setMinSeverity logConfig ll
@@ -73,13 +77,18 @@ runMain logConfig config = do
     slotNo <- getTipSlot config
     print slotNo
 
+    -- Channel for broadcasting 'ChainSyncEvent's
+    chan <- newBroadcastTChanIO
     syncHandler
       <- defaultChainSyncHandler runReq
         & storeFromBlockNo (fromCardanoBlockNo $ Config.cicStoreFrom config)
-        & showingProgress
+        & writeChainSyncEventToChan convertEventToSyncStats chan
 
     putStrLn $ "Connecting to the node using socket: " <> Config.cicSocketPath config
     syncChainIndex config runReq syncHandler
+
+    (trace :: Trace IO (PrettyObject SyncLog), _) <- setupTrace_ logConfig "chain-index"
+    withAsync (runLogEffects (convertLog PrettyObject trace) $ logProgress chan) wait
 
     let port = show (Config.cicPort config)
     putStrLn $ "Starting webserver on port " <> port

--- a/plutus-chain-index/src/Plutus/ChainIndex/CommandLine.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/CommandLine.hs
@@ -12,8 +12,8 @@ import Control.Lens (over)
 import Options.Applicative (CommandFields, Mod, Parser, ParserInfo, argument, auto, command, flag, fullDesc, header,
                             help, helper, hsubparser, info, long, metavar, option, progDesc, short, str, value, (<**>))
 
-import Cardano.Api (NetworkId (..), NetworkMagic (..))
-import Cardano.BM.Data.Severity
+import Cardano.Api (NetworkId (Testnet), NetworkMagic (NetworkMagic))
+import Cardano.BM.Data.Severity (Severity (Debug))
 import GHC.Word (Word32)
 import Plutus.ChainIndex.Config (ChainIndexConfig)
 import Plutus.ChainIndex.Config qualified as Config

--- a/plutus-chain-index/src/Plutus/ChainIndex/Config.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Config.hs
@@ -21,14 +21,14 @@ module Plutus.ChainIndex.Config(
   storeFrom
   ) where
 
-import Cardano.Api (BlockNo (..), NetworkId (..))
+import Cardano.Api (BlockNo (BlockNo), NetworkId (Mainnet, Testnet))
 import Control.Exception (Exception)
 import Control.Lens (makeLensesFor)
 import Data.Aeson (FromJSON, ToJSON)
 import GHC.Generics (Generic)
-import Ledger.TimeSlot (SlotConfig (..))
-import Ouroboros.Network.Magic (NetworkMagic (..))
-import Prettyprinter (Pretty (..), viaShow, vsep, (<+>))
+import Ledger.TimeSlot (SlotConfig (SlotConfig, scSlotLength, scSlotZeroTime))
+import Ouroboros.Network.Magic (NetworkMagic (NetworkMagic))
+import Prettyprinter (Pretty (pretty), viaShow, vsep, (<+>))
 
 data ChainIndexConfig = ChainIndexConfig
   { cicSocketPath    :: String

--- a/plutus-chain-index/src/Plutus/ChainIndex/Logging.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Logging.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -8,10 +6,11 @@ module Plutus.ChainIndex.Logging where
 
 import Cardano.BM.Configuration (setup)
 import Cardano.BM.Configuration.Model qualified as CM
-import Cardano.BM.Data.BackendKind
-import Cardano.BM.Data.Configuration (Endpoint (..))
-import Cardano.BM.Data.Output
-import Cardano.BM.Data.Severity
+import Cardano.BM.Data.BackendKind (BackendKind (AggregationBK, EKGViewBK, KatipBK, MonitoringBK))
+import Cardano.BM.Data.Configuration (Endpoint (Endpoint))
+import Cardano.BM.Data.Output (ScribeDefinition (ScribeDefinition, scFormat, scKind, scMaxSev, scMinSev, scName, scPrivacy, scRotation),
+                               ScribeFormat (ScText), ScribeKind (StdoutSK), ScribePrivacy (ScPublic))
+import Cardano.BM.Data.Severity (Severity (Info))
 
 -- | Logging (definitions from Plutus.PAB.Monitoring.Config)
 

--- a/plutus-chain-index/src/Plutus/ChainIndex/SyncStats.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/SyncStats.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Plutus.ChainIndex.SyncStats where
+
+import Cardano.BM.Tracing (ToObject)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.STM (TChan, atomically, dupTChan, tryReadTChan)
+import Control.Monad.Freer (Eff, LastMember, Member)
+import Control.Monad.Freer.Extras (LogMsg, logInfo, logWarn)
+import Control.Monad.IO.Class (liftIO)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Time.Units (Second, TimeUnit (fromMicroseconds))
+import GHC.Generics (Generic)
+import Ledger (Slot (Slot))
+import Plutus.ChainIndex (Point (PointAtGenesis), tipAsPoint)
+import Plutus.ChainIndex qualified as CI
+import Plutus.ChainIndex.Lib (ChainSyncEvent (Resume, RollBackward, RollForward))
+import Prettyprinter (Pretty (pretty), comma, viaShow, (<+>))
+import Text.Printf (printf)
+
+data SyncStats = SyncStats
+    { syncStatsAppliedBlocks    :: Integer -- ^ Number of applied blocks
+    , syncStatsAppliedRollbacks :: Integer -- ^ Number of rollbacks
+    , syncStatsChainSyncPoint   :: CI.Point -- ^ Chain index syncing tip
+    , syncStatsNodePoint        :: CI.Point -- ^ Current tip of the node
+    }
+    deriving stock (Eq, Show, Generic)
+    deriving anyclass (FromJSON, ToJSON, ToObject)
+
+instance Semigroup SyncStats where
+    SyncStats n1 m1 ct1 nt1 <> SyncStats n2 m2 ct2 nt2 =
+        SyncStats (n1 + n2) (m1 + m2) (ct1 <> ct2) (nt1 <> nt2)
+
+instance Monoid SyncStats where
+    mempty = SyncStats 0 0 mempty mempty
+
+data SyncLog = SyncLog
+    { syncStateSyncLog :: SyncState -- ^ State of the syncing
+    , syncStatsSyncLog :: SyncStats -- ^ Stats of the syncing
+    , delaySyncLog     :: Second -- ^ Delay in seconds used to accumulate log events
+    }
+    deriving stock (Eq, Show, Generic)
+    deriving anyclass (FromJSON, ToJSON, ToObject)
+
+instance Pretty SyncLog where
+  pretty = \case
+    SyncLog syncState
+            (SyncStats numRollForward numRollBackwards chainSyncPoint _)
+            seconds ->
+        let currentTipMsg NotSyncing = ""
+            currentTipMsg _          = "Current tip is" <+> pretty chainSyncPoint
+         in
+            pretty syncState
+                <+> "Applied"
+                <+> pretty numRollForward
+                <+> "blocks"
+                <> comma
+                <+> pretty numRollBackwards
+                <+> "rollbacks in the last"
+                <+> viaShow seconds
+                <> "."
+                <+> currentTipMsg syncState
+
+data SyncState = Synced | Syncing Double | NotSyncing
+    deriving stock (Eq, Show, Generic)
+    deriving anyclass (FromJSON, ToJSON, ToObject)
+
+instance Pretty SyncState where
+  pretty = \case
+    Synced      -> "Still in sync."
+    Syncing pct -> "Syncing (" <> pretty (printf "%.2f" pct :: String) <> "%)."
+    NotSyncing  -> "Not syncing."
+
+-- | Read 'ChainSyncEvent's for the 'TChan' every 30 seconds and log syncing summary.
+logProgress :: forall effs.
+    ( Member (LogMsg SyncLog) effs
+    , LastMember IO effs
+    )
+    => TChan SyncStats
+    -> Eff effs ()
+logProgress broadcastChan = do
+    chan <- liftIO $ atomically $ dupTChan broadcastChan
+    go chan 30_000_000 -- 30s
+  where
+    go chan delay = do
+        liftIO $ threadDelay (fromIntegral delay)
+        syncStats <- liftIO $ foldTChanUntilEmpty chan
+        let syncState = getSyncStateFromStats syncStats
+        case syncState of
+          NotSyncing -> do
+              logWarn $ SyncLog syncState syncStats (fromMicroseconds delay)
+              go chan 300_000_000 -- 300s
+          Synced -> do
+              logInfo $ SyncLog syncState syncStats (fromMicroseconds delay)
+              go chan 300_000_000 -- 300s
+          Syncing _ -> do
+              logInfo $ SyncLog syncState syncStats (fromMicroseconds delay)
+              go chan 30_000_000 -- 30s
+
+-- | Get the 'SyncState' for a 'SyncState'.
+--
+-- TODO: The syncing percentage is valid when the node is already fully synced.
+-- But when the node and chain-index are started at the same time, the syncing
+-- percentage is not a valid number considering the actual tip of the node.
+-- Find a better way to calculate this percentage.
+getSyncStateFromStats :: SyncStats -> SyncState
+getSyncStateFromStats (SyncStats _ _ chainSyncPoint nodePoint) =
+    case (chainSyncPoint, nodePoint) of
+        (_, PointAtGenesis) -> NotSyncing
+        (CI.PointAtGenesis, CI.Point _ _) -> Syncing 0
+        (CI.Point (Slot chainSyncSlot) _, CI.Point (Slot nodeSlot) _)
+          -- TODO: MAGIC number here. Is there a better number?
+          -- 100 represents the number of slots before the
+          -- node where we consider the chain-index to be synced.
+          | nodeSlot - chainSyncSlot < 100 -> Synced
+        (CI.Point (Slot chainSyncSlot) _, CI.Point (Slot nodeSlot) _) ->
+            let pct = ((100 :: Double) * fromIntegral chainSyncSlot) / fromIntegral nodeSlot
+             in Syncing pct
+
+-- | Read all elements from the 'TChan' until it is empty and combine them with
+-- it's 'Monoid' instance.
+foldTChanUntilEmpty :: (Monoid a) => TChan a -> IO a
+foldTChanUntilEmpty chan =
+    let go combined = do
+            elementM <- atomically $ tryReadTChan chan
+            case elementM of
+              Nothing      -> pure combined
+              Just element -> go (combined <> element)
+     in go mempty
+
+convertEventToSyncStats :: ChainSyncEvent -> SyncStats
+convertEventToSyncStats (RollForward (CI.Block chainSyncTip _) nodeTip) =
+    SyncStats 1 0 (tipAsPoint chainSyncTip) (tipAsPoint nodeTip)
+convertEventToSyncStats (RollBackward chainSyncPoint nodeTip) =
+    SyncStats 0 1 chainSyncPoint (tipAsPoint nodeTip)
+convertEventToSyncStats (Resume chainSyncPoint) =
+    SyncStats 0 0 chainSyncPoint mempty

--- a/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions.txt
@@ -1,65 +1,65 @@
 Slot 00000: TxnValidate 98d5fbcefe21113b3f0390c1441e075b8a870cc5a8fa2a56dcde1d8247e41715
 Slot 00000: SlotAdd Slot 1
-Slot 00001: W1bc5f27: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: W3a47782: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: W4e76ce6: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: W5f5a4f5: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: W7ce812d: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: W872cb83: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: Wbdf8dbc: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: Wc19599f: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: Wc30efb7: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: Wd3eddd0: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
+Slot 00001: W1bc5f27: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: W3a47782: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: W4e76ce6: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: W5f5a4f5: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: W7ce812d: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: W872cb83: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: Wbdf8dbc: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: Wc19599f: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: Wc30efb7: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: Wd3eddd0: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
 Slot 00001: W872cb83: TxSubmit: 5fbf9df5dedb42fd29135c7d8b2bd15413abdd9efef6cae3780aafb915c278cd
 Slot 00001: TxnValidate 5fbf9df5dedb42fd29135c7d8b2bd15413abdd9efef6cae3780aafb915c278cd
 Slot 00001: SlotAdd Slot 2
-Slot 00002: W1bc5f27: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3), blockNo= 1). UTxO state was added to the end.
-Slot 00002: W3a47782: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3), blockNo= 1). UTxO state was added to the end.
-Slot 00002: W4e76ce6: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3), blockNo= 1). UTxO state was added to the end.
-Slot 00002: W5f5a4f5: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3), blockNo= 1). UTxO state was added to the end.
-Slot 00002: W7ce812d: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3), blockNo= 1). UTxO state was added to the end.
-Slot 00002: W872cb83: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3), blockNo= 1). UTxO state was added to the end.
-Slot 00002: Wbdf8dbc: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3), blockNo= 1). UTxO state was added to the end.
-Slot 00002: Wc19599f: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3), blockNo= 1). UTxO state was added to the end.
-Slot 00002: Wc30efb7: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3), blockNo= 1). UTxO state was added to the end.
-Slot 00002: Wd3eddd0: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3), blockNo= 1). UTxO state was added to the end.
+Slot 00002: W1bc5f27: InsertionSuccess: New tip is Tip(Slot 2, BlockId 1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W3a47782: InsertionSuccess: New tip is Tip(Slot 2, BlockId 1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W4e76ce6: InsertionSuccess: New tip is Tip(Slot 2, BlockId 1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W5f5a4f5: InsertionSuccess: New tip is Tip(Slot 2, BlockId 1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W7ce812d: InsertionSuccess: New tip is Tip(Slot 2, BlockId 1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W872cb83: InsertionSuccess: New tip is Tip(Slot 2, BlockId 1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: Wbdf8dbc: InsertionSuccess: New tip is Tip(Slot 2, BlockId 1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: Wc19599f: InsertionSuccess: New tip is Tip(Slot 2, BlockId 1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: Wc30efb7: InsertionSuccess: New tip is Tip(Slot 2, BlockId 1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: Wd3eddd0: InsertionSuccess: New tip is Tip(Slot 2, BlockId 1a2bb99590f7f1513dc6c6a068c0a483668bf91cf30703d202c6c1c9ccad71b3, BlockNumber 1). UTxO state was added to the end.
 Slot 00002: W7ce812d: TxSubmit: 96d70e6a37b36fbc061c7cc3cfd7fef0e190c31ced3e3be51298f98bfb2db25a
 Slot 00002: TxnValidate 96d70e6a37b36fbc061c7cc3cfd7fef0e190c31ced3e3be51298f98bfb2db25a
 Slot 00002: SlotAdd Slot 3
-Slot 00003: W1bc5f27: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468), blockNo= 2). UTxO state was added to the end.
-Slot 00003: W3a47782: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468), blockNo= 2). UTxO state was added to the end.
-Slot 00003: W4e76ce6: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468), blockNo= 2). UTxO state was added to the end.
-Slot 00003: W5f5a4f5: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468), blockNo= 2). UTxO state was added to the end.
-Slot 00003: W7ce812d: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468), blockNo= 2). UTxO state was added to the end.
-Slot 00003: W872cb83: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468), blockNo= 2). UTxO state was added to the end.
-Slot 00003: Wbdf8dbc: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468), blockNo= 2). UTxO state was added to the end.
-Slot 00003: Wc19599f: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468), blockNo= 2). UTxO state was added to the end.
-Slot 00003: Wc30efb7: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468), blockNo= 2). UTxO state was added to the end.
-Slot 00003: Wd3eddd0: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468), blockNo= 2). UTxO state was added to the end.
+Slot 00003: W1bc5f27: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W3a47782: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W4e76ce6: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W5f5a4f5: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W7ce812d: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W872cb83: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: Wbdf8dbc: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: Wc19599f: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: Wc30efb7: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: Wd3eddd0: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5136a94e19ce23b8fefe74f386c117d89944f8e14ba19da89f7b7a60944ab468, BlockNumber 2). UTxO state was added to the end.
 Slot 00003: Wc30efb7: TxSubmit: e1af35831a7c34b97b70e3f3b5381428814466bc769a9d864ad39ca49170e3e5
 Slot 00003: TxnValidate e1af35831a7c34b97b70e3f3b5381428814466bc769a9d864ad39ca49170e3e5
 Slot 00003: SlotAdd Slot 4
-Slot 00004: W1bc5f27: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7), blockNo= 3). UTxO state was added to the end.
-Slot 00004: W3a47782: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7), blockNo= 3). UTxO state was added to the end.
-Slot 00004: W4e76ce6: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7), blockNo= 3). UTxO state was added to the end.
-Slot 00004: W5f5a4f5: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7), blockNo= 3). UTxO state was added to the end.
-Slot 00004: W7ce812d: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7), blockNo= 3). UTxO state was added to the end.
-Slot 00004: W872cb83: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7), blockNo= 3). UTxO state was added to the end.
-Slot 00004: Wbdf8dbc: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7), blockNo= 3). UTxO state was added to the end.
-Slot 00004: Wc19599f: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7), blockNo= 3). UTxO state was added to the end.
-Slot 00004: Wc30efb7: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7), blockNo= 3). UTxO state was added to the end.
-Slot 00004: Wd3eddd0: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7), blockNo= 3). UTxO state was added to the end.
+Slot 00004: W1bc5f27: InsertionSuccess: New tip is Tip(Slot 4, BlockId 178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W3a47782: InsertionSuccess: New tip is Tip(Slot 4, BlockId 178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W4e76ce6: InsertionSuccess: New tip is Tip(Slot 4, BlockId 178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W5f5a4f5: InsertionSuccess: New tip is Tip(Slot 4, BlockId 178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W7ce812d: InsertionSuccess: New tip is Tip(Slot 4, BlockId 178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W872cb83: InsertionSuccess: New tip is Tip(Slot 4, BlockId 178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: Wbdf8dbc: InsertionSuccess: New tip is Tip(Slot 4, BlockId 178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: Wc19599f: InsertionSuccess: New tip is Tip(Slot 4, BlockId 178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: Wc30efb7: InsertionSuccess: New tip is Tip(Slot 4, BlockId 178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: Wd3eddd0: InsertionSuccess: New tip is Tip(Slot 4, BlockId 178667e9898350c266370b9f3a3c3c6ab736190108679c647de8e8c8eccd3cd7, BlockNumber 3). UTxO state was added to the end.
 Slot 00004: SlotAdd Slot 5
-Slot 00005: W1bc5f27: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 4). UTxO state was added to the end.
-Slot 00005: W3a47782: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 4). UTxO state was added to the end.
-Slot 00005: W4e76ce6: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 4). UTxO state was added to the end.
-Slot 00005: W5f5a4f5: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 4). UTxO state was added to the end.
-Slot 00005: W7ce812d: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 4). UTxO state was added to the end.
-Slot 00005: W872cb83: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 4). UTxO state was added to the end.
-Slot 00005: Wbdf8dbc: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 4). UTxO state was added to the end.
-Slot 00005: Wc19599f: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 4). UTxO state was added to the end.
-Slot 00005: Wc30efb7: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 4). UTxO state was added to the end.
-Slot 00005: Wd3eddd0: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 4). UTxO state was added to the end.
+Slot 00005: W1bc5f27: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W3a47782: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W4e76ce6: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W5f5a4f5: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W7ce812d: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W872cb83: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: Wbdf8dbc: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: Wc19599f: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: Wc30efb7: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: Wd3eddd0: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.
 Final balances
 Wallet 1bc5f27d7b4e20083977418e839e429d00cc87f3: 
     {, ""}: 100000000

--- a/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions2.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions2.txt
@@ -1,78 +1,78 @@
 Slot 00000: TxnValidate 98d5fbcefe21113b3f0390c1441e075b8a870cc5a8fa2a56dcde1d8247e41715
 Slot 00000: SlotAdd Slot 1
-Slot 00001: W1bc5f27: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: W3a47782: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: W4e76ce6: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: W5f5a4f5: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: W7ce812d: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: W872cb83: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: Wbdf8dbc: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: Wc19599f: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: Wc30efb7: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: Wd3eddd0: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
+Slot 00001: W1bc5f27: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: W3a47782: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: W4e76ce6: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: W5f5a4f5: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: W7ce812d: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: W872cb83: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: Wbdf8dbc: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: Wc19599f: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: Wc30efb7: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: Wd3eddd0: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
 Slot 00001: W872cb83: TxSubmit: c8efa3052773d734f6f88dc1a50fb94da80091ffe98ef60a7e7d9baaafca272d
 Slot 00001: TxnValidate c8efa3052773d734f6f88dc1a50fb94da80091ffe98ef60a7e7d9baaafca272d
 Slot 00001: SlotAdd Slot 2
-Slot 00002: W1bc5f27: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146), blockNo= 1). UTxO state was added to the end.
-Slot 00002: W3a47782: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146), blockNo= 1). UTxO state was added to the end.
-Slot 00002: W4e76ce6: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146), blockNo= 1). UTxO state was added to the end.
-Slot 00002: W5f5a4f5: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146), blockNo= 1). UTxO state was added to the end.
-Slot 00002: W7ce812d: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146), blockNo= 1). UTxO state was added to the end.
-Slot 00002: W872cb83: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146), blockNo= 1). UTxO state was added to the end.
-Slot 00002: Wbdf8dbc: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146), blockNo= 1). UTxO state was added to the end.
-Slot 00002: Wc19599f: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146), blockNo= 1). UTxO state was added to the end.
-Slot 00002: Wc30efb7: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146), blockNo= 1). UTxO state was added to the end.
-Slot 00002: Wd3eddd0: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146), blockNo= 1). UTxO state was added to the end.
+Slot 00002: W1bc5f27: InsertionSuccess: New tip is Tip(Slot 2, BlockId 129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W3a47782: InsertionSuccess: New tip is Tip(Slot 2, BlockId 129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W4e76ce6: InsertionSuccess: New tip is Tip(Slot 2, BlockId 129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W5f5a4f5: InsertionSuccess: New tip is Tip(Slot 2, BlockId 129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W7ce812d: InsertionSuccess: New tip is Tip(Slot 2, BlockId 129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W872cb83: InsertionSuccess: New tip is Tip(Slot 2, BlockId 129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: Wbdf8dbc: InsertionSuccess: New tip is Tip(Slot 2, BlockId 129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: Wc19599f: InsertionSuccess: New tip is Tip(Slot 2, BlockId 129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: Wc30efb7: InsertionSuccess: New tip is Tip(Slot 2, BlockId 129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: Wd3eddd0: InsertionSuccess: New tip is Tip(Slot 2, BlockId 129b72c20d4ce4ccb057d521cca1f0b8583f74bb3b2bbec03690497b05e79146, BlockNumber 1). UTxO state was added to the end.
 Slot 00002: W7ce812d: TxSubmit: 0721804b430d1a4d0b1e89945891dba730ed19e8d733ec1790fce612d0d23968
 Slot 00002: TxnValidate 0721804b430d1a4d0b1e89945891dba730ed19e8d733ec1790fce612d0d23968
 Slot 00002: SlotAdd Slot 3
-Slot 00003: W1bc5f27: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0), blockNo= 2). UTxO state was added to the end.
-Slot 00003: W3a47782: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0), blockNo= 2). UTxO state was added to the end.
-Slot 00003: W4e76ce6: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0), blockNo= 2). UTxO state was added to the end.
-Slot 00003: W5f5a4f5: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0), blockNo= 2). UTxO state was added to the end.
-Slot 00003: W7ce812d: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0), blockNo= 2). UTxO state was added to the end.
-Slot 00003: W872cb83: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0), blockNo= 2). UTxO state was added to the end.
-Slot 00003: Wbdf8dbc: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0), blockNo= 2). UTxO state was added to the end.
-Slot 00003: Wc19599f: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0), blockNo= 2). UTxO state was added to the end.
-Slot 00003: Wc30efb7: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0), blockNo= 2). UTxO state was added to the end.
-Slot 00003: Wd3eddd0: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0), blockNo= 2). UTxO state was added to the end.
+Slot 00003: W1bc5f27: InsertionSuccess: New tip is Tip(Slot 3, BlockId 7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W3a47782: InsertionSuccess: New tip is Tip(Slot 3, BlockId 7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W4e76ce6: InsertionSuccess: New tip is Tip(Slot 3, BlockId 7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W5f5a4f5: InsertionSuccess: New tip is Tip(Slot 3, BlockId 7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W7ce812d: InsertionSuccess: New tip is Tip(Slot 3, BlockId 7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W872cb83: InsertionSuccess: New tip is Tip(Slot 3, BlockId 7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: Wbdf8dbc: InsertionSuccess: New tip is Tip(Slot 3, BlockId 7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: Wc19599f: InsertionSuccess: New tip is Tip(Slot 3, BlockId 7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: Wc30efb7: InsertionSuccess: New tip is Tip(Slot 3, BlockId 7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: Wd3eddd0: InsertionSuccess: New tip is Tip(Slot 3, BlockId 7503b9f5864e5aebcf8b294f264398527960e0810e7f70ec21cb2d882580f5b0, BlockNumber 2). UTxO state was added to the end.
 Slot 00003: Wc30efb7: TxSubmit: bb6938ca95aad9c4665cd994c4987b1b4369d16d3880ef00f0a101ce7212ff30
 Slot 00003: TxnValidate bb6938ca95aad9c4665cd994c4987b1b4369d16d3880ef00f0a101ce7212ff30
 Slot 00003: SlotAdd Slot 4
-Slot 00004: W1bc5f27: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc), blockNo= 3). UTxO state was added to the end.
-Slot 00004: W3a47782: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc), blockNo= 3). UTxO state was added to the end.
-Slot 00004: W4e76ce6: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc), blockNo= 3). UTxO state was added to the end.
-Slot 00004: W5f5a4f5: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc), blockNo= 3). UTxO state was added to the end.
-Slot 00004: W7ce812d: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc), blockNo= 3). UTxO state was added to the end.
-Slot 00004: W872cb83: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc), blockNo= 3). UTxO state was added to the end.
-Slot 00004: Wbdf8dbc: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc), blockNo= 3). UTxO state was added to the end.
-Slot 00004: Wc19599f: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc), blockNo= 3). UTxO state was added to the end.
-Slot 00004: Wc30efb7: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc), blockNo= 3). UTxO state was added to the end.
-Slot 00004: Wd3eddd0: InsertionSuccess: New tip is Tip(slot= Slot 4, blockId= BlockId(05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc), blockNo= 3). UTxO state was added to the end.
+Slot 00004: W1bc5f27: InsertionSuccess: New tip is Tip(Slot 4, BlockId 05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W3a47782: InsertionSuccess: New tip is Tip(Slot 4, BlockId 05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W4e76ce6: InsertionSuccess: New tip is Tip(Slot 4, BlockId 05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W5f5a4f5: InsertionSuccess: New tip is Tip(Slot 4, BlockId 05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W7ce812d: InsertionSuccess: New tip is Tip(Slot 4, BlockId 05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W872cb83: InsertionSuccess: New tip is Tip(Slot 4, BlockId 05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: Wbdf8dbc: InsertionSuccess: New tip is Tip(Slot 4, BlockId 05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: Wc19599f: InsertionSuccess: New tip is Tip(Slot 4, BlockId 05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: Wc30efb7: InsertionSuccess: New tip is Tip(Slot 4, BlockId 05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: Wd3eddd0: InsertionSuccess: New tip is Tip(Slot 4, BlockId 05bdfe1dd592af45f1e2f31c3f9ea24d67128424369b4b0c5f11c2d886b17bdc, BlockNumber 3). UTxO state was added to the end.
 Slot 00004: W872cb83: TxSubmit: 3311cd600bea89be3cbe9bf79159afdddff55b290fa6677f11396f19fc9d6e06
 Slot 00004: TxnValidate 3311cd600bea89be3cbe9bf79159afdddff55b290fa6677f11396f19fc9d6e06
 Slot 00004: SlotAdd Slot 5
-Slot 00005: W1bc5f27: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4), blockNo= 4). UTxO state was added to the end.
-Slot 00005: W3a47782: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4), blockNo= 4). UTxO state was added to the end.
-Slot 00005: W4e76ce6: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4), blockNo= 4). UTxO state was added to the end.
-Slot 00005: W5f5a4f5: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4), blockNo= 4). UTxO state was added to the end.
-Slot 00005: W7ce812d: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4), blockNo= 4). UTxO state was added to the end.
-Slot 00005: W872cb83: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4), blockNo= 4). UTxO state was added to the end.
-Slot 00005: Wbdf8dbc: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4), blockNo= 4). UTxO state was added to the end.
-Slot 00005: Wc19599f: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4), blockNo= 4). UTxO state was added to the end.
-Slot 00005: Wc30efb7: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4), blockNo= 4). UTxO state was added to the end.
-Slot 00005: Wd3eddd0: InsertionSuccess: New tip is Tip(slot= Slot 5, blockId= BlockId(0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4), blockNo= 4). UTxO state was added to the end.
+Slot 00005: W1bc5f27: InsertionSuccess: New tip is Tip(Slot 5, BlockId 0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W3a47782: InsertionSuccess: New tip is Tip(Slot 5, BlockId 0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W4e76ce6: InsertionSuccess: New tip is Tip(Slot 5, BlockId 0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W5f5a4f5: InsertionSuccess: New tip is Tip(Slot 5, BlockId 0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W7ce812d: InsertionSuccess: New tip is Tip(Slot 5, BlockId 0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W872cb83: InsertionSuccess: New tip is Tip(Slot 5, BlockId 0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: Wbdf8dbc: InsertionSuccess: New tip is Tip(Slot 5, BlockId 0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: Wc19599f: InsertionSuccess: New tip is Tip(Slot 5, BlockId 0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: Wc30efb7: InsertionSuccess: New tip is Tip(Slot 5, BlockId 0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: Wd3eddd0: InsertionSuccess: New tip is Tip(Slot 5, BlockId 0af3b55936658b33cb8f9efea912089a992948c218ce9d7965b60a7a84a684e4, BlockNumber 4). UTxO state was added to the end.
 Slot 00005: SlotAdd Slot 6
-Slot 00006: W1bc5f27: InsertionSuccess: New tip is Tip(slot= Slot 6, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 5). UTxO state was added to the end.
-Slot 00006: W3a47782: InsertionSuccess: New tip is Tip(slot= Slot 6, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 5). UTxO state was added to the end.
-Slot 00006: W4e76ce6: InsertionSuccess: New tip is Tip(slot= Slot 6, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 5). UTxO state was added to the end.
-Slot 00006: W5f5a4f5: InsertionSuccess: New tip is Tip(slot= Slot 6, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 5). UTxO state was added to the end.
-Slot 00006: W7ce812d: InsertionSuccess: New tip is Tip(slot= Slot 6, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 5). UTxO state was added to the end.
-Slot 00006: W872cb83: InsertionSuccess: New tip is Tip(slot= Slot 6, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 5). UTxO state was added to the end.
-Slot 00006: Wbdf8dbc: InsertionSuccess: New tip is Tip(slot= Slot 6, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 5). UTxO state was added to the end.
-Slot 00006: Wc19599f: InsertionSuccess: New tip is Tip(slot= Slot 6, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 5). UTxO state was added to the end.
-Slot 00006: Wc30efb7: InsertionSuccess: New tip is Tip(slot= Slot 6, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 5). UTxO state was added to the end.
-Slot 00006: Wd3eddd0: InsertionSuccess: New tip is Tip(slot= Slot 6, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 5). UTxO state was added to the end.
+Slot 00006: W1bc5f27: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.
+Slot 00006: W3a47782: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.
+Slot 00006: W4e76ce6: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.
+Slot 00006: W5f5a4f5: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.
+Slot 00006: W7ce812d: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.
+Slot 00006: W872cb83: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.
+Slot 00006: Wbdf8dbc: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.
+Slot 00006: Wc19599f: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.
+Slot 00006: Wc30efb7: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.
+Slot 00006: Wd3eddd0: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.
 Final balances
 Wallet 1bc5f27d7b4e20083977418e839e429d00cc87f3: 
     {, ""}: 100000000

--- a/plutus-contract/test/Spec/golden/traceOutput - wait1.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - wait1.txt
@@ -1,37 +1,37 @@
 Slot 00000: TxnValidate 98d5fbcefe21113b3f0390c1441e075b8a870cc5a8fa2a56dcde1d8247e41715
 Slot 00000: SlotAdd Slot 1
-Slot 00001: W1bc5f27: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: W3a47782: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: W4e76ce6: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: W5f5a4f5: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: W7ce812d: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: W872cb83: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: Wbdf8dbc: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: Wc19599f: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: Wc30efb7: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
-Slot 00001: Wd3eddd0: InsertionSuccess: New tip is Tip(slot= Slot 1, blockId= BlockId(1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c), blockNo= 0). UTxO state was added to the end.
+Slot 00001: W1bc5f27: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: W3a47782: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: W4e76ce6: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: W5f5a4f5: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: W7ce812d: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: W872cb83: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: Wbdf8dbc: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: Wc19599f: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: Wc30efb7: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
+Slot 00001: Wd3eddd0: InsertionSuccess: New tip is Tip(Slot 1, BlockId 1033bd6bfb9d90108db08880ad32a58980ae8dafd14c6217d7f83db6fae6f70c, BlockNumber 0). UTxO state was added to the end.
 Slot 00001: SlotAdd Slot 2
-Slot 00002: W1bc5f27: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 1). UTxO state was added to the end.
-Slot 00002: W3a47782: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 1). UTxO state was added to the end.
-Slot 00002: W4e76ce6: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 1). UTxO state was added to the end.
-Slot 00002: W5f5a4f5: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 1). UTxO state was added to the end.
-Slot 00002: W7ce812d: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 1). UTxO state was added to the end.
-Slot 00002: W872cb83: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 1). UTxO state was added to the end.
-Slot 00002: Wbdf8dbc: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 1). UTxO state was added to the end.
-Slot 00002: Wc19599f: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 1). UTxO state was added to the end.
-Slot 00002: Wc30efb7: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 1). UTxO state was added to the end.
-Slot 00002: Wd3eddd0: InsertionSuccess: New tip is Tip(slot= Slot 2, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 1). UTxO state was added to the end.
+Slot 00002: W1bc5f27: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W3a47782: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W4e76ce6: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W5f5a4f5: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W7ce812d: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W872cb83: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: Wbdf8dbc: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: Wc19599f: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: Wc30efb7: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: Wd3eddd0: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.
 Slot 00002: SlotAdd Slot 3
-Slot 00003: W1bc5f27: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 2). UTxO state was added to the end.
-Slot 00003: W3a47782: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 2). UTxO state was added to the end.
-Slot 00003: W4e76ce6: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 2). UTxO state was added to the end.
-Slot 00003: W5f5a4f5: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 2). UTxO state was added to the end.
-Slot 00003: W7ce812d: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 2). UTxO state was added to the end.
-Slot 00003: W872cb83: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 2). UTxO state was added to the end.
-Slot 00003: Wbdf8dbc: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 2). UTxO state was added to the end.
-Slot 00003: Wc19599f: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 2). UTxO state was added to the end.
-Slot 00003: Wc30efb7: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 2). UTxO state was added to the end.
-Slot 00003: Wd3eddd0: InsertionSuccess: New tip is Tip(slot= Slot 3, blockId= BlockId(76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71), blockNo= 2). UTxO state was added to the end.
+Slot 00003: W1bc5f27: InsertionSuccess: New tip is Tip(Slot 3, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W3a47782: InsertionSuccess: New tip is Tip(Slot 3, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W4e76ce6: InsertionSuccess: New tip is Tip(Slot 3, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W5f5a4f5: InsertionSuccess: New tip is Tip(Slot 3, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W7ce812d: InsertionSuccess: New tip is Tip(Slot 3, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W872cb83: InsertionSuccess: New tip is Tip(Slot 3, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: Wbdf8dbc: InsertionSuccess: New tip is Tip(Slot 3, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: Wc19599f: InsertionSuccess: New tip is Tip(Slot 3, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: Wc30efb7: InsertionSuccess: New tip is Tip(Slot 3, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: Wd3eddd0: InsertionSuccess: New tip is Tip(Slot 3, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 2). UTxO state was added to the end.
 Final balances
 Wallet 1bc5f27d7b4e20083977418e839e429d00cc87f3: 
     {, ""}: 100000000

--- a/plutus-ledger/src/Ledger/Blockchain.hs
+++ b/plutus-ledger/src/Ledger/Blockchain.hs
@@ -77,7 +77,9 @@ instance OpenApi.ToSchema BlockId where
     declareNamedSchema _ = OpenApi.declareNamedSchema (Proxy @String)
 
 instance Pretty BlockId where
-    pretty (BlockId blockId) = "BlockId(" <> pretty (fromRight (JSON.encodeByteString blockId) $ decodeUtf8' blockId) <> ")"
+    pretty (BlockId blockId) =
+        "BlockId "
+     <> pretty (fromRight (JSON.encodeByteString blockId) $ decodeUtf8' blockId)
 
 -- | A transaction on the blockchain.
 -- Invalid transactions are still put on the chain to be able to collect fees.


### PR DESCRIPTION
Summary of changes:

* Syncing message now logs every 30s

* Prints syncing percentage, number of applied blocks, number of rollbacks and current tip

* Logging uses the Trace for more consistent logging with PAB and cardano-node.

* Added warning flag for missing import list

Example of new chain-index logging (the number shown are not the actual values):

```
[chain-index:Warning:30] [2022-02-09 13:59:51.71 UTC] No synced blocks in the last 30s.
[chain-index:Info:30] [2022-02-09 13:59:54.71 UTC] Syncing (7.38%). Applied 7 blocks, 1 rollbacks in the last 30s. Current tip is Point(Slot 3898564, BlockId 93e58766e4ab743ea07d5f2a070cb9c3e7b95db160d04203c4764fb1050d422d)
[chain-index:Info:30] [2022-02-09 13:59:57.72 UTC] Syncing (7.38%). Applied 67 blocks, 0 rollbacks in the last 30s. Current tip is Point(Slot 3898572, BlockId 1df9f2d8967be312bdadef8649e0738101c5660096343c17d4ca1a34b66f7f59)
[chain-index:Warning:30] [2022-02-09 14:01:24.80 UTC] No synced blocks in the last 30s.
[chain-index:Error:34] [2022-02-09 14:01:47.22 UTC] ChainIndexError: Error during Beam operation: SqlError (via Beam): SQLite3 returned ErrorMisuse while attempting to perform prepare "ROLLBACK TRANSACTION": bad parameter or other API misuse
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
