### PR TITLE
ContractModel: lazier precondition for ContractModel

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Test/ContractModel/Internal.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/ContractModel/Internal.hs
@@ -843,9 +843,9 @@ instance ContractModel state => StateModel (ModelState state) where
     nextState s (WaitUntil n) _          = runSpec (() <$ waitUntil n) (error "unreachable") s
     nextState s Unilateral{} _           = s
 
-    precondition s (ContractAction _ cmd) = getAllSymtokens cmd `Set.isSubsetOf` (s ^. symTokens)
-                                          && s ^. assertionsOk
+    precondition s (ContractAction _ cmd) = s ^. assertionsOk
                                           && precondition s cmd
+                                          && getAllSymtokens cmd `Set.isSubsetOf` (s ^. symTokens)
     precondition s (WaitUntil n)          = n > s ^. currentSlot
     precondition _ _                      = True
 


### PR DESCRIPTION
This fixes a tiny bug whereby the precondition for ContractModel actions was slightly stricter than it needs to be - which caused some clever tricks(tm) to break.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
