### PR TITLE
SCP-3680: Use the number of transactions instead of number of blocks for queue.

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-chain-index.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-chain-index.nix
@@ -59,6 +59,7 @@
           ];
         buildable = true;
         modules = [
+          "Control/Concurrent/STM/TBMQueue"
           "Plutus/ChainIndex/App"
           "Plutus/ChainIndex/Events"
           "Plutus/ChainIndex/CommandLine"

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-chain-index.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-chain-index.nix
@@ -59,6 +59,7 @@
           ];
         buildable = true;
         modules = [
+          "Control/Concurrent/STM/TBMQueue"
           "Plutus/ChainIndex/App"
           "Plutus/ChainIndex/Events"
           "Plutus/ChainIndex/CommandLine"

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-chain-index.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-chain-index.nix
@@ -59,6 +59,7 @@
           ];
         buildable = true;
         modules = [
+          "Control/Concurrent/STM/TBMQueue"
           "Plutus/ChainIndex/App"
           "Plutus/ChainIndex/Events"
           "Plutus/ChainIndex/CommandLine"

--- a/plutus-chain-index/plutus-chain-index.cabal
+++ b/plutus-chain-index/plutus-chain-index.cabal
@@ -37,6 +37,7 @@ library
         Plutus.ChainIndex.Lib
         Plutus.ChainIndex.Logging
         Plutus.ChainIndex.SyncStats
+    other-modules: Control.Concurrent.STM.TBMQueue
     hs-source-dirs: src
     build-depends:
         plutus-ledger -any,

--- a/plutus-chain-index/src/Control/Concurrent/STM/TBMQueue.hs
+++ b/plutus-chain-index/src/Control/Concurrent/STM/TBMQueue.hs
@@ -1,0 +1,77 @@
+module Control.Concurrent.STM.TBMQueue
+  ( TBMQueue
+  , newTBMQueue
+  , newTBMQueueIO
+  , writeTBMQueue
+  , isFullTBMQueue
+  , flushTBMQueue
+  , sizeTBMQueue
+  ) where
+
+import Control.Concurrent.STM (STM, retry)
+import Control.Concurrent.STM.TQueue (TQueue, flushTQueue, isEmptyTQueue, newTQueue, newTQueueIO, writeTQueue)
+import Control.Concurrent.STM.TVar (TVar, newTVar, newTVarIO, readTVar, writeTVar)
+import Control.Monad (when)
+import Numeric.Natural (Natural)
+
+
+-- | 'TBMQueue' is an abstract type representing a bounded FIFO channel with a custom measure function.
+-- 'TBMQueue' with a measure function 'const 1' should be equivalent to 'TBQueue'.
+data TBMQueue a = TBMQueue !(TQueue a)
+                           {-# UNPACK #-} !(TVar Natural) -- Current size
+                           {-# UNPACK #-} !(TVar Bool) -- Is the queue full? Is the last item too big?
+                           !Natural -- Max size
+                           !(a -> Natural) -- Measure function
+
+-- | Builds and returns a new instance of 'TBMQueue'.
+newTBMQueue :: Natural -> (a -> Natural) -> STM (TBMQueue a)
+newTBMQueue maxSize measure = do
+  queue <- newTQueue
+  isFull <- newTVar False
+  currentSize <- newTVar 0
+  return $ TBMQueue queue currentSize isFull maxSize measure
+
+-- | 'IO' version of 'newTBMQueue'.
+newTBMQueueIO :: Natural -> (a -> Natural) -> IO (TBMQueue a)
+newTBMQueueIO maxSize measure = do
+  queue <- newTQueueIO
+  isFull <- newTVarIO False
+  currentSize <- newTVarIO 0
+  return $ TBMQueue queue currentSize isFull maxSize measure
+
+-- | Write a value to a 'TBMQueue'; blocks if the queue is full.
+writeTBMQueue :: TBMQueue a -> a -> STM ()
+writeTBMQueue (TBMQueue q currentSize isFull maxSize measure) item = do
+  full <- readTVar isFull
+  if full then retry
+  else do
+    current <- readTVar currentSize
+    let newCurrentSize = measure item + current
+    if newCurrentSize <= maxSize then do
+      writeTQueue q item
+      writeTVar currentSize newCurrentSize
+    else do
+      isQueueEmpty <- isEmptyTQueue q
+      -- if queue is empty and an item is too big to insert
+      -- we still insert it alone to avoid an infinite loop
+      when isQueueEmpty $ do
+        writeTQueue q item
+        writeTVar currentSize newCurrentSize
+      writeTVar isFull True
+
+-- | Returns 'True' if the supplied 'TBMQueue' is full.
+isFullTBMQueue :: TBMQueue a -> STM Bool
+isFullTBMQueue (TBMQueue _ _ isFull _ _) = readTVar isFull
+
+-- | Efficiently read the entire contents of a 'TBMQueue' into a list. This
+-- function never retries.
+flushTBMQueue :: TBMQueue a -> STM [a]
+flushTBMQueue (TBMQueue q currentSize isFull _ _) = do
+  items <- flushTQueue q
+  writeTVar currentSize 0
+  writeTVar isFull False
+  return items
+
+-- | Returns current size of the queue.
+sizeTBMQueue :: TBMQueue a -> STM Natural
+sizeTBMQueue (TBMQueue _ currentSize _ _ _) = readTVar currentSize

--- a/plutus-chain-index/src/Control/Concurrent/STM/TBMQueue.hs
+++ b/plutus-chain-index/src/Control/Concurrent/STM/TBMQueue.hs
@@ -9,9 +9,8 @@ module Control.Concurrent.STM.TBMQueue
   ) where
 
 import Control.Concurrent.STM (STM, retry)
-import Control.Concurrent.STM.TQueue (TQueue, flushTQueue, isEmptyTQueue, newTQueue, newTQueueIO, writeTQueue)
+import Control.Concurrent.STM.TQueue (TQueue, flushTQueue, newTQueue, newTQueueIO, writeTQueue)
 import Control.Concurrent.STM.TVar (TVar, newTVar, newTVarIO, readTVar, writeTVar)
-import Control.Monad (when)
 import Numeric.Natural (Natural)
 
 
@@ -19,7 +18,6 @@ import Numeric.Natural (Natural)
 -- 'TBMQueue' with a measure function 'const 1' should be equivalent to 'TBQueue'.
 data TBMQueue a = TBMQueue !(TQueue a)
                            {-# UNPACK #-} !(TVar Natural) -- Current size
-                           {-# UNPACK #-} !(TVar Bool) -- Is the queue full? Is the last item too big?
                            !Natural -- Max size
                            !(a -> Natural) -- Measure function
 
@@ -27,51 +25,39 @@ data TBMQueue a = TBMQueue !(TQueue a)
 newTBMQueue :: Natural -> (a -> Natural) -> STM (TBMQueue a)
 newTBMQueue maxSize measure = do
   queue <- newTQueue
-  isFull <- newTVar False
   currentSize <- newTVar 0
-  return $ TBMQueue queue currentSize isFull maxSize measure
+  return $ TBMQueue queue currentSize maxSize measure
 
 -- | 'IO' version of 'newTBMQueue'.
 newTBMQueueIO :: Natural -> (a -> Natural) -> IO (TBMQueue a)
 newTBMQueueIO maxSize measure = do
   queue <- newTQueueIO
-  isFull <- newTVarIO False
   currentSize <- newTVarIO 0
-  return $ TBMQueue queue currentSize isFull maxSize measure
+  return $ TBMQueue queue currentSize maxSize measure
 
 -- | Write a value to a 'TBMQueue'; blocks if the queue is full.
 writeTBMQueue :: TBMQueue a -> a -> STM ()
-writeTBMQueue (TBMQueue q currentSize isFull maxSize measure) item = do
-  full <- readTVar isFull
-  if full then retry
+writeTBMQueue (TBMQueue q currentSize maxSize measure) item = do
+  size <- readTVar currentSize
+  if size > maxSize then retry
   else do
-    current <- readTVar currentSize
-    let newCurrentSize = measure item + current
-    if newCurrentSize <= maxSize then do
-      writeTQueue q item
-      writeTVar currentSize newCurrentSize
-    else do
-      isQueueEmpty <- isEmptyTQueue q
-      -- if queue is empty and an item is too big to insert
-      -- we still insert it alone to avoid an infinite loop
-      when isQueueEmpty $ do
-        writeTQueue q item
-        writeTVar currentSize newCurrentSize
-      writeTVar isFull True
+    writeTQueue q item
+    writeTVar currentSize (measure item + size)
 
 -- | Returns 'True' if the supplied 'TBMQueue' is full.
 isFullTBMQueue :: TBMQueue a -> STM Bool
-isFullTBMQueue (TBMQueue _ _ isFull _ _) = readTVar isFull
+isFullTBMQueue (TBMQueue _ currentSize maxSize _) = do
+  size <- readTVar currentSize
+  return $ size > maxSize
 
 -- | Efficiently read the entire contents of a 'TBMQueue' into a list. This
 -- function never retries.
 flushTBMQueue :: TBMQueue a -> STM [a]
-flushTBMQueue (TBMQueue q currentSize isFull _ _) = do
+flushTBMQueue (TBMQueue q currentSize _ _) = do
   items <- flushTQueue q
   writeTVar currentSize 0
-  writeTVar isFull False
   return items
 
 -- | Returns current size of the queue.
 sizeTBMQueue :: TBMQueue a -> STM Natural
-sizeTBMQueue (TBMQueue _ currentSize _ _ _) = readTVar currentSize
+sizeTBMQueue (TBMQueue _ currentSize _ _) = readTVar currentSize

--- a/plutus-chain-index/src/Plutus/ChainIndex/App.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/App.hs
@@ -22,13 +22,13 @@ import Cardano.BM.Configuration.Model qualified as CM
 import Cardano.BM.Setup (setupTrace_)
 import Cardano.BM.Trace (Trace)
 import Control.Concurrent.Async (wait, withAsync)
-import Control.Concurrent.STM.TBQueue (newTBQueueIO)
+import Control.Concurrent.STM.TBMQueue (newTBMQueueIO)
 import Plutus.ChainIndex.CommandLine (AppConfig (AppConfig, acCLIConfigOverrides, acCommand, acConfigPath, acLogConfigPath, acMinLogLevel),
                                       Command (DumpDefaultConfig, DumpDefaultLoggingConfig, StartChainIndex),
                                       applyOverrides, cmdWithHelpParser)
 import Plutus.ChainIndex.Compatibility (fromCardanoBlockNo)
 import Plutus.ChainIndex.Config qualified as Config
-import Plutus.ChainIndex.Events (processEventsQueue)
+import Plutus.ChainIndex.Events (measureEventByTxs, processEventsQueue)
 import Plutus.ChainIndex.Lib (getTipSlot, storeChainSyncHandler, storeFromBlockNo, syncChainIndex, withRunRequirements)
 import Plutus.ChainIndex.Logging qualified as Logging
 import Plutus.ChainIndex.Server qualified as Server
@@ -78,7 +78,7 @@ runMain logConfig config = do
     print slotNo
 
     -- Queue for processing events
-    eventsQueue <- newTBQueueIO $ fromIntegral (Config.cicAppendQueueSize config)
+    eventsQueue <- newTBMQueueIO (fromIntegral (Config.cicAppendQueueSize config)) measureEventByTxs
     syncHandler
       <- storeChainSyncHandler eventsQueue
         & storeFromBlockNo (fromCardanoBlockNo $ Config.cicStoreFrom config)

--- a/plutus-chain-index/src/Plutus/ChainIndex/App.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/App.hs
@@ -78,7 +78,7 @@ runMain logConfig config = do
     print slotNo
 
     -- Queue for processing events
-    eventsQueue <- newTBMQueueIO (fromIntegral (Config.cicAppendQueueSize config)) measureEventByTxs
+    eventsQueue <- newTBMQueueIO (Config.cicAppendTransactionQueueSize config) measureEventByTxs
     syncHandler
       <- storeChainSyncHandler eventsQueue
         & storeFromBlockNo (fromCardanoBlockNo $ Config.cicStoreFrom config)

--- a/plutus-chain-index/src/Plutus/ChainIndex/CommandLine.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/CommandLine.hs
@@ -15,27 +15,28 @@ import Options.Applicative (CommandFields, Mod, Parser, ParserInfo, argument, au
 import Cardano.Api (NetworkId (Testnet), NetworkMagic (NetworkMagic))
 import Cardano.BM.Data.Severity (Severity (Debug))
 import GHC.Word (Word32)
+import Numeric.Natural (Natural)
 import Plutus.ChainIndex.Config (ChainIndexConfig)
 import Plutus.ChainIndex.Config qualified as Config
 
 data CLIConfigOverrides =
   CLIConfigOverrides
-    { ccSocketPath      :: Maybe String
-    , ccDbPath          :: Maybe String
-    , ccPort            :: Maybe Int
-    , ccNetworkId       :: Maybe Word32
-    , ccAppendQueueSize :: Maybe Int
+    { ccSocketPath                 :: Maybe String
+    , ccDbPath                     :: Maybe String
+    , ccPort                       :: Maybe Int
+    , ccNetworkId                  :: Maybe Word32
+    , ccAppendTransactionQueueSize :: Maybe Natural
     }
     deriving (Eq, Ord, Show)
 
 -- | Apply the CLI soverrides to the 'ChainIndexConfig'
 applyOverrides :: CLIConfigOverrides -> ChainIndexConfig -> ChainIndexConfig
-applyOverrides CLIConfigOverrides{ccSocketPath, ccDbPath, ccPort, ccNetworkId, ccAppendQueueSize} =
+applyOverrides CLIConfigOverrides{ccSocketPath, ccDbPath, ccPort, ccNetworkId, ccAppendTransactionQueueSize} =
   over Config.socketPath (maybe id const ccSocketPath)
   . over Config.dbPath (maybe id const ccDbPath)
   . over Config.port (maybe id const ccPort)
   . over Config.networkId (maybe id (const . Testnet . NetworkMagic) ccNetworkId)
-  . over Config.appendQueueSize (maybe id const ccAppendQueueSize)
+  . over Config.appendTransactionQueueSize (maybe id const ccAppendTransactionQueueSize)
 
 -- | Configuration
 data Command =
@@ -67,7 +68,7 @@ optParser =
 
 cliConfigOverridesParser :: Parser CLIConfigOverrides
 cliConfigOverridesParser =
-  CLIConfigOverrides <$> socketPathParser <*> dbPathParser <*> portParser <*> networkIDParser <*> appendQueueSizeParser where
+  CLIConfigOverrides <$> socketPathParser <*> dbPathParser <*> portParser <*> networkIDParser <*> appendTransactionQueueSizeParser where
     socketPathParser =
       option (Just <$> str) (long "socket-path" <> value Nothing <> help "Node socket path")
     dbPathParser =
@@ -76,8 +77,8 @@ cliConfigOverridesParser =
       option (Just <$> auto) (long "port" <> value Nothing <> help "Port")
     networkIDParser =
       option (Just <$> auto) (long "network-id" <> value Nothing <> help "Network ID")
-    appendQueueSizeParser =
-      option (Just <$> auto) (long "append-queue-size" <> value Nothing <> help "Append queue size")
+    appendTransactionQueueSizeParser =
+      option (Just <$> auto) (long "append-transaction-queue-size" <> value Nothing <> help "Append transaction queue size")
 
 loggingConfigParser :: Parser (Maybe FilePath)
 loggingConfigParser =

--- a/plutus-chain-index/src/Plutus/ChainIndex/Config.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Config.hs
@@ -69,7 +69,7 @@ defaultConfig = ChainIndexConfig
         , scSlotLength   = 1000
         }
   , cicStoreFrom = BlockNo 0
-  , cicAppendQueueSize = 15000
+  , cicAppendQueueSize = 500
   }
 
 instance Pretty ChainIndexConfig where

--- a/plutus-chain-index/src/Plutus/ChainIndex/Config.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Config.hs
@@ -20,7 +20,7 @@ module Plutus.ChainIndex.Config(
   securityParam,
   slotConfig,
   storeFrom,
-  appendQueueSize
+  appendTransactionQueueSize
   ) where
 
 import Cardano.Api (BlockNo (BlockNo), NetworkId (Mainnet, Testnet))
@@ -29,18 +29,19 @@ import Control.Lens (makeLensesFor)
 import Data.Aeson (FromJSON, ToJSON)
 import GHC.Generics (Generic)
 import Ledger.TimeSlot (SlotConfig (SlotConfig, scSlotLength, scSlotZeroTime))
+import Numeric.Natural (Natural)
 import Ouroboros.Network.Magic (NetworkMagic (NetworkMagic))
 import Prettyprinter (Pretty (pretty), viaShow, vsep, (<+>))
 
 data ChainIndexConfig = ChainIndexConfig
-  { cicSocketPath      :: String
-  , cicDbPath          :: String
-  , cicPort            :: Int
-  , cicNetworkId       :: NetworkId
-  , cicSecurityParam   :: Int -- ^ The number of blocks after which a transaction cannot be rolled back anymore
-  , cicSlotConfig      :: SlotConfig
-  , cicStoreFrom       :: BlockNo -- ^ Only store transactions from this block number onward
-  , cicAppendQueueSize :: Int -- ^ The size of the queue and a number of blocks to collect before writing to the database
+  { cicSocketPath                 :: String
+  , cicDbPath                     :: String
+  , cicPort                       :: Int
+  , cicNetworkId                  :: NetworkId
+  , cicSecurityParam              :: Int -- ^ The number of blocks after which a transaction cannot be rolled back anymore
+  , cicSlotConfig                 :: SlotConfig
+  , cicStoreFrom                  :: BlockNo -- ^ Only store transactions from this block number onward
+  , cicAppendTransactionQueueSize :: Natural -- ^ The size of the queue and a number of transactions to collect before writing to the database
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)
@@ -69,18 +70,18 @@ defaultConfig = ChainIndexConfig
         , scSlotLength   = 1000
         }
   , cicStoreFrom = BlockNo 0
-  , cicAppendQueueSize = 500
+  , cicAppendTransactionQueueSize = 500
   }
 
 instance Pretty ChainIndexConfig where
-  pretty ChainIndexConfig{cicSocketPath, cicDbPath, cicPort, cicNetworkId, cicSecurityParam, cicStoreFrom, cicAppendQueueSize} =
+  pretty ChainIndexConfig{cicSocketPath, cicDbPath, cicPort, cicNetworkId, cicSecurityParam, cicStoreFrom, cicAppendTransactionQueueSize} =
     vsep [ "Socket:" <+> pretty cicSocketPath
          , "Db:" <+> pretty cicDbPath
          , "Port:" <+> pretty cicPort
          , "Network Id:" <+> viaShow cicNetworkId
          , "Security Param:" <+> pretty cicSecurityParam
          , "Store from:" <+> viaShow cicStoreFrom
-         , "Append queue size:" <+> viaShow cicAppendQueueSize
+         , "Append transaction queue size:" <+> viaShow cicAppendTransactionQueueSize
          ]
 
 makeLensesFor [
@@ -91,7 +92,7 @@ makeLensesFor [
   ("cicSecurityParam", "securityParam"),
   ("cicSlotConfig", "slotConfig"),
   ("cicStoreFrom", "storeFrom"),
-  ("cicAppendQueueSize", "appendQueueSize")
+  ("cicAppendTransactionQueueSize", "appendTransactionQueueSize")
   ] 'ChainIndexConfig
 
 newtype DecodeConfigException = DecodeConfigException String

--- a/plutus-chain-index/src/Plutus/ChainIndex/Lib.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Lib.hs
@@ -62,7 +62,8 @@ import Cardano.BM.Trace (Trace, logDebug, logError, nullTracer)
 
 import Cardano.Protocol.Socket.Client qualified as C
 import Cardano.Protocol.Socket.Type (epochSlots)
-import Control.Concurrent.STM (TBQueue, atomically, writeTBQueue)
+import Control.Concurrent.STM (atomically)
+import Control.Concurrent.STM.TBMQueue (TBMQueue, writeTBMQueue)
 import Plutus.ChainIndex (ChainIndexLog (BeamLogItem), RunRequirements (RunRequirements), getResumePoints,
                           runChainIndexEffects, tipBlockNo)
 import Plutus.ChainIndex qualified as CI
@@ -133,10 +134,10 @@ toCardanoChainSyncHandler runReq handler = \case
 
 -- | A handler for chain synchronisation events.
 type ChainSyncHandler = ChainSyncEvent -> IO ()
-type EventsQueue = TBQueue ChainSyncEvent
+type EventsQueue = TBMQueue ChainSyncEvent
 
 storeChainSyncHandler :: EventsQueue -> ChainSyncHandler
-storeChainSyncHandler eventsQueue = atomically . writeTBQueue eventsQueue
+storeChainSyncHandler eventsQueue = atomically . writeTBMQueue eventsQueue
 
 -- | Changes the given @ChainSyncHandler@ to only store transactions with a block number no smaller than the given one.
 storeFromBlockNo :: CI.BlockNumber -> ChainSyncHandler -> ChainSyncHandler


### PR DESCRIPTION
This should reduce the fluctuation of the memory usage of the chain-index.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
