### PR TITLE
Fixed "error: attribute 'pab-setup-invoker' missing" when running nix-build

### DIFF
--- a/plutus-pab-executables/demo/pab-nami/client/default.nix
+++ b/plutus-pab-executables/demo/pab-nami/client/default.nix
@@ -57,5 +57,5 @@ let
     });
 in
 {
-  inherit client pab-nami-demo-invoker pab-nami-demo-generator generate-purescript generated-purescript start-backend;
+  inherit pab-setup-invoker client pab-nami-demo-invoker pab-nami-demo-generator generate-purescript generated-purescript start-backend;
 }


### PR DESCRIPTION

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
