### PR TITLE
SCP-3331 Fixed error handling for transaction balancing in PAB.

### DIFF
--- a/plutus-pab/src/Cardano/Wallet/LocalClient.hs
+++ b/plutus-pab/src/Cardano/Wallet/LocalClient.hs
@@ -94,7 +94,7 @@ handleWalletClient config (Wallet _ (WalletId walletId)) event = do
             case result of
                 Left err -> do
                     logWarn (WalletClientError $ show err)
-                    throwError err
+                    pure . Left $ err
                 Right _ -> pure result
 
         submitTxnH :: CardanoTx -> Eff effs ()


### PR DESCRIPTION
The `Cardano.Wallet.LocalClient.runClient'` function erroneously rethrows errors it catches instead of returning them via `pure . Left`, as required by its type signature. The errors are not handled and end up killing the thread that handles the contract instance. This change successfully passes the Marlowe test https://github.com/input-output-hk/marlowe-cardano/blob/sprint-52/marlowe-cli/test/test-wallet-failure.yaml.

(In general, I recommend reviewing the PAB codebase for similar re-throwing problems and for `forkIO`s that aren't guarded against its thread dying because of an uncaught exception.)

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
