### PR TITLE
Ledger Orphans: derive ToSchema for DiffMilliSeconds

### DIFF
--- a/plutus-ledger/src/Ledger/Orphans.hs
+++ b/plutus-ledger/src/Ledger/Orphans.hs
@@ -38,6 +38,7 @@ import Plutus.V1.Ledger.Bytes (bytes)
 import Plutus.V1.Ledger.Crypto (PrivateKey (PrivateKey, getPrivateKey), PubKey (PubKey), Signature (Signature))
 import Plutus.V1.Ledger.Scripts (ScriptHash (..))
 import Plutus.V1.Ledger.Slot (Slot (Slot))
+import Plutus.V1.Ledger.Time (DiffMilliSeconds (DiffMilliSeconds))
 import Plutus.V1.Ledger.Tx (RedeemerPtr, ScriptTag, Tx, TxIn, TxInType)
 import Plutus.V1.Ledger.Value (AssetClass (AssetClass))
 import PlutusCore (Kind, Some, Term, Type, ValueOf, Version)
@@ -156,6 +157,7 @@ deriving newtype instance OpenApi.ToSchema LedgerBytes
 deriving newtype instance OpenApi.ToSchema ValidatorHash
 deriving newtype instance OpenApi.ToSchema Signature
 deriving newtype instance OpenApi.ToSchema POSIXTime
+deriving newtype instance OpenApi.ToSchema DiffMilliSeconds
 deriving newtype instance OpenApi.ToSchema BuiltinData
 deriving newtype instance OpenApi.ToSchema AssetClass
 deriving instance OpenApi.ToSchema a => OpenApi.ToSchema (Extended a)


### PR DESCRIPTION
`DiffMilliSeconds` is a common type for endpoint parameters, having an orphan instance derived here would be quite convenient.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
