### PR TITLE
ContractModel: Add wiggle room options to NoLockedFunds

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Test/ContractModel.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/ContractModel.hs
@@ -125,10 +125,9 @@ module Plutus.Contract.Test.ContractModel
     --
     -- $noLockedFunds
     , NoLockedFundsProof(..)
+    , defaultNLFP
     , checkNoLockedFundsProof
     , checkNoLockedFundsProofFast
-    , checkNoLockedFundsProofWithWiggleRoom
-    , checkNoLockedFundsProofWithWiggleRoomFast
     -- $checkNoPartiality
     , Whitelist
     , whitelistOk

--- a/plutus-contract/src/Plutus/Contract/Test/ContractModel/Symbolics.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/ContractModel/Symbolics.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 module Plutus.Contract.Test.ContractModel.Symbolics where
 
+import Ledger.Ada qualified as Ada
 import Ledger.Value (AssetClass, Value, assetClassValue, isZero, leq)
 import PlutusTx.Monoid qualified as PlutusTx
 
@@ -70,6 +71,9 @@ instance SymValueLike Value where
 
 instance SymValueLike SymValue where
   toSymValue = id
+
+instance SymValueLike Ada.Ada where
+  toSymValue = toSymValue . Ada.toValue
 
 inv :: SymValue -> SymValue
 inv (SymValue m v) = SymValue (negate <$> m) (PlutusTx.inv v)

--- a/plutus-use-cases/test/Spec/Auction.hs
+++ b/plutus-use-cases/test/Spec/Auction.hs
@@ -322,7 +322,7 @@ prop_FinishAuction = forAllDL finishAuction prop_Auction
 --   seller walks away the buyer will not get their token (unless going around the off-chain code
 --   and building a Payout transaction manually).
 noLockProof :: NoLockedFundsProof AuctionModel
-noLockProof = NoLockedFundsProof
+noLockProof = defaultNLFP
   { nlfpMainStrategy   = strat
   , nlfpWalletStrategy = const strat }
   where

--- a/plutus-use-cases/test/Spec/Escrow.hs
+++ b/plutus-use-cases/test/Spec/Escrow.hs
@@ -184,7 +184,7 @@ prop_FinishEscrow :: Property
 prop_FinishEscrow = forAllDL finishEscrow prop_Escrow
 
 noLockProof :: NoLockedFundsProof EscrowModel
-noLockProof = NoLockedFundsProof
+noLockProof = defaultNLFP
   { nlfpMainStrategy   = finishingStrategy (const True)
   , nlfpWalletStrategy = finishingStrategy . (==) }
 

--- a/plutus-use-cases/test/Spec/GameStateMachine.hs
+++ b/plutus-use-cases/test/Spec/GameStateMachine.hs
@@ -272,7 +272,7 @@ prop_NoLockedFunds :: Property
 prop_NoLockedFunds = forAllDL noLockedFunds prop_Game
 
 noLockProof :: NoLockedFundsProof GameModel
-noLockProof = NoLockedFundsProof{
+noLockProof = defaultNLFP {
       nlfpMainStrategy   = mainStrat,
       nlfpWalletStrategy = walletStrat }
     where

--- a/plutus-use-cases/test/Spec/Prism.hs
+++ b/plutus-use-cases/test/Spec/Prism.hs
@@ -197,10 +197,7 @@ prop_Prism = propRunActions @PrismModel finalPredicate
 
 -- | The Prism contract does not lock any funds.
 noLockProof :: NoLockedFundsProof PrismModel
-noLockProof = NoLockedFundsProof
-  { nlfpMainStrategy   = return ()
-  , nlfpWalletStrategy = \ _ -> return ()
-  }
+noLockProof = defaultNLFP
 
 prop_NoLock :: Property
 prop_NoLock = checkNoLockedFundsProof defaultCheckOptionsContractModel noLockProof

--- a/plutus-use-cases/test/Spec/SealedBidAuction.hs
+++ b/plutus-use-cases/test/Spec/SealedBidAuction.hs
@@ -248,7 +248,7 @@ prop_FinishAuction :: Property
 prop_FinishAuction = forAllDL finishAuction prop_Auction
 
 noLockProof :: NoLockedFundsProof AuctionModel
-noLockProof = NoLockedFundsProof
+noLockProof = defaultNLFP
   { nlfpMainStrategy   = finishingStrategy w1
   , nlfpWalletStrategy = finishingStrategy }
 

--- a/plutus-use-cases/test/Spec/Vesting.hs
+++ b/plutus-use-cases/test/Spec/Vesting.hs
@@ -197,7 +197,7 @@ prop_Vesting :: Actions VestingModel -> Property
 prop_Vesting = propRunActions_
 
 noLockProof :: NoLockedFundsProof VestingModel
-noLockProof = NoLockedFundsProof{
+noLockProof = defaultNLFP {
       nlfpMainStrategy   = mainStrat,
       nlfpWalletStrategy = walletStrat }
     where


### PR DESCRIPTION
Some contracts, like the Uniswap example contract, have predictable overhead and rounding errors that prevent the strict NoLockedFunds property from passing. This PR introduces a little bit of wiggle room to allow for such contracts.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
