### PR TITLE
[chain-index]: start a web server with forkProcess instead of withAsync

### DIFF
--- a/plutus-chain-index/plutus-chain-index.cabal
+++ b/plutus-chain-index/plutus-chain-index.cabal
@@ -64,6 +64,7 @@ library
         stm -any,
         time-units -any,
         yaml -any,
+        unix -any
 
 executable plutus-chain-index
   main-is: Main.hs


### PR DESCRIPTION
This PR replaces `withAsync` with `forkProcess` to start a web server in a different process to avoid thread blocking because `processEventsQueue` and `syncChainIndex` take too much resources.

Not sure if it a good solution but at the moment it seems the only one that works.

---

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
