### PR TITLE
Make PAB log less in recent slots

### DIFF
--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
@@ -76,16 +76,9 @@ handleSyncAction action = do
   case result of
     Left err -> putStrLn $ "handleSyncAction failed with: " <> show err
     Right (Slot s, BlockNumber n) -> do
-      let recentSlot = 41511045 -- TODO: This is a relatively recent slot number
-                                -- we start logging from here to avoid spamming the terminal
-                                -- should be removed when we have better logging to report
-                                -- on the PAB sync status
       stdGen <- newStdGen
-      let logBlock = fst (randomR (0 :: Int, 10_000) stdGen) == 0
-      if  logBlock || (s >= recentSlot)
-        then do
-          putStrLn $ "Current block: " <> show n <> ". Current slot: " <> show s
-        else pure ()
+      when (fst (randomR (0 :: Int, 10_000) stdGen) == 0) $
+        putStrLn $ "Current block: " <> show n <> ". Current slot: " <> show s
   either (error . show) (const $ pure ()) result
 
 updateInstances :: IndexedBlock -> InstanceClientEnv -> STM ()


### PR DESCRIPTION
PAB is logging too much in recent slots - making it impractical to run PAB on real networks.

---

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
