### PR TITLE
ContractModel: add assertSpec operation

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Test/ContractModel.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/ContractModel.hs
@@ -46,6 +46,7 @@ module Plutus.Contract.Test.ContractModel
     , transfer
     , modifyContractState
     , createToken
+    , assertSpec
     , ($=)
     , ($~)
     -- * Helper functions for writing perform functions
@@ -97,6 +98,7 @@ module Plutus.Contract.Test.ContractModel
     , HandleFun
     -- ** Model properties
     , propSanityCheckModel
+    , propSanityCheckAssertions
     -- ** Coverage cheking options
     , CoverageOptions
     , defaultCoverageOptions

--- a/plutus-use-cases/test/Spec/GameStateMachine.hs
+++ b/plutus-use-cases/test/Spec/GameStateMachine.hs
@@ -21,6 +21,7 @@ module Spec.GameStateMachine
   , prop_NoLockedFunds
   , prop_CheckNoLockedFundsProof
   , prop_SanityCheckModel
+  , prop_SanityCheckAssertions
   , prop_GameCrashTolerance
   ) where
 
@@ -144,7 +145,8 @@ instance ContractModel GameModel where
     -- command given the current model state.
     arbitraryAction s = oneof $
         [ genLockAction ] ++
-        [ Guess w   <$> genGuess  <*> genGuess <*> genGuessAmount | val > Ada.getLovelace Ledger.minAdaTxOut, Just w <- [tok] ] ++
+        [ Guess w   <$> genGuess  <*> genGuess <*> genGuessAmount
+          | val > Ada.getLovelace Ledger.minAdaTxOut, Just w <- [tok] ] ++
         [ GiveToken <$> genWallet | isJust tok ]
         where
             genGuessAmount = frequency [(1, pure val), (1, pure $ Ada.getLovelace Ledger.minAdaTxOut), (8, choose (Ada.getLovelace Ledger.minAdaTxOut, val))]
@@ -194,6 +196,9 @@ prop_GameWhitelist = checkErrorWhitelist defaultWhitelist
 
 prop_SanityCheckModel :: Property
 prop_SanityCheckModel = propSanityCheckModel @GameModel
+
+prop_SanityCheckAssertions :: Property
+prop_SanityCheckAssertions = propSanityCheckAssertions @GameModel
 
 check_prop_Game_with_coverage :: IO CoverageReport
 check_prop_Game_with_coverage =


### PR DESCRIPTION
This adds the ability to assert properties directly in the `ContractModel` specifications.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
