### PR TITLE
Allow chain-index to print silently.

### DIFF
--- a/plutus-chain-index/src/Plutus/ChainIndex/App.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/App.hs
@@ -72,7 +72,7 @@ main = do
 runMain :: CM.Configuration -> Config.ChainIndexConfig -> IO ()
 runMain = runMainWithLog putStrLn
 
--- Run main with provided function to log startup logs. 
+-- Run main with provided function to log startup logs.
 runMainWithLog :: (String -> IO ()) -> CM.Configuration -> Config.ChainIndexConfig -> IO ()
 runMainWithLog logger logConfig config = do
   withRunRequirements logConfig config $ \runReq -> do

--- a/plutus-chain-index/src/Plutus/ChainIndex/App.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/App.hs
@@ -7,7 +7,7 @@
 
 {-| Main entry points to the chain index.
 -}
-module Plutus.ChainIndex.App(main, runMain) where
+module Plutus.ChainIndex.App(main, runMain, runMainWithLog) where
 
 import Control.Exception (throwIO)
 import Data.Aeson qualified as A
@@ -70,12 +70,16 @@ main = do
       runMain logConfig config
 
 runMain :: CM.Configuration -> Config.ChainIndexConfig -> IO ()
-runMain logConfig config = do
+runMain = runMainWithLog putStrLn
+
+-- Run main with provided function to log startup logs. 
+runMainWithLog :: (String -> IO ()) -> CM.Configuration -> Config.ChainIndexConfig -> IO ()
+runMainWithLog logger logConfig config = do
   withRunRequirements logConfig config $ \runReq -> do
 
-    putStr "\nThe tip of the local node: "
     slotNo <- getTipSlot config
-    print slotNo
+    let slotNoStr = "\nThe tip of the local node: " <> show slotNo
+    logger slotNoStr
 
     -- Queue for processing events
     eventsQueue <- newTBMQueueIO (Config.cicAppendTransactionQueueSize config) measureEventByTxs
@@ -84,16 +88,15 @@ runMain logConfig config = do
         & storeFromBlockNo (fromCardanoBlockNo $ Config.cicStoreFrom config)
         & pure
 
-    putStrLn $ "Connecting to the node using socket: " <> Config.cicSocketPath config
+    logger $ "Connecting to the node using socket: " <> Config.cicSocketPath config
     syncChainIndex config runReq syncHandler
 
     (trace :: Trace IO (PrettyObject SyncLog), _) <- setupTrace_ logConfig "chain-index"
     withAsync (processEventsQueue trace runReq eventsQueue) $ \processAsync -> do
 
       let port = show (Config.cicPort config)
-      putStrLn $ "Starting webserver on port " <> port
-      putStrLn $ "A Swagger UI for the endpoints are available at "
+      logger $ "Starting webserver on port " <> port
+      logger $ "A Swagger UI for the endpoints are available at "
               <> "http://localhost:" <> port <> "/swagger/swagger-ui"
       Server.serveChainIndexQueryServer (Config.cicPort config) runReq
       wait processAsync
-


### PR DESCRIPTION
### description
Pr adds a new definition `Plutus.ChainIndex.App (runMainWithLog)` allowing to run chain-index with different function to do startup logs and refactors `runMain` to use this definition. This is a tiny commit.

### explanation
In [plutip](https://github.com/mlabs-haskell/plutip/issues/48) - a tool to spin up a testnet and run contracts - we call **chain-index**'s main function (from code with `runMain`) as one of the components. It does logging at startup to stdout and these logs get mixed up with the rest of the logs. Running it in a new process is troublesome, so I am asking if I could just add this small change to chain-index itself. 