### PR TITLE
Removed the match on the removed MalformedScript constructor

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Test/Coverage.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/Coverage.hs
@@ -46,7 +46,6 @@ getCoverageReport es =
 
       logOf (Left (Ledger.EvaluationError lg _)) = lg
       logOf (Left Ledger.EvaluationException{})  = []
-      logOf (Left Ledger.MalformedScript{})      = []
       logOf (Right (_, lg))                      = lg
 
   in fold $ do


### PR DESCRIPTION
The `MalformedScript`  onstructor of  the `ScriptError` datatype [has been removed](https://github.com/input-output-hk/plutus/commit/3f93f74bc565ec4ed0b1e1e9dbea1b7bb12f6bac#diff-cb4fae72ab44c8b348c3d0f7dc80d29cc4f3c63805870ab6836ce435caece150) from `plutus-ledger-api`, but this reference was overlooked.
