### PR TITLE
Add "cicAppendTransactionQueueSize" to config

### DIFF
--- a/plutus-pab/test-node/testnet/chain-index-config.json
+++ b/plutus-pab/test-node/testnet/chain-index-config.json
@@ -15,5 +15,6 @@
   },
   "cicStoreFrom": {
     "unBlockNo": 0
-  }
+  },
+  "cicAppendTransactionQueueSize": 500
 }


### PR DESCRIPTION
Add the "cicAppendTransactionQueueSize" field to the chain index config so that parsing succeeds.
Use a value from the default config.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
