### PR TITLE
Coverage static analysis

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -91,7 +91,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: 4127e9cd6e889824d724c30eae55033cb50cbf3e
+  tag: 00a6eee2ed318fc2ba46c7672576e692196f2ada
   subdir:
     plutus-core
     plutus-ledger-api

--- a/doc/plutus/tutorials/Auction.hs
+++ b/doc/plutus/tutorials/Auction.hs
@@ -359,7 +359,7 @@ check_propAuctionWithCoverage = do
     withMaxSuccess 1000 $
       propRunActionsWithOptions @AuctionModel
         (set minLogLevel Critical options) covopts (const (pure True))
-  writeCoverageReport "Auction" covIdx cr
+  writeCoverageReport "Auction" cr
 
 tests :: TestTree
 tests =

--- a/doc/plutus/tutorials/Escrow5.hs
+++ b/doc/plutus/tutorials/Escrow5.hs
@@ -235,5 +235,5 @@ check_propEscrowWithCoverage = do
     withMaxSuccess 1000 $
       CM.propRunActionsWithOptions @EscrowModel CM.defaultCheckOptionsContractModel covopts
         (const (pure True))
-  writeCoverageReport "Escrow" covIdx cr
+  writeCoverageReport "Escrow" cr
 {- END check_propEscrowWithCoverage -}

--- a/doc/plutus/tutorials/Escrow6.hs
+++ b/doc/plutus/tutorials/Escrow6.hs
@@ -273,6 +273,6 @@ prop_CrashTolerance = CM.propRunActions_
 
 check_propEscrowWithCoverage :: IO ()
 check_propEscrowWithCoverage = do
-  cr <- CM.quickCheckWithCoverage stdArgs (set coverageIndex covIdx defaultCoverageOptions) $ \covopts ->
-    withMaxSuccess 1000 $ CM.propRunActionsWithOptions @EscrowModel CM.defaultCheckOptionsContractModel covopts (const (pure True))
-  writeCoverageReport "Escrow" covIdx cr
+  cr <- quickCheckWithCoverage stdArgs (set coverageIndex covIdx $ defaultCoverageOptions) $ \covopts ->
+    withMaxSuccess 1000 $ propRunActionsWithOptions @EscrowModel defaultCheckOptionsContractModel covopts (const (pure True))
+  writeCoverageReport "Escrow" cr

--- a/nix/pkgs/haskell/sha256map.nix
+++ b/nix/pkgs/haskell/sha256map.nix
@@ -11,7 +11,7 @@
   "https://github.com/input-output-hk/goblins"."cde90a2b27f79187ca8310b6549331e59595e7ba" = "17c88rbva3iw82yg9srlxjv2ia5wjb9cyqw44hik565f5v9svnyg";
   "https://github.com/input-output-hk/iohk-monitoring-framework"."46f994e216a1f8b36fe4669b47b2a7011b0e153c" = "1il8fx3misp3650ryj368b3x95ksz01zz3x0z9k00807j93d0ka0";
   "https://github.com/input-output-hk/ouroboros-network"."4fac197b6f0d2ff60dc3486c593b68dc00969fbf" = "1b43vbdsr9m3ry1kgag2p2ixpv54gw7a4vvmndxl6knqg8qbsb8b";
-  "https://github.com/input-output-hk/plutus"."4127e9cd6e889824d724c30eae55033cb50cbf3e" = "186w0x7vk8m8npmsfg9pdkxds0rlj6bmhr8nkgn96rkvaz5azjsb";
+  "https://github.com/input-output-hk/plutus"."00a6eee2ed318fc2ba46c7672576e692196f2ada" = "1zfka8bj4zc348pzgriavn0mbz0503x3gb9fv0bfks0d7yx1rvkp";
   "https://github.com/input-output-hk/purescript-bridge"."47a1f11825a0f9445e0f98792f79172efef66c00" = "0da1vn2l6iyfxcjk58qal1l4755v92zi6yppmjmqvxf1gacyf9px";
   "https://github.com/input-output-hk/servant-purescript"."44e7cacf109f84984cd99cd3faf185d161826963" = "10pb0yfp80jhb9ryn65a4rha2lxzsn2vlhcc6xphrrkf4x5lhzqc";
   "https://github.com/input-output-hk/Win32-network"."3825d3abf75f83f406c1f7161883c438dac7277d" = "19wahfv726fa3mqajpqdqhnl9ica3xmf68i254q45iyjcpj1psqx";

--- a/plutus-contract/plutus-contract.cabal
+++ b/plutus-contract/plutus-contract.cabal
@@ -37,6 +37,7 @@ flag defer-plugin-errors
 
 library
     import: lang
+    ghc-options: -O2 +RTS -T -N -qn8 -A1G -RTS
     exposed-modules:
         Data.Row.Extras
         Data.Text.Extras
@@ -133,6 +134,7 @@ library
         mmorph -any,
         mtl -any,
         prettyprinter >=1.1.0.1,
+        pretty -any,
         profunctors -any,
         quickcheck-dynamic -any,
         row-types >= 1.0.1.0,
@@ -150,7 +152,8 @@ library
         openapi3 -any,
         cardano-wallet-core -any,
         text-class -any,
-        uniplate -any
+        uniplate -any,
+        stm -any
 
     if !(impl(ghcjs) || os(ghcjs))
         build-depends: plutus-tx-plugin -any
@@ -163,6 +166,12 @@ library
             Plutus.Contract.Test
             Plutus.Contract.Test.Coverage
             Plutus.Contract.Test.Coverage.ReportCoverage
+            Plutus.Contract.Test.Coverage.Analysis
+            Plutus.Contract.Test.Coverage.Analysis.Common
+            Plutus.Contract.Test.Coverage.Analysis.DeBruijn
+            Plutus.Contract.Test.Coverage.Analysis.Interpreter
+            Plutus.Contract.Test.Coverage.Analysis.Pretty
+            Plutus.Contract.Test.Coverage.Analysis.Types
             Plutus.Contract.Test.ContractModel
             Plutus.Contract.Test.ContractModel.Internal
             Plutus.Contract.Test.ContractModel.Symbolics
@@ -225,7 +234,15 @@ test-suite plutus-contract-test
         tasty-hunit -any,
         tasty-quickcheck -any,
         text -any,
-        transformers -any
+        transformers -any,
+        plutus-core -any,
+        pretty -any,
+        prettyprinter -any,
+        utf8-string -any,
+        deepseq -any,
+        stm -any,
+        serialise -any,
+        splitmix -any
 
     if !(impl(ghcjs) || os(ghcjs))
         build-depends: plutus-tx-plugin -any

--- a/plutus-contract/src/Plutus/Contract/Test.hs
+++ b/plutus-contract/src/Plutus/Contract/Test.hs
@@ -143,7 +143,7 @@ import Wallet.Emulator.Folds (EmulatorFoldErr (..), Outcome (..), describeError,
 import Wallet.Emulator.Folds qualified as Folds
 import Wallet.Emulator.Stream (filterLogLevel, foldEmulatorStreamM, initialChainState, initialDist)
 
-type TestEffects = '[Reader InitialDistribution, Error EmulatorFoldErr, Writer (Doc Void), Writer CoverageReport]
+type TestEffects = '[Reader InitialDistribution, Error EmulatorFoldErr, Writer (Doc Void), Writer CoverageData]
 newtype TracePredicateF a = TracePredicate (forall effs. Members TestEffects effs => FoldM (Eff effs) EmulatorEvent a)
   deriving (Functor)
 instance Applicative TracePredicateF where
@@ -231,7 +231,7 @@ checkPredicateInner :: forall m.
     -> EmulatorTrace ()
     -> (String -> m ()) -- ^ Print out debug information in case of test failures
     -> (Bool -> m ()) -- ^ assert
-    -> (CoverageReport -> m ())
+    -> (CoverageData -> m ())
     -> m ()
 checkPredicateInner opts@CheckOptions{_emulatorConfig} predicate action annot assert cover =
     checkPredicateInnerStream opts predicate (S.void $ runEmulatorStream _emulatorConfig action) annot assert cover
@@ -243,17 +243,17 @@ checkPredicateInnerStream :: forall m.
     -> (forall effs. S.Stream (S.Of (LogMessage EmulatorEvent)) (Eff effs) ())
     -> (String -> m ()) -- ^ Print out debug information in case of test failures
     -> (Bool -> m ()) -- ^ assert
-    -> (CoverageReport -> m ())
+    -> (CoverageData -> m ())
     -> m ()
 checkPredicateInnerStream CheckOptions{_minLogLevel, _emulatorConfig} (TracePredicate predicate) theStream annot assert cover = do
     let dist = _emulatorConfig ^. initialChainState . to initialDist
         consumedStream :: Eff (TestEffects :++: '[m]) Bool
         consumedStream = S.fst' <$> foldEmulatorStreamM (liftA2 (&&) predicate generateCoverage) theStream
 
-        generateCoverage = flip postMapM (L.generalize Folds.emulatorLog) $ (True <$) . tell @CoverageReport . getCoverageReport
+        generateCoverage = flip postMapM (L.generalize Folds.emulatorLog) $ (True <$) . tell @CoverageData . getCoverageData
 
     result <- runM
-                $ interpretM @(Writer CoverageReport) @m (\case { Tell r -> cover r })
+                $ interpretM @(Writer CoverageData) @m (\case { Tell r -> cover r })
                 $ interpretM @(Writer (Doc Void)) @m (\case { Tell d -> annot $ Text.unpack $ renderStrict $ layoutPretty defaultLayoutOptions d })
                 $ runError
                 $ runReader dist

--- a/plutus-contract/src/Plutus/Contract/Test/ContractModel/Internal.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/ContractModel/Internal.hs
@@ -211,7 +211,7 @@ import Plutus.Trace.Emulator as Trace (EmulatorTrace, activateContract, callEndp
 import Plutus.Trace.Emulator.Types (unContractInstanceTag)
 import Plutus.V1.Ledger.Scripts
 import PlutusTx.Builtins qualified as Builtins
-import PlutusTx.Coverage
+import PlutusTx.Coverage hiding (_coverageIndex)
 import PlutusTx.ErrorCodes
 import Streaming qualified as S
 import Test.QuickCheck.DynamicLogic.Monad qualified as DL
@@ -1375,7 +1375,7 @@ instance GetModelState (DL state) where
 data CoverageOptions = CoverageOptions { _checkCoverage       :: Bool
                                        , _endpointCoverageReq :: ContractInstanceTag -> String -> Double
                                        , _coverageIndex       :: CoverageIndex
-                                       , _coverageIORef       :: Maybe (IORef CoverageReport)
+                                       , _coverageIORef       :: Maybe (IORef CoverageData)
                                        }
 
 makeLenses ''CoverageOptions
@@ -1405,8 +1405,9 @@ quickCheckWithCoverageAndResult qcargs copts prop = do
   case copts ^. coverageIORef of
     Nothing -> fail "Unreachable case in quickCheckWithCoverage"
     Just ref -> do
-      report <- readIORef ref
-      when (chatty qcargs) $ putStrLn . show $ pprCoverageReport (copts ^. coverageIndex) report
+      covdata <- readIORef ref
+      let report = CoverageReport (copts ^. coverageIndex) covdata
+      when (chatty qcargs) $ putStrLn . show $ pretty report
       return (report, res)
 
 finalChecks :: ContractModel state
@@ -1472,7 +1473,6 @@ addEndpointCoverage copts keys es pm
                          , e <- eps ]
     endpointCovers `deepseq`
       (QC.monitor . foldr (.) id $ endpointCovers)
-    QC.monitor QC.checkCoverage
     return x
   | otherwise = pm
 
@@ -1531,8 +1531,7 @@ propRunActions = propRunActionsWithOptions defaultCheckOptionsContractModel defa
 -- options :: `Map` `Wallet` `Value` -> `Slot` -> `Control.Monad.Freer.Extras.Log.LogLevel` -> `CheckOptions`
 -- options dist slot logLevel =
 --     `defaultCheckOptions` `&` `emulatorConfig` . `Plutus.Trace.Emulator.initialChainState` `.~` `Left` dist
---                         `&` `maxSlot`                            `.~` slot
---                         `&` `minLogLevel`                        `.~` logLevel
+--                           `&` `minLogLevel`                        `.~` logLevel
 -- @
 --
 propRunActionsWithOptions ::

--- a/plutus-contract/src/Plutus/Contract/Test/Coverage.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/Coverage.hs
@@ -1,27 +1,23 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Plutus.Contract.Test.Coverage
   ( getInvokedEndpoints
-  , getCoverageReport
+  , getCoverageData
   , CoverageRef(..)
   , newCoverageRef
   , readCoverageRef
   , writeCoverageReport
   ) where
 
-import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import Data.Foldable
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
-import GHC.Generics
 
 import Data.Text qualified as Text
 
-import Control.DeepSeq
 import Control.Lens
 
 import Ledger qualified
@@ -48,8 +44,8 @@ getInvokedEndpoints es =
   in epsCovered
 
 -- | Collect every executed coverage annotation in the validators executed in `es`
-getCoverageReport :: [EmulatorEvent] -> CoverageReport
-getCoverageReport es =
+getCoverageData :: [EmulatorEvent] -> CoverageData
+getCoverageData es =
   let extractLog e = case e of
         ChainEvent (TxnValidate _ _ valEvs)             -> logOf . Ledger.sveResult <$> valEvs
         ChainEvent (TxnValidationFail _ _ _ _ valEvs _) -> logOf . Ledger.sveResult <$> valEvs
@@ -64,49 +60,17 @@ getCoverageReport es =
     log <- extractLog $ event ^. eteEvent
     logEvent <- log
     let msg = Text.unpack logEvent
-    return $ coverageReportFromLogMsg msg
+    return $ coverageDataFromLogMsg msg
 
-newtype CoverageRef = CoverageRef (IORef CoverageReport)
+newtype CoverageRef = CoverageRef (IORef CoverageData)
 
 newCoverageRef :: IO CoverageRef
 newCoverageRef = CoverageRef <$> newIORef mempty
 
-readCoverageRef :: CoverageRef -> IO CoverageReport
+readCoverageRef :: CoverageRef -> IO CoverageData
 readCoverageRef (CoverageRef ioref) = readIORef ioref
 
 -- | Write a coverage report to name.html for the given index.
-writeCoverageReport :: String -> CoverageIndex -> CoverageReport -> IO ()
+writeCoverageReport :: String -> CoverageReport -> IO ()
 writeCoverageReport = ReportCoverage.writeCoverageReport
 
--- TODO: Move this to plutus core to avoid orhpan instance
-instance NFData CovLoc where
-  rnf (CovLoc f sl el sc ec) =
-    rnf f  `seq`
-    rnf sl `seq`
-    rnf el `seq`
-    rnf sc `seq`
-    rnf ec
-instance NFData CoverageAnnotation where
-  rnf (CoverLocation loc) = rnf loc
-  rnf (CoverBool loc b)   = rnf b `seq` rnf loc
-deriving anyclass instance NFData CoverageReport
-deriving instance Generic CoverageReport
-deriving anyclass instance ToJSON CoverageReport
-deriving anyclass instance FromJSON CoverageReport
-
-deriving anyclass instance ToJSON CoverageIndex
-deriving anyclass instance FromJSON CoverageIndex
-
-deriving anyclass instance ToJSON CoverageAnnotation
-deriving anyclass instance FromJSON CoverageAnnotation
-deriving anyclass instance ToJSONKey CoverageAnnotation
-deriving anyclass instance FromJSONKey CoverageAnnotation
-
-deriving anyclass instance ToJSON CovLoc
-deriving anyclass instance FromJSON CovLoc
-
-deriving anyclass instance ToJSON CoverageMetadata
-deriving anyclass instance FromJSON CoverageMetadata
-
-deriving anyclass instance ToJSON Metadata
-deriving anyclass instance FromJSON Metadata

--- a/plutus-contract/src/Plutus/Contract/Test/Coverage/Analysis.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/Coverage/Analysis.hs
@@ -1,0 +1,24 @@
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module Plutus.Contract.Test.Coverage.Analysis
+  ( computeRefinedCoverageIndex
+  ) where
+
+import Control.Lens
+
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+
+import PlutusCore.Default
+import PlutusTx.Code
+import PlutusTx.Coverage
+
+import Plutus.Contract.Test.Coverage.Analysis.Interpreter
+
+computeRefinedCoverageIndex :: CompiledCodeIn DefaultUni DefaultFun a -> CoverageIndex
+computeRefinedCoverageIndex cc =
+    foldr (flip addCoverageMetadata IgnoredAnnotation) covIdx (Set.toList ignoredLocs)
+  where
+    covIdx        = getCovIdx cc
+    importantLocs = allNonFailLocations cc
+    ignoredLocs   = covIdx ^. coverageMetadata . to Map.keysSet . to (`Set.difference` importantLocs)

--- a/plutus-contract/src/Plutus/Contract/Test/Coverage/Analysis/Common.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/Coverage/Analysis/Common.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE ImportQualifiedPost   #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE NumericUnderscores    #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE ViewPatterns          #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Plutus.Contract.Test.Coverage.Analysis.Common where
+import Control.DeepSeq
+import Data.Text qualified as Text
+import Debug.Trace
+import GHC.Stack
+import PlutusCore.DeBruijn hiding (DeBruijn)
+import PlutusCore.Default
+import PlutusCore.Name
+import PlutusIR
+import PlutusIR.Compiler
+import PlutusTx.Coverage
+import Text.PrettyPrint hiding (integer, (<>))
+import Text.Read (readMaybe)
+
+type Trm = Term NamedTyDeBruijn NamedDeBruijn DefaultUni DefaultFun ()
+type Typ = Type NamedTyDeBruijn DefaultUni ()
+type Kin = Kind ()
+type Dat = Datatype NamedTyDeBruijn NamedDeBruijn DefaultUni DefaultFun ()
+type Bind = Binding NamedTyDeBruijn NamedDeBruijn DefaultUni DefaultFun ()
+
+type Trm'  = Term TyName Name DefaultUni DefaultFun ()
+type Typ'  = Type TyName DefaultUni ()
+type Dat'  = Datatype TyName Name DefaultUni DefaultFun ()
+type Bind' = Binding TyName Name DefaultUni DefaultFun ()
+type Err'  = Error DefaultUni DefaultFun ()
+
+pattern BIF_Trace :: Term tyname name uni DefaultFun ()
+pattern BIF_Trace = Builtin () Trace
+
+pattern BIF_If :: Term tyname name uni DefaultFun ()
+pattern BIF_If = Builtin () IfThenElse
+
+pattern LIT_Loc :: CoverageAnnotation -> Term tyname name DefaultUni fun ()
+pattern LIT_Loc l <- Constant _ (Some (ValueOf DefaultUniString (readMaybe . Text.unpack -> Just l)))
+  where LIT_Loc l = Constant () (Some (ValueOf DefaultUniString (Text.pack (show l))))
+
+pattern Const :: DefaultUni (Esc a) -> a -> Term tyname name DefaultUni fun ()
+pattern Const b a = Constant () (Some (ValueOf b a))
+
+builtinKind :: SomeTypeIn DefaultUni -> Kin
+builtinKind (SomeTypeIn t) = case t of
+  DefaultUniProtoList -> Star :-> Star
+  DefaultUniProtoPair -> Star :-> Star :-> Star
+  DefaultUniApply f _ -> let _ :-> k = builtinKind (SomeTypeIn f) in k
+  _                   -> Star
+
+-- *** Debug helpers
+data Verbosity = Low
+               | Med
+               | High
+               | Unions
+               deriving (Ord, Eq, Show)
+
+debug :: Bool
+debug = False
+
+verbosity :: [Verbosity]
+verbosity = []
+
+traceDoc :: Verbosity -> Doc -> a -> a
+traceDoc v d a | debug && v `elem` verbosity = trace (show d) a
+               | otherwise = a
+
+traceDocIf :: Bool -> Verbosity -> Doc -> a -> a
+traceDocIf True = traceDoc
+traceDocIf _    = \ _ _ a -> a
+
+errorDoc :: HasCallStack => Doc -> a
+errorDoc = error . ("\n"++) . show
+
+deriving instance NFData Trm'
+deriving instance NFData Bind'
+deriving instance NFData (VarDecl TyName Name DefaultUni DefaultFun ())
+deriving instance NFData (TyVarDecl TyName ())
+deriving instance NFData Dat'
+deriving instance NFData Strictness
+deriving instance NFData Recursivity
+
+deriving instance NFData (TyVarDecl NamedTyDeBruijn ())
+deriving instance NFData Dat
+deriving instance NFData (VarDecl NamedTyDeBruijn NamedDeBruijn DefaultUni DefaultFun ())
+deriving instance NFData Bind
+deriving instance NFData Trm
+
+{-# COMPLETE Star, (:->) #-}
+pattern Star :: Kin
+pattern Star  = Type ()
+
+pattern (:->) :: Kin -> Kin -> Kin
+pattern (:->) a b = KindArrow () a b
+infixr 3 :->

--- a/plutus-contract/src/Plutus/Contract/Test/Coverage/Analysis/DeBruijn.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/Coverage/Analysis/DeBruijn.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE NumericUnderscores    #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE ViewPatterns          #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
+module Plutus.Contract.Test.Coverage.Analysis.DeBruijn where
+
+import Control.Arrow hiding ((<+>))
+import Data.List hiding (insert)
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Maybe
+import GHC.Stack
+import PlutusCore.DeBruijn hiding (DeBruijn)
+import PlutusCore.Name
+import PlutusIR
+import PlutusTx.Code
+import PlutusTx.Code qualified as PlutusTx
+
+import Plutus.Contract.Test.Coverage.Analysis.Common
+
+-- *** Conversion to DeBruijn
+
+type DBCtx nm = [nm]
+
+class Eq n => IsName n where
+  type DeBruijn n
+  mkDeBruijn :: n -> Index -> DeBruijn n
+
+instance IsName Name where
+  type DeBruijn Name = NamedDeBruijn
+  mkDeBruijn (Name t _) i = NamedDeBruijn t i
+
+instance IsName TyName where
+  type DeBruijn TyName = NamedTyDeBruijn
+  mkDeBruijn (TyName n) i = NamedTyDeBruijn (mkDeBruijn n i)
+
+class IsDbName n where
+  setDbIndex :: n -> Index -> n
+  getDbIndex :: n -> Index
+
+instance IsDbName NamedDeBruijn where
+  setDbIndex (NamedDeBruijn x _) i = NamedDeBruijn x i
+  getDbIndex (NamedDeBruijn _ i) = i
+
+instance IsDbName NamedTyDeBruijn where
+  setDbIndex (NamedTyDeBruijn x) i = NamedTyDeBruijn (setDbIndex x i)
+  getDbIndex (NamedTyDeBruijn x) = getDbIndex x
+
+deBruijn :: HasCallStack => IsName n => DBCtx n -> n -> DeBruijn n
+deBruijn ctx n = case findIndex (==n) ctx of
+  Nothing -> error "no dumb here - this is a no dumb area"
+  Just i  -> mkDeBruijn n $ fromIntegral i
+
+extendDBCtx :: HasCallStack => DBCtx n -> n -> DBCtx n
+extendDBCtx = flip (:)
+
+toDeBruijn_Trm :: HasCallStack => DBCtx TyName -> DBCtx Name -> Trm' -> Trm
+toDeBruijn_Trm tyCtx trmCtx trm = case trm of
+  Let _ rec binds body
+    | Rec <- rec ->
+      let (tyCtx', trmCtx') = foldl bindCtx_Bind (tyCtx, trmCtx) binds in
+      Let () rec (toDeBruijn_Bind True tyCtx' trmCtx' <$> binds) (toDeBruijn_Trm tyCtx' trmCtx' body)
+    | otherwise  ->
+      let (binds', (tyCtx', trmCtx')) = go' (tyCtx, trmCtx) binds in
+      Let () rec binds' (toDeBruijn_Trm tyCtx' trmCtx' body)
+      where
+        go' ctxs@(tyCtx, trmCtx) (bind :| binds) = first (toDeBruijn_Bind False tyCtx trmCtx bind :|)
+                                                         (go (bindCtx_Bind ctxs bind) binds)
+        go ctxs []                           = ([], ctxs)
+        go ctxs@(tyCtx, trmCtx) (bind:binds) = first (toDeBruijn_Bind False tyCtx trmCtx bind :)
+                                                     (go (bindCtx_Bind ctxs bind) binds)
+
+  Error _ ty -> Error () (toDeBruijn_Typ tyCtx ty)
+
+  Var _ x -> Var () $ deBruijn trmCtx x
+
+  TyAbs _ x k t -> TyAbs () (mkDeBruijn x 0) k $ toDeBruijn_Trm (extendDBCtx tyCtx x) trmCtx t
+
+  LamAbs _ x a t -> LamAbs () (mkDeBruijn x 0) (toDeBruijn_Typ tyCtx a) $
+                                toDeBruijn_Trm tyCtx (extendDBCtx trmCtx x) t
+
+  Apply _ t t' -> Apply () (toDeBruijn_Trm tyCtx trmCtx t) (toDeBruijn_Trm tyCtx trmCtx t')
+
+  TyInst _ t a -> TyInst () (toDeBruijn_Trm tyCtx trmCtx t) (toDeBruijn_Typ tyCtx a)
+
+  Constant _ c -> Constant () c
+
+  Builtin _ b  -> Builtin () b
+
+  IWrap{}      -> error "toDeBruijn_Trm: IWrap"
+  Unwrap{}     -> error "toDeBruijn_Trm: Unwrap"
+
+toDeBruijn_Typ :: HasCallStack => DBCtx TyName -> Typ' -> Typ
+toDeBruijn_Typ tyCtx a = case a of
+  TyVar _ x        -> TyVar () (deBruijn tyCtx x)
+  TyBuiltin _ b    -> TyBuiltin () b
+  TyFun _ a b      -> TyFun () (toDeBruijn_Typ tyCtx a) (toDeBruijn_Typ tyCtx b)
+  TyForall _ x k a -> TyForall () (mkDeBruijn x 0) k (toDeBruijn_Typ (extendDBCtx tyCtx x) a)
+  TyLam _ x k a    -> TyLam () (mkDeBruijn x 0) k (toDeBruijn_Typ (extendDBCtx tyCtx x) a)
+  TyApp _ a b      -> TyApp () (toDeBruijn_Typ tyCtx a) (toDeBruijn_Typ tyCtx b)
+  TyIFix _ _ _     -> error "normalizeType: TyIFix"
+
+bindCtx_Dat :: HasCallStack => (DBCtx TyName, DBCtx Name) -> Dat' -> (DBCtx TyName, DBCtx Name)
+bindCtx_Dat (tyCtx, trmCtx) (Datatype _ (TyVarDecl _ n _) _ match constrs) =
+  (extendDBCtx tyCtx n, foldl extendDBCtx trmCtx $ match : [ x | VarDecl _ x _ <- constrs])
+
+toDeBruijn_Dat :: HasCallStack => Bool -> DBCtx TyName -> Dat' -> Dat
+toDeBruijn_Dat rec tyCtx (Datatype _ (TyVarDecl _ n k) args match constrs) =
+  let tyCtx' = foldl extendDBCtx tyCtx ([ n | not rec ] ++ [ n | TyVarDecl _ n _ <- args ]) in
+  Datatype () (TyVarDecl () (mkDeBruijn n 0) k)
+              [TyVarDecl () (mkDeBruijn n 0) k | TyVarDecl _ n k <- args]
+              (mkDeBruijn match 0)
+              [VarDecl () (mkDeBruijn c 0) (toDeBruijn_Typ tyCtx' ty) | VarDecl _ c ty <- constrs]
+
+bindCtx_Bind :: HasCallStack => (DBCtx TyName, DBCtx Name) -> Bind' -> (DBCtx TyName, DBCtx Name)
+bindCtx_Bind (tyCtx, trmCtx) (TermBind _ _ (VarDecl _ x _) _) = (tyCtx, extendDBCtx trmCtx x)
+bindCtx_Bind (tyCtx, trmCtx) (TypeBind _ (TyVarDecl _ x _) _) = (extendDBCtx tyCtx x, trmCtx)
+bindCtx_Bind ctxs (DatatypeBind _ dat)                        = bindCtx_Dat ctxs dat
+
+toDeBruijn_Bind :: HasCallStack => Bool -> DBCtx TyName -> DBCtx Name -> Bind' -> Bind
+toDeBruijn_Bind _ tyCtx trmCtx (TermBind _ s (VarDecl _ x ty) body) =
+  TermBind () s (VarDecl () (mkDeBruijn x 0) (toDeBruijn_Typ tyCtx ty)) (toDeBruijn_Trm tyCtx trmCtx body)
+toDeBruijn_Bind _ tyCtx _ (TypeBind _ (TyVarDecl _ x k) ty) =
+  TypeBind () (TyVarDecl () (mkDeBruijn x 0) k) (toDeBruijn_Typ tyCtx ty)
+toDeBruijn_Bind r tyCtx _ (DatatypeBind _ dat) =
+  DatatypeBind () (toDeBruijn_Dat r tyCtx dat)
+
+getTrm :: HasCallStack => CompiledCode a -> Trm
+getTrm cc = let Program _ t = fromJust $ PlutusTx.getPir cc in toDeBruijn_Trm [] [] t

--- a/plutus-contract/src/Plutus/Contract/Test/Coverage/Analysis/Interpreter.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/Coverage/Analysis/Interpreter.hs
@@ -1,0 +1,858 @@
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE NumericUnderscores    #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE ViewPatterns          #-}
+
+{-# OPTIONS_GHC -fno-warn-name-shadowing
+                -fno-warn-redundant-constraints
+                -fno-warn-incomplete-record-updates
+                -fno-warn-incomplete-uni-patterns
+                -fno-warn-unused-top-binds
+                #-}
+-- TODO: the final -fno-warn here will be removed when we
+-- merge the test harness (after PIR generators are merged into core)
+-- and know what needs to be exported to make that make as much sense as possible.
+
+module Plutus.Contract.Test.Coverage.Analysis.Interpreter (allNonFailLocations) where
+import Control.Arrow hiding ((<+>))
+import Data.Foldable
+import Data.List hiding (insert)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text qualified as Text
+import GHC.Stack
+import PlutusCore.Builtin
+import PlutusCore.DeBruijn hiding (DeBruijn)
+import PlutusCore.Default
+import PlutusIR
+import PlutusTx.Code
+import PlutusTx.Coverage
+import Text.PrettyPrint hiding (integer, (<>))
+
+import Plutus.Contract.Test.Coverage.Analysis.Common
+import Plutus.Contract.Test.Coverage.Analysis.DeBruijn
+import Plutus.Contract.Test.Coverage.Analysis.Pretty
+import Plutus.Contract.Test.Coverage.Analysis.Types
+
+{- Note [Static analysis for non-fail-paths in plutus programs]
+  In this module we implement at static analysis tool losely based
+  on some form of abstract interpretation for finding program locatations
+  (represented as PlutusTx coverage annotations) that are on the success
+  paths of a plutus program. For example, in the following program:
+
+    foo x y = if <Program Location 0> x == y then
+                <Program Location 1> error "Fail"
+              else
+                <Program Location 2> ()
+
+  Program locations 0 and 2 are on the success path (that doesn't result in error)
+  and program location 1 is on the fail path. This information can be used (and is
+  used in `Plutus.Contract.Test.Coverage.Analysis`) to improve coverage annotations
+  to make the result of coverage checking significantly more readable.
+
+  The way this works is we basically do abstract interpretation. That is to say we
+  interpret PIR programs in a domain of "abstract programs" `Dom`. This domain track
+  of possible program locations, unions of possible results,
+  representations of datatypes and suspended computations, and a few escape hatches for
+  embedding full PIR programs. Abstract interpretation then works by short-cutting recursion
+  (by introducing DTop top values in the abstract domain) and aggressively expanding branches
+  (case expressions) as unions.
+
+  Most of the complexity in this module is related to the fact that we need to keep track
+  of types in order to expand branches. Note that a number of functions have dependent
+  types in comments above the type signature. THESE ARE IMPORTANT: not adhering to these
+  specifications will most likely break the analysis and because they are not type-checked
+  changes in this module have to be made with care.
+-}
+
+cost :: DDat -> Int
+cost (DDat _ _ _ _ constrs)
+    | length constrs < 2 = 0
+    | otherwise = 1
+
+idDTySubst :: TyCtx -> Subst DTyp
+idDTySubst ctx = go ctx 0
+  where
+    go Nil _ = Nil
+    go (ctx :> e) !i =
+      case e of
+        x ::: _                   -> go ctx (i + 1) :> DTVar (setDbIndex x i) []
+        TyCtxDat (DDat _ x _ _ _) -> go ctx (i + 1) :> DTVar (setDbIndex x i) []
+        TyCtxRecDat ds            -> go ctx (i + fromIntegral (length ds)) <> goDats ds i
+
+    goDats Nil _                    = Nil
+    goDats (ds :> DDat _ x _ _ _) i = goDats ds (i + 1) :> DTVar (setDbIndex x i) []
+
+-- wkDat :: {ctx : TyCtx, ctx' : TyCtx}
+--       -> (wk : Subst ctx ctx')
+--       -> DDat ctx
+--       -> DDat ctx'
+wkDat :: Weakening -> DDat -> DDat
+wkDat w (DDat rec nm k pars cons) =
+  DDat rec (wkDbIndex w nm) k pars [ DCon (wkT (shiftsWeakening (length pars + if rec then 0 else 1) w) <$> args)
+                                   | DCon args <- cons ]
+  where
+    shiftsWeakening n = foldr (.) id (replicate n shiftWeakening)
+
+-- lookupDat :: (ctx : TyCtx)
+--           -> Index
+--           -> DDat ctx
+lookupDat :: HasCallStack
+          => TyCtx
+          -> NamedTyDeBruijn
+          -> DDat
+lookupDat ctx nm =
+  case lookupCtx ctx nm of
+    Left{} -> errorDoc $
+          "lookupDat: " <+> vcat [ "ctx =" <+> pretty ctx
+                                 , "nm =" <+> pretty nm]
+    Right dat -> dat
+
+lookupCtx :: HasCallStack => TyCtx -> NamedTyDeBruijn -> Either Kin DDat
+lookupCtx ctx0 nm = go ctx0 (getDbIndex nm) mempty
+  where
+    go :: TyCtx -> Index -> Weakening -> Either Kin DDat
+    go Nil _ _ = errorDoc $
+        "lookupCtx Nil:" <+> vcat [ "ctx0 =" <+> pretty ctx0
+                                  , "nm =" <+> pretty nm ]
+
+    go (ctx :> _ ::: k) i w
+      | i == 0    = Left k
+      | otherwise = go ctx (i - 1) (wkBy 1 <> w)
+
+    go (ctx :> TyCtxRecDat ds) i w
+      | i < len ds = Right $ wkDat w (lookupSubst ds i)
+      | otherwise  = go ctx (i - len ds) (wkBy (len ds) <> w)
+
+    go (ctx :> TyCtxDat d) i w
+      | i == 0    = Right $ wkDat (wkBy 1 <> w) d
+      | otherwise = go ctx (i-1) (wkBy 1 <> w)
+
+dUnion :: Dom -> Dom -> Dom
+dUnion DError d      = d
+dUnion d DError      = d
+dUnion (DUnion ds) d = DUnion (insert (pushWeaken d) ds)
+dUnion l r           = DUnion (insert (pushWeaken r) [pushWeaken l])
+
+dUnions :: [Dom] -> Dom
+dUnions [] = errorDoc "dUnions []"
+dUnions ds = foldr1 dUnion ds
+
+insert :: Dom -> [Dom] -> [Dom]
+insert d@DLam{} ds     = d : ds
+insert (DUnion ds') ds = foldr insert ds ds'
+insert d []            = [d]
+insert d (d':ds)       = case (d, d') of
+  (DTop ty depth locs , DTop ty' depth' locs')
+    | not debug || normTy ty == normTy ty' ->
+      DTop ty (max depth depth') (locs <> locs') : ds
+    | otherwise -> errorDoc $ "insert DTop type error:" <?> vcat ["ty =" <+> pretty ty, "ty' =" <+> pretty ty']
+  (DSusp locs inner , DSusp locs' inner')
+    | locs == locs' -> DSusp locs (dUnion inner inner') : ds
+    | [inner''] <- insert inner [inner'] -> DSusp (locs <> locs') inner'' : ds
+  (DTySusp nm k locs inner , DTySusp _ _ locs' inner')
+    | locs == locs' -> DTySusp nm k locs (dUnion inner inner') : ds
+    | [inner''] <- insert inner [inner'] -> DTySusp nm k (locs <> locs') inner'' : ds
+  (DIf ty locs , DIf ty' locs')
+    | not debug || normTy ty == normTy ty' ->
+      DIf ty (locs <> locs') : ds
+    | otherwise -> errorDoc $ "insert DIf type error:" <?> vcat ["ty =" <+> pretty ty, "ty' =" <+> pretty ty']
+  (DTrace ty locs , DTrace ty' locs')
+    | not debug || normTy ty == normTy ty' ->
+      DTrace ty (locs <> locs') : ds
+    | otherwise -> errorDoc $ "insert DTrace type error:" <?> vcat ["ty =" <+> pretty ty, "ty' =" <+> pretty ty']
+  (DLoc l , DLoc l')
+    | l == l' ->
+      DLoc l : ds
+  (DConstr dat idx argsD locs , DConstr dat' idx' argsD' locs')
+    | not debug || (normTy dat == normTy dat' && length argsD == length argsD')
+    , idx == idx' ->
+      DConstr dat idx (zipWithSnoc dUnion argsD argsD') (locs <> locs') : ds
+    | idx == idx' -> errorDoc $ "insert DConstr type error:"
+      <?> vcat ["idx =" <+> pretty idx
+               ,"dat =" <+> pretty dat, "dat' =" <+> pretty dat'
+               ,"argsD =" <+> pretty argsD, "argsD' =" <+> pretty argsD']
+  (DMatch dat locs , DMatch dat' locs')
+    | dat == dat' ->
+      DMatch dat (locs <> locs') : ds
+  _ -> d' : insert d ds
+
+aggro :: Int
+aggro = 100
+
+addLocations :: HasCallStack => Set CoverageAnnotation -> Dom -> Dom
+addLocations locs d | null locs = d
+addLocations locs (DUnion ds) = DUnion (addLocations locs <$> ds)
+addLocations locs (DWeaken n d) = DWeaken n (addLocations locs d)
+addLocations _    DError = DError
+addLocations _    (DLoc l) = DLoc l
+addLocations locs d = d { _locations = _locations d <> locs }
+
+allLocations :: HasCallStack => TyCtx -> Dom -> Set CoverageAnnotation
+allLocations ctx d = case pushWeaken d of
+  DSusp locs d                      -> locs <> allLocations ctx d
+  DTySusp x k locs d                -> locs <> allLocations (ctx :> x ::: k) d
+  DLam _ ty substD substT body locs -> locs <> (uncurry allLocations . first (ctx <>)
+                                               $ interp ctx (substD :> dTop ty aggro mempty) substT body [])
+  DUnion ds                         -> foldMap (allLocations ctx) ds
+  DWeaken{}                         -> error "allLocations: DWeaken"
+  DConstr _ _ args locs             -> locs <> foldMap (allLocations ctx) (toList args)
+  DLoc _                            -> mempty
+  _                                 -> topLevelLocations d
+
+normalize_ :: HasCallStack => TyCtx -> Dom -> Dom
+normalize_ ctx d = nf
+  where (Nil, nf) = normalize ctx d
+
+normalize :: HasCallStack => TyCtx -> Dom -> (TyCtx, Dom)
+normalize ctx d = let d' = pushWeaken d in
+  case d' of
+    DSusp locs d                      -> second (DSusp locs) (normalize ctx d)
+    DTySusp x k locs d                -> (Nil, DTySusp x k locs $ normalize_ (ctx :> x ::: k) d)
+    DLam _ ty substD substT body locs -> (ctx' <> ctx'', DSusp locs nf)
+      where
+        (ctx', d'') = interp ctx (substD :> dTop ty aggro mempty) substT body []
+        (ctx'', nf) = normalize (ctx <> ctx') d''
+    DUnion ds ->
+      case unzip $ normalize ctx <$> ds of
+        (ctx : ctxs, ds) | all (ctx ==) ctxs -> (ctx, dUnions ds)
+        (ctxs, ds)                           -> errorDoc $ "normalize DUnion:" <+> pretty (zip ctxs ds)
+    DConstr dat con args locs         ->
+      (Nil, DConstr (normTy dat) con (normalize_ ctx <$> args) locs)
+    DTop ty d locs -> (Nil, DTop (normTy ty) d locs)
+    _ -> (Nil, d')
+
+wkD :: HasCallStack => Weakening -> Dom -> Dom
+wkD (Wk []) d        = d
+wkD w (DWeaken wk d) = DWeaken (w <> wk) d
+wkD w (DUnion ds)    = DUnion (wkD w <$> ds)
+wkD w d              = DWeaken w d
+
+wkT :: HasCallStack => Weakening -> DTyp -> DTyp
+wkT (Wk []) a     = a
+wkT w (DTWk wk a) = DTWk (w <> wk) a
+wkT w a           = DTWk w a
+
+wkArg :: HasCallStack => Weakening -> DArg -> DArg
+wkArg w (TyArg t) = TyArg (wkT w t)
+wkArg w (DArg d)  = DArg  (wkD w d)
+
+--lookupSubst :: {_ctx ctx}
+--            -> Subst _ctx (f ctx)
+--            -> Index
+--            -> f ctx
+lookupSubst :: HasCallStack => Subst a -> Index -> a
+lookupSubst (_   :> x) 0 = x
+lookupSubst (sub :> _) i = lookupSubst sub (i - 1)
+lookupSubst Nil        _ = error "lookupSubst: out of bounds"
+
+len :: (Functor f, Foldable f, Integral i) => f a -> i
+len = sum . fmap (const 1)
+
+ctxLen :: HasCallStack => TyCtx -> Index
+ctxLen = sum . fmap entryLen
+  where
+    entryLen (_ ::: _)        = 1
+    entryLen TyCtxDat{}       = 1
+    entryLen (TyCtxRecDat ds) = len ds
+
+pushWeaken :: HasCallStack => Dom -> Dom
+pushWeaken (DWeaken w d) = case d of
+  DTop ty dep locs                  -> dTop (wkT w ty) dep locs
+  DError                            -> DError
+  DSusp locs d                      -> DSusp locs (wkD w d)
+  DTySusp x k locs d                -> DTySusp x k locs (wkD (shiftWeakening w) d)
+  DIf ty locs                       -> DIf (wkT w ty) locs
+  DTrace ty locs                    -> DTrace (wkT w ty) locs
+  DLoc{}                            -> d
+  DLam x ty substD substT body locs -> DLam x (wkT w ty) (wkD w <$> substD) (wkT w <$> substT) body locs
+  DConstr dat con args locs         -> DConstr (wkT w dat) con (wkD w <$> args) locs
+  DMatch dat locs                   -> DMatch (wkT w dat) locs
+  DUnion{}                          -> error "pushWeaken: DWeaken/DUnion"
+  DWeaken{}                         -> error "pushWeaken: DWeaken/DWeaken"
+pushWeaken (DUnion ds) = DUnion (pushWeaken <$> ds)
+pushWeaken d = d
+
+wkDbIndex :: IsDbName i => Weakening -> i -> i
+wkDbIndex w x = setDbIndex x (wkIndex w (getDbIndex x))
+
+pushWeakenTy :: HasCallStack => DTyp -> DTyp
+pushWeakenTy (DTWk w a) = case a of
+  DTVar x ts     -> DTVar (wkDbIndex w x) (wkT w <$> ts)
+  DTFun s t      -> DTFun (wkT w s) (wkT w t)
+  DTLam x k t    -> DTLam x k (wkT (shiftWeakening w) t)
+  DTForall x k t -> DTForall x k (wkT (shiftWeakening w) t)
+  DTyBuiltin k   -> DTyBuiltin k
+  DTWk _ _       -> error "pushWeakenTy: DTWk"
+pushWeakenTy a = a
+
+normTy :: DTyp -> DTyp
+normTy a = case pushWeakenTy a of
+  DTVar x ts     -> DTVar x (normTy <$> ts)
+  DTFun s t      -> DTFun (normTy s) (normTy t)
+  DTLam x k t    -> DTLam x k (normTy t)
+  DTForall x k t -> DTForall x k (normTy t)
+  DTyBuiltin k   -> DTyBuiltin k
+  DTWk{}         -> error "normTy: DTWk"
+
+tyCheck :: TyCtx -> DTyp -> Dom -> Bool
+tyCheck ctx a d = case pushWeaken d of
+  DTop b _ _ -> normTy a == normTy b
+  DSusp _ d  ->
+    case pushWeakenTy a of
+      DTFun _ b -> tyCheck ctx b d
+      _         -> False
+  DError{}   -> True
+  DTySusp x k _ d ->
+    case pushWeakenTy a of
+      DTForall y k' b | x == y, k == k' -> tyCheck (ctx :> x ::: k) b d
+      _                                 -> False
+  DLam _ ty _ _ _ _ ->
+    case pushWeakenTy a of
+      DTFun argTy _ -> normTy ty == normTy argTy
+      _             -> False
+  DConstr (normTy -> ddat@(DTVar dat pars)) i args _
+    | length pars /= length xs       -> False
+    | i >= length cs                 -> False
+    | length args > length conArgTys -> False
+    | otherwise                      ->
+      and $ (normTy a == normTy (foldr DTFun ddat conArgTys2))
+          : zipWith (tyCheck ctx) conArgTys1 (toList args)
+    where
+      -- DDat ctx, so cs : [DCon (ctx :> (if rec then Nil else dat ::: _) :> xs ::: _)]
+      DDat rec _ _ xs cs       = lookupDat ctx dat
+      DCon conArgTys           = cs !! i
+      (conArgTys1, conArgTys2) = splitAt (length args) $ map inst conArgTys
+      inst ty | rec       = tyInsts ty pars
+              -- inst : DTyp (ctx :> dat ::: _ :> xs ::: _) -> DTyp ctx
+              | otherwise = tyInsts ty (DTVar dat [] : pars)
+
+  DConstr{}  -> False
+
+  DMatch (normTy -> (DTVar dat pars)) _ -> case normTy a of
+    DTFun (DTVar dat' pars') (DTForall r Star body)
+      | dat' /= dat                         -> False
+      | map normTy pars /= map normTy pars' -> False
+      | length pars /= length xs            -> False
+      | otherwise                           ->
+        and $ (normTy bodyRes == DTVar r []) : [ normTy b == normTy (foldr DTFun (DTVar r []) (map (wkT (wkBy 1) .  inst) conArgs))
+                                               | (b, DCon conArgs) <- zip bodyArgs cs ]
+                                    where (bodyArgs, bodyRes) = view body
+    _ -> False
+    where DDat rec _ _ xs cs = lookupDat ctx dat
+          inst ty | rec       = tyInsts ty pars
+                  | otherwise = tyInsts ty (DTVar dat [] : pars)
+          view (DTFun a b) = first (a:) (view b)
+          view a           = ([], a)
+
+  DMatch{} -> False
+
+  DIf ty _    -> normTy (DTFun (DTyBuiltin Star) (DTFun ty (DTFun ty ty))) == normTy a
+  DTrace ty _ -> normTy (DTFun (DTyBuiltin Star) (DTFun ty ty)) == normTy a
+  DUnion ds   -> all (tyCheck ctx a) ds
+  DLoc{}      -> normTy a == DTyBuiltin Star
+  DWeaken{}   -> error "tyCheck: DWeaken"
+
+-- dTop :: {ctx :: TyCtx} -> DTyp ctx -> Int -> Set CoverageAnnotation -> Dom ctx
+dTop :: DTyp -> Int -> Set CoverageAnnotation -> Dom
+dTop (pushWeakenTy -> DTForall x k dt) i locs = DTySusp x k locs $ dTop dt i mempty
+dTop ty i locs                                = DTop ty i locs
+
+-- tyInsts :: DTyp (ctx :> ctx')
+--         -> { xs : [DTyp ctx] | length xs = length ctx', xs !! i : toList ctx' !! i }
+--         -> DTyp ctx
+tyInsts :: DTyp -> [DTyp] -> DTyp
+tyInsts a []     = a
+tyInsts a (x:xs) = tyInsts (tyInst (fromIntegral $ length xs) a x) xs
+
+domApp :: HasCallStack
+       => TyCtx   -- (ctx : TyCtx)
+       -> Dom     -- Dom ctx
+       -> Dom     -- Dom ctx
+       -> Dom     -- Dom ctx
+domApp _ DError _ = DError -- DONT MOVE! The order of this case shortcuts unions in the argument
+domApp ctx d (pushWeaken -> DUnion ds) = dUnions (domApp ctx d <$> ds)
+domApp _ _ DError = DError
+domApp ctx d arg = addLocations (topLevelLocations arg) $ case d of
+  DTop (pushWeakenTy -> DTFun argT b) dep locs
+    | not debug || tyCheck ctx argT arg ->
+      dTop b dep (locs <> allLocations ctx arg)
+    | otherwise -> errorDoc $ "domApp - type error - DTop:"
+                                <?> vcat ["d =" <+> pretty d
+                                         ,"arg =" <+> pretty arg]
+
+  DError -> DError
+
+  DSusp locs d -> addLocations (locs <> allLocations ctx arg) d
+
+  DIf ty locs -> case arg of
+    DTop (pushWeakenTy -> DTyBuiltin Type{}) _ _ ->
+      let x = NamedDeBruijn "x" 0
+          y = NamedDeBruijn "y" 0
+          a = TyVar () (NamedTyDeBruijn (NamedDeBruijn "a" 0))
+          substT' = Nil :> ty
+          -- Here _ctx = a{0}
+          -- and under the LamAbs it's (in the mixed ctx format) _ctx = a{0} :> y : a{0}
+          dTrue  = DLam x ty mempty substT' (LamAbs () y a (Var () (setDbIndex x 1))) locs
+          dFalse = DLam x ty mempty substT' (LamAbs () y a (Var () y)) locs
+      in dUnion dTrue dFalse
+    _ -> errorDoc $ "domApp: DIf" <?> ("arg =" <+> pretty arg)
+
+  DTrace ty locs -> case pushWeaken arg of
+    DLoc l              ->
+      let x = NamedDeBruijn "x" 0
+      in DLam x ty mempty mempty (Var () x) (locs <> Set.singleton l)
+    DTop (pushWeakenTy -> DTyBuiltin Type{}) _ _ ->
+      let x = NamedDeBruijn "x" 0
+      in DLam x ty mempty mempty (Var () x) locs
+    _                  -> errorDoc $ "domApp: DTrace" <?> vcat [ "arg =" <+> pretty arg ]
+
+  DLam _ ty substD substT body locs
+    | not debug || tyCheck ctx ty arg ->
+      addLocations locs $ interp_ ctx (substD :> arg) substT body []
+    | otherwise -> errorDoc $ "domApp - type error - DLam:"
+                                <?> vcat ["ty =" <+> pretty (normTy ty)
+                                         ,"body =" <+> pretty body
+                                         ,"arg =" <+> pretty arg]
+
+  DConstr dat con args locs -> DConstr dat con (args :> arg) locs
+
+  match@(DMatch (pushWeakenTy -> DTVar d pars) locs) -> case pushWeaken arg of
+
+    DTop (pushWeakenTy -> ty) depth alocs
+      | DTVar{} <- ty
+      , dat@(DDat False nm _ _ constrs) <- lookupDat ctx d
+      , depth >= cost dat ->
+         -- We are matching on datatype `C` and the argument is `T[C p0 ... pn]`
+         traceDoc Med ("domApp - lookupDat" <?> vcat ["ctx =" <+> pretty ctx, "d =" <+> pretty d]) $
+         -- Here we are working in `ctx`
+         let topArgs (DCon args) = foldl (:>) Nil
+              [ dTop (tyInsts a (DTVar nm [] : pars)) (depth-cost dat) mempty
+              | a <- args ]
+         in traceDoc Unions (("expand" <> brackets (pretty $ length constrs)) <+> pretty ty)
+            $ foldl1 dUnion [ domApp ctx match $ DConstr ty i (topArgs c) alocs
+                            | (i, c) <- zip [0..] constrs ]
+      -- TODO: unuglyfy
+      | DTVar{} <- ty
+      , (DDat True _ _ _ _) <- lookupDat ctx d ->
+        let ty = DTForall r Star $ foldr DTFun (DTVar r []) argTypes
+        in dTop ty aggro (locs <> allLocations ctx arg)
+      | otherwise ->
+        let ty = DTForall r Star $ foldr DTFun (DTVar r []) argTypes
+        in dTop ty 0 (locs <> allLocations ctx arg)
+
+    -- Constructor argument
+    -- TODO: refactor lambdas (maybe have named (DLam) and un-named (DSusp) abstraction in the language
+    -- and push closures over terms to their own constructor?)
+    DConstr _ conIdx argsD alocs ->
+      let n = length constrs
+          m = length argsD
+          -- c_0{0} , ... , c_(n-1){0}
+          xCargs = [ NamedDeBruijn ("c" <> Text.pack (show i)) 0
+                   | i <- [0..n-1] ]
+          -- a_0{n} , ... , a_(m-1){n+m-1} :: Trm (_ctx :> c_0 ... c_(n-1))
+          xAargs = [ Var () $ NamedDeBruijn ("a" <> Text.pack (show i)) $ fromIntegral (i + n)
+                   | i <- [0..m-1] ]
+          -- a_m :> ... :> a_0
+          -- argsD :: SnocList (DTyp ctx)
+          -- means we need to shift it into ctx'
+          substD = wkD (wkBy 1) <$> foldl (:>) Nil (reverse $ toList argsD)
+          -- t_1{0} , ... , t_(n-1){n-2}
+          targs = [ TyVar () $ NamedTyDeBruijn
+                             $ NamedDeBruijn ("t" <> Text.pack (show (i+1)))
+                             $ fromIntegral i
+                  | i <- [0..n - 2] ]
+          -- t_n :> ... :> t_1
+          substT = foldl (:>) Nil (reverse $ tail argTypes)
+          -- c_conIdx{(n-1)-conIdx}
+          con = Var () $ NamedDeBruijn ("c" <> Text.pack (show conIdx)) (fromIntegral $ (n - 1) - conIdx)
+      in DTySusp r Star (locs <> alocs) $
+          -- \ c_0 : ta_0 ->
+          DLam (head xCargs) (head argTypes)
+               substD -- a_m :> ... :> a_0
+               substT -- t_n :> ... :> t_1
+               -- \ c_1 : t_1{0} , ... , c_n : t_n{n-1} ->
+               (flip (foldr (uncurry (LamAbs ()))) (zip (tail xCargs) targs) $
+                -- c_conIdx{n-conIdx} a_0{0} ... a_m{m}
+                foldl (Apply ()) con xAargs)
+               mempty
+
+    _ -> error $ "domApp: DMatch\narg = " ++ show arg ++ "\n\nctx = " ++ show ctx
+
+    where
+      r    = NamedTyDeBruijn $ NamedDeBruijn "r" 0
+      ctx' = ctx :> r ::: Star
+      -- pars :: [DTyp ctx]
+      -- pars' :: [DTyp ctx']
+      pars' = wkT (wkBy 1) <$> pars
+      -- d' :: DTyp ctx'
+      d'    = wkDbIndex (wkBy 1) d
+      -- constrs :: [DCon (ctx' :> _nm ::: _k :> (_pars ::: _someKinds))]
+      -- _nm = d'
+      DDat _r _nm _k _pars constrs = lookupDat ctx' d'
+      -- mkConTy :: DCon (ctx' :> _nm{0} ::: _k :> (_pars ::: _someKinds)) -> DTyp ctx'
+      mkConTy (DCon args) = foldr DTFun (DTVar r []) $ flip tyInsts (if _r then pars' else DTVar d' [] : pars') <$> args
+      -- argTypes :: [DTyp ctx']
+      argTypes = map mkConTy constrs
+
+  _                                 -> errorDoc $ "domApp: " <?> vcat [ "d =" <+> pretty d
+                                                                      , "arg =" <+> pretty arg
+                                                                      , "ctx =" <+> pretty ctx]
+
+domTyApp :: HasCallStack
+         => TyCtx   -- (ctx : TyCtx)
+         -> Dom     -- Dom ctx
+         -> DTyp    -- DTyp ctx
+         -> Dom     -- Dom ctx
+domTyApp ctx DTySusp{..} a = addLocations _locations $ domTyInst ctx inner a
+domTyApp _ DError        _ = DError
+domTyApp _ d t             = errorDoc $ "domTyApps: " <?> vcat [ "d =" <+> pretty d
+                                                                 , "t =" <+> pretty t ]
+
+-- tyInst :: {ctx ctx' : TyCtx}
+--        -> (i : Index | i == length ctx')
+--        -> DTyp (ctx :> a ::: k :> ctx')
+--        -> DTyp ctx
+--        -> DTyp (ctx :> ctx')
+tyInst :: HasCallStack => Index -> DTyp -> DTyp -> DTyp
+tyInst i a b = case pushWeakenTy a of
+  DTVar x ts | getDbIndex x > i  -> DTVar (setDbIndex x (getDbIndex x - 1)) ts'
+             | getDbIndex x == i -> tyApps (wkT (wkBy i) b) ts'
+             | otherwise         -> DTVar x ts'
+             where ts' = [ tyInst i a b | a <- ts ]
+  DTFun s t      -> DTFun (tyInst i s b) (tyInst i t b)
+  DTLam x k t    -> DTLam x k (tyInst (i+1) t b)
+  DTForall x k t -> DTForall x k (tyInst (i+1) t b)
+  DTyBuiltin k   -> DTyBuiltin k
+  DTWk _ _       -> error "tyInst: DTWk"
+
+domTyInst :: HasCallStack
+          => TyCtx  -- (ctx : TyCtx)
+          -> Dom    -- Dom (ctx :> x ::: k)
+          -> DTyp   -- DTyp ctx
+          -> Dom    -- Dom ctx
+domTyInst _ d t = go 0 d
+  where
+    -- go :: {ctx' : TyCtx}
+    --    -> (i : Index | i == length ctx')
+    --    -> Dom (ctx :> a ::: k :> ctx')
+    --    -> Dom (ctx :> ctx')
+    go !i d = case pushWeaken d of
+      DTop ty dep locs                  -> dTop (tyInst i ty t) dep locs
+      DError                            -> DError
+      DTySusp x k locs body             -> DTySusp x k locs (go (i + 1) body)
+      DSusp locs d                      -> DSusp locs (go i d)
+      DIf ty locs                       -> DIf (tyInst i ty t) locs
+      DTrace ty locs                    -> DTrace (tyInst i ty t) locs
+      DLam x ty substD substT body locs -> DLam x (tyInst i ty t) (go i <$> substD)
+                                                                  (flip (tyInst i) t <$> substT)
+                                                                  body locs
+      DConstr dat con args locs         -> DConstr (tyInst i dat t) con (go i <$> args) locs
+      DMatch dat locs                   -> DMatch (tyInst i dat t) locs
+      DLoc{}                            -> d
+      DUnion ds                         -> dUnions (go i <$> ds)
+      DWeaken{}                         -> error "domTyInst: DWeaken"
+
+tyApps :: HasCallStack => DTyp -> [DTyp] -> DTyp
+tyApps t []                          = t
+tyApps t@DTWk{} args                 = tyApps (pushWeakenTy t) args
+tyApps (DTVar x args0) args          = DTVar x (args0 <> args)
+tyApps (DTLam _ _ body) (arg : args) = tyApps (tyInst 0 body arg) args
+tyApps (DTyBuiltin (_ :-> k)) (_ : args) = tyApps (DTyBuiltin k) args
+tyApps t args                        = errorDoc $ "tyApps:" <?> vcat [ "t =" <+> pretty t
+                                                                     , "args =" <+> pretty args ]
+
+domApps :: HasCallStack
+        => TyCtx
+        -> Dom
+        -> [DArg] -> Dom
+domApps ctx = foldl (app . pushWeaken)
+  where
+    app d@(DUnion ds) a =
+      let res0 = (`app` a) <$> ds
+          res = dUnions res0 in
+      traceDoc High ("dUnionsApp:" <?> vcat [ "ctx =" <+> pretty ctx
+                                            , "d =" <+> pretty d
+                                            , "a =" <+> pretty a
+                                            , "ds app a=" <+> pretty res0
+                                            , "res =" <+> pretty res ])
+            res
+    app d a@(TyArg t)   =
+      let res = domTyApp ctx d t in
+      traceDoc High ("domTyApp:" <?> vcat [ "ctx =" <+> pretty ctx
+                                          , "d =" <+> pretty d
+                                          , "a =" <+> pretty a
+                                          , "res =" <+> pretty res ])
+            res
+    app d a@(DArg d')      =
+      let res = domApp ctx d (pushWeaken d') in
+      traceDoc High ("domApp:" <?> vcat [ "ctx =" <+> pretty ctx
+                                        , "d =" <+> pretty d
+                                        , "a =" <+> pretty a
+                                        , "res =" <+> pretty res ])
+            res
+
+interpTy :: HasCallStack
+         => TyCtx         -- (ctx : TyCtx) {_ctx : TyCtx}
+         -> Subst DTyp    -- Subst _ctx (DTyp ctx)
+         -> Typ           -- Typ _ctx
+         -> [DTyp]        -- [DTyp ctx]
+         -> DTyp          -- DTyp ctx
+interpTy ctx substT ty args = case ty of
+  TyVar _ x     -> lookupSubst substT (getDbIndex x) `tyApps` args
+  TyBuiltin _ c -> DTyBuiltin (builtinKind c `kindApp` args)
+    where
+      kindApp k         []         = k
+      kindApp (_ :-> k) (_ : args) = kindApp k args
+      kindApp Star      _          = errorDoc $ "interpTy TyBuiltin:" <+> pretty ty
+  TyFun _ a b | [] <- args -> DTFun (interpTy ctx substT a []) (interpTy ctx substT b [])
+              | otherwise  -> error "interpTy: TyFun"
+  TyForall _ x k b
+    | [] <- args -> DTForall x k $ interpTy (ctx :> x ::: k) ((wkT (wkBy 1) <$> substT) :> DTVar x []) b []
+    | otherwise  -> error "interpTy: TyForall"
+  TyLam _ x k b ->
+    case args of
+      []         -> DTLam x k $ interpTy (ctx :> x ::: k) ((wkT (wkBy 1) <$> substT) :> DTVar x []) b []
+      arg : args -> interpTy ctx (substT :> arg) b args
+  TyApp _ a b   -> interpTy ctx substT a (interpTy ctx substT b [] : args)
+  TyIFix _ _ _  -> error "interpTy: TyIFix"
+
+-- interpDat :: {_ctx : TyCtx} (ctx : TyCtx)
+--           -> Subst _ctx (DTyp ctx)
+--           -> Dat _ctx
+--           -> DDat ctx
+interpDat :: HasCallStack
+          => TyCtx
+          -> Subst DTyp
+          -> Dat
+          -> Bool
+          -> DDat
+interpDat ctx substT (Datatype _ (TyVarDecl _ n k) pars _ constrs) rec =
+  DDat rec n k [ n | TyVarDecl _ n _ <- pars ] [ mkDCon c | c <- constrs ]
+  where
+    ctxExts = [ n ::: k | not rec ] ++ [ n ::: k | TyVarDecl _ n k <- pars ]
+    ctx' = foldl (:>) ctx ctxExts
+    wkAmt = genericLength ctxExts
+
+    substExts = [ DTVar n [] | not rec ] ++
+                [ DTVar (setDbIndex n $ fromIntegral i) []
+                | (i, TyVarDecl _ n _) <- zip (reverse [0..length pars - 1]) pars]
+
+    substT' = foldl (:>) ((wkT (wkBy wkAmt) <$> substT)) substExts
+
+    mkDCon (VarDecl _ _ ty) = DCon [ interpTy ctx' substT' a []
+                                   | a <- funArgs ty [] ]
+
+    funArgs (TyFun _ a b) args = funArgs b (a : args)
+    funArgs _ args             = reverse args
+
+-- interp_ :: {_ctx : TyCtx}
+--         -> (ctx : TyCtx)
+--         -> Subst _ctx (Dom ctx)
+--         -> Subst _ctx (Typ ctx)
+--         -> Trm _ctx
+--         -> [DArg ctx]
+--         -> Dom ctx
+interp_ :: HasCallStack
+        => TyCtx
+        -> Subst Dom
+        -> Subst DTyp
+        -> Trm
+        -> [DArg]
+        -> Dom
+interp_ ctx substD substT trm args =
+  case interp ctx substD substT trm args of
+    (Nil, d)  -> d
+    (ctx', _) -> errorDoc $ "interp_: " <+> pretty ctx'
+
+-- interp :: {_ctx : TyCtx}
+--        -> (ctx : TyCtx)
+--        -> Subst _ctx (Dom ctx)
+--        -> Subst _ctx (Typ ctx)
+--        -> Trm _ctx
+--        -> [DArg ctx]
+--        -> (ctx' : TyCtx) * Dom (ctx <> ctx')
+interp :: HasCallStack
+       => TyCtx
+       -> Subst Dom
+       -> Subst DTyp
+       -> Trm
+       -> [DArg]
+       -> (TyCtx, Dom)
+interp ctx substD substT trm args =
+  traceDoc High ("interp:" <?> vcat [ "ctx =" <+> pretty ctx
+                                    , "substD =" <+> pretty substD
+                                    , "substT =" <+> pretty substT
+                                    , "trm =" <+> pretty trm
+                                    , "args =" <+> pretty args
+                                    , "res =" <+> pretty (snd res)])
+        res
+  where res = case trm of
+                BIF_Trace -> (Nil, domApps ctx (DTySusp a Star mempty (DTrace (DTVar a []) mempty)) args)
+                  where a = NamedTyDeBruijn $ NamedDeBruijn "a" 0
+
+                BIF_If -> (Nil, domApps ctx (DTySusp a Star mempty (DIf (DTVar a []) mempty)) args)
+                  where a = NamedTyDeBruijn $ NamedDeBruijn "a" 0
+
+                LIT_Loc l
+                  | [] <- args -> (Nil, DLoc l)
+                  | otherwise  -> error "interp: DLoc"
+
+                Let _ Rec binds body -> first (dctx <>) $ go substDwk (toList binds)
+                  where
+                    fv              = wkBy (len dats)
+                    substDwk        = wkD fv <$> substD
+                    (dats, substT') = buildTSubst Nil (wkT fv <$> substT) (toList binds)
+                    dctx | Nil <- dats = Nil
+                         | otherwise   = Nil :> TyCtxRecDat dats
+                    ctx'            = ctx <> dctx
+                    substDR         = buildDSubst substDwk (toList binds)
+
+                    buildTSubst dats substT [] = (dats, substT)
+                    buildTSubst dats substT (b:binds) = case b of
+                      TypeBind _ (TyVarDecl _ _ _) ty ->
+                        -- This is subtle! We use the ctx' and substT' that we are in the process of computing
+                        -- (laziness ftw). This is fine (insert dog meme) because type synonyms can't be recursive.
+                        buildTSubst dats (substT :> interpTy ctx' substT' ty []) binds
+                      DatatypeBind _ dat@(Datatype _ (TyVarDecl _ n _) pars _ constrs) ->
+                        let normDat      = interpDat ctx' substT' dat True -- :: Dat ctx'
+                            (dDat, _, _) = mkDat n pars constrs binds
+                        in buildTSubst (dats :> normDat) (substT :> dDat) binds
+                      _ -> buildTSubst dats substT binds
+
+                    buildDSubst substD [] = substD
+                    buildDSubst substD (b:binds) = case b of                                    -- TODO: locations?? (should be all locations in the letrec!) really use aggro here?
+                      TermBind _ _ (VarDecl _ _ ty) _ -> buildDSubst (substD :> dTop (interpTy ctx' substT' ty []) aggro mempty)
+                                                                     binds
+                      DatatypeBind _ (Datatype _ (TyVarDecl _ n _) pars _ constrs) ->
+                        let (_, dMatch, dConstrs) = mkDat n pars constrs binds
+                            substD'   = foldl (:>) substD (dMatch : dConstrs)
+                        in buildDSubst substD' binds
+                      _ -> buildDSubst substD binds
+
+                    go substD [] = interp ctx' substD substT' body $ wkArg fv <$> args
+                    go substD (b:binds) = case b of
+                      TermBind _ s (VarDecl _ _ _) body ->
+                        let result = interp_ ctx' substDR substT' body []
+                            locs result = if s == Strict then topLevelLocations result else mempty
+                        in case result of
+                            -- TODO: the compiler bug also affects this line below!
+                            DError | s == Strict -> second (const DError) $ go (substD :> result) binds
+                            DUnion ds            ->
+                              let rs = [ second (addLocations (locs result))
+                                           $ go (substD :> result) binds | result <- ds ]
+                              in (fst (head rs), dUnions $ map snd rs)
+                            _                    -> second (addLocations (locs result))
+                                                      $ go (substD :> result) binds
+
+                      DatatypeBind _ (Datatype _ (TyVarDecl _ n _) pars _ constrs) ->
+                        let (_, dMatch, dConstrs) = mkDat n pars constrs binds
+                            substD'  = foldl (:>) substD (dMatch : dConstrs)
+                        in go substD' binds
+
+                      _ -> go substD binds
+
+                Let _ _ binds body -> go Nil substD substT (toList binds)
+                  where
+                    -- go :: {_ctx : Ctx} (ctx' : Ctx)
+                    --    -> Subst _ctx (Dom (ctx <> ctx'))
+                    --    -> Subst _ctx (Typ (ctx <> ctx'))
+                    --    -> Binds _ctx
+                    --    -> (ctx'' : Ctx) * Dom (ctx <> ctx'')
+                    go ctx' substD substT [] = first (ctx' <>) $ interp (ctx <> ctx') substD substT body
+                                                                  $ wkArg (wkBy $ ctxLen ctx') <$> args
+                    go ctx' substD substT (b:binds) = case b of
+                      TermBind _ s (VarDecl _ _ _) body ->
+                        let result = interp_ (ctx <> ctx') substD substT body []
+                            locs result = if s == Strict then topLevelLocations result else mempty
+                        in case result of
+                            -- TODO: not the fastest way to do this (datatypes in the continuation?)
+                            DError | s == Strict -> second (const DError)
+                                                    $ go ctx' (substD :> result) substT binds
+                            DUnion ds            ->
+                              let rs = [second (addLocations (locs result))
+                                                                $ go ctx' (substD :> result) substT binds
+                                                            | result <- ds ]
+                              in (fst (head rs), dUnions (map snd rs))
+                            _                    -> second (addLocations (locs result))
+                                                    $ go ctx' (substD :> result) substT binds
+
+                      -- TODO: remove (also wrong?)
+                      TypeBind _ (TyVarDecl _ _ _) ty    ->
+                        go ctx' substD (substT :> interpTy (ctx <> ctx') substT ty []) binds
+
+                      DatatypeBind _ dat@(Datatype _ (TyVarDecl _ n _) pars _ constrs) ->
+                        let (dDat, dMatch, dConstrs) = mkDat n pars constrs Nil  -- dDat == Var 0
+                            normDat = interpDat (ctx <> ctx') substT dat False -- :: DDat (ctx <> ctx')
+                            substD' = foldl (:>) (wkD (wkBy 1) <$> substD) (dMatch : dConstrs)
+                        in go (ctx' :> TyCtxDat normDat) substD' (fmap (wkT (wkBy 1)) substT :> dDat) binds
+
+                Error{} -> (Nil, DError)
+
+                Var _ nm@(NamedDeBruijn _ idx) ->
+                  traceDoc Low ("interp: lookupVar" <+> pretty nm)
+                    (Nil, domApps ctx (lookupSubst substD idx) args)
+
+                TyAbs _ x k t
+                  | TyArg a : args' <- args -> (Nil, interp_ ctx substD (substT :> a) t args')
+
+                  | [] <- args              -> (Nil, DTySusp x k mempty $ interp_ (ctx :> x ::: k)
+                                                                                  (wkD (wkBy 1) <$> substD)
+                                                                                  (fmap (wkT $ wkBy 1) substT :> DTVar x [])
+                                                                                  t []) -- x is guaranteed to be 0 + a name
+
+                  | otherwise              -> error "interp: TyAbs"
+
+                (LamAbs _ x a t)
+                  | DArg d : args' <- args -> (Nil, addLocations (topLevelLocations d) $ interp_ ctx (substD :> d) substT t args')
+
+                  | [] <- args -> (Nil, DLam x (interpTy ctx substT a []) substD substT t mempty)
+
+                  | otherwise -> error "interp: LamAbs"
+
+                Apply _ t t' -> case interp_ ctx substD substT t' [] of
+                  DError -> (Nil, DError)
+                  d      -> (Nil, interp_ ctx substD substT t (DArg d : args))
+
+                TyInst _ t a -> (Nil, interp_ ctx substD substT t (TyArg (interpTy ctx substT a []) : args))
+
+                Constant _ _
+                  | [] <- args -> (Nil, dTop (DTyBuiltin $ Star) aggro mempty)
+                  | otherwise   -> error "interp: Constant"
+
+                Builtin _ b -> (Nil, domApps ctx (dTop (interpTy ctx substT
+                                                                 (toDeBruijn_Typ [] $ typeOfBuiltinFunction b) [])
+                                                       aggro mempty) args)
+
+                IWrap{} -> error "interp: IWrap"
+                Unwrap{} -> error "interp: Unwrap"
+                where
+                  mkDat n pars constrs binds = ( dDat 0 []
+                                               , susp $ DMatch (dDat (length pars) args) mempty
+                                               , [ susp $ DConstr (dDat (length pars) args) i Nil mempty
+                                                 | i <- [0..length constrs - 1] ])
+                    where
+                      susp = foldr (.) id [ DTySusp x k mempty | TyVarDecl _ x k <- pars ]
+                      args = reverse [ DTVar (setDbIndex x i) [] | (i, TyVarDecl _ x _ ) <- zip [0..] (reverse pars) ]
+                      -- Compute db index for a datatype by counting number of data type binds remaining.
+                      dDat k = DTVar (setDbIndex n $ fromIntegral $ k + length [() | DatatypeBind{} <- toList binds])
+
+interpCode :: HasCallStack => CompiledCodeIn DefaultUni DefaultFun a -> (TyCtx, Dom)
+interpCode cc = interp Nil Nil Nil (getTrm cc) []
+
+allNonFailLocations :: HasCallStack => CompiledCodeIn DefaultUni DefaultFun a -> Set CoverageAnnotation
+allNonFailLocations = uncurry allLocations . interpCode

--- a/plutus-contract/src/Plutus/Contract/Test/Coverage/Analysis/Pretty.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/Coverage/Analysis/Pretty.hs
@@ -1,0 +1,368 @@
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE NumericUnderscores    #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE ViewPatterns          #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module Plutus.Contract.Test.Coverage.Analysis.Pretty where
+
+import Control.Arrow hiding ((<+>))
+import Control.Lens ((^.))
+import Data.Foldable
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text qualified as Text
+import PlutusCore.Core (TyDecl (..))
+import PlutusCore.DeBruijn hiding (DeBruijn)
+import PlutusCore.Default
+import PlutusCore.Name
+import PlutusIR
+import PlutusTx.Code qualified as PlutusTx
+import PlutusTx.Coverage
+import Prettyprinter qualified as Pp
+import Test.QuickCheck
+import Text.PrettyPrint hiding (integer, (<>))
+import Text.Read (readMaybe)
+
+import UntypedPlutusCore qualified as UPLC
+
+import Plutus.Contract.Test.Coverage.Analysis.Types
+
+{- Note [Prettyprinting of PIR in plutus-apps]
+   This code will be migrated to plutus-core in a future release. However, in order to make
+   the static anylsis code in `Plutus.Contract.Test.Coverage.Analysis.Interpreter` debuggable
+   now we need this here until that is done. Therefore, we will have to accept the slight
+   inconvenience of this being in the wrong place (and using the wrong prettyprinting library)
+   for now.
+-}
+
+-- Sane pretty printer for Plutus IR
+
+class Pretty a where
+  pretty     :: a -> Doc
+  prettyPrec :: Int -> a -> Doc
+
+  pretty = prettyPrec 0
+  prettyPrec _ = pretty
+
+  {-# MINIMAL pretty | prettyPrec #-}
+
+(<?>) :: Doc -> Doc -> Doc
+a <?> b = hang a 2 b
+
+pParen :: Bool -> Doc -> Doc
+pParen False = id
+pParen True  = parens
+
+type PrettyTm tyname name uni fun = (Eq tyname, Pretty tyname
+                                    , Pretty name, Pretty (SomeTypeIn uni)
+                                    , Pretty (Some (ValueOf uni)), Pretty fun)
+type PrettyTy tyname uni = (Eq tyname, Pretty tyname, Pretty (SomeTypeIn uni))
+
+instance Pretty Text.Text where
+  pretty = text . Text.unpack
+
+instance Pretty (PlutusTx.CompiledCode a) where
+  pretty = maybe "Nothing" pretty . PlutusTx.getPir
+
+instance PrettyTm tyname name uni fun => Pretty (Program tyname name uni fun ann) where
+  prettyPrec p (Program _ t) = prettyPrec p t
+
+instance Pretty (SomeTypeIn DefaultUni) where
+  pretty = text . show . Pp.pretty
+
+instance Pretty (Some (ValueOf DefaultUni)) where
+  pretty c = case readMaybe =<< readMaybe s of
+      Just ann -> pretty (ann :: CoverageAnnotation)
+      Nothing  -> text s
+    where s = show (Pp.pretty c)
+
+instance Pretty DefaultFun where
+  pretty = text . show . Pp.pretty
+
+instance Pretty Name where
+  pretty (Name x u)
+    | isDead x  = "_"
+    | otherwise = text . (++ ("{" ++ show (unUnique u) ++ "}")) . show . Pp.pretty $ x
+    where
+      isDead x = show (Pp.pretty x) == "dead"
+
+instance Pretty NamedDeBruijn where
+  pretty (NamedDeBruijn x idx)
+    | isDead x  = "_"
+    | otherwise = text . (++ ("{" ++ show idx ++ "}")) . show . Pp.pretty $ x
+    where
+      isDead x = show (Pp.pretty x) == "dead"
+
+instance Pretty TyName where
+  pretty (TyName x) = pretty x
+
+instance Pretty NamedTyDeBruijn where
+  pretty (NamedTyDeBruijn x) = pretty x
+
+instance Pretty CoverageAnnotation where
+  pretty (CoverLocation loc) = hcat ["\"", pretty loc, "\""]
+  pretty (CoverBool loc b)   = hcat ["\"", pretty loc, if b then "/True" else "/False", "\""]
+
+instance Pretty CovLoc where
+  pretty (CovLoc _ l1 l2 c1 c2)
+    | l1 Prelude.== l2 = text $ concat [show l1, ":", show c1, "-", show c2]
+    | otherwise        = text $ concat [show l1, ":", show c1, "-", show l2, ":", show c2]
+
+instance Pretty (Kind ann) where
+  prettyPrec _ (Type _)           = "*"
+  prettyPrec p (KindArrow _ k k') = pParen (p > 1) $ sep [prettyPrec 2 k, "->" <+> prettyPrec 1 k']
+
+ppTyBind :: Pretty tyname => (tyname, Kind ann) -> Doc
+ppTyBind (x, Type{}) = pretty x
+ppTyBind (x, k)      = parens (pretty x <+> ":" <+> pretty k)
+
+ppAbstr :: Pretty b => Int -> (arg -> Doc) -> Doc -> ([arg], b) -> Doc
+ppAbstr p ppBind binder (binds, body) = pParen (p > 0)  $ (binder <+> (fsep (map ppBind binds) <> ".")) <?> pretty body
+
+instance PrettyTy tyname uni => Pretty (Type tyname uni ann) where
+  prettyPrec p a = case a of
+    TyVar _ x     -> pretty x
+    TyBuiltin _ c -> pretty c
+    TyFun _ a b   -> pParen (p > 1)  $ sep [prettyPrec 2 a, "->" <+> prettyPrec 1 b]
+    TyIFix _ a b  -> pParen (p > 10) $ "Fix" <+> sep [prettyPrec 11 a, prettyPrec 11 b]
+    -- TyForall _ x Type{} (TyVar _ x') | x == x' -> "⊥"
+    TyForall{}    -> ppAbstr p ppTyBind "∀" (view a)
+      where
+        view (TyForall _ x k b) = first ((x, k):) $ view b
+        view a                  = ([], a)
+    TyLam{}     -> ppAbstr p ppTyBind "Λ" (viewLam a)
+      where
+        viewLam (TyLam _ x k b) = first ((x, k):) $ viewLam b
+        viewLam b               = ([], b)
+    TyApp{} -> pParen (p > 10) $ prettyPrec 10 hd <?> fsep (map (prettyPrec 11) args)
+      where
+        (hd, args) = viewApp a []
+        viewApp (TyApp _ a b) args = viewApp a (b : args)
+        viewApp a args             = (a, args)
+
+-- data Binding tyname name uni fun a = TermBind a Strictness (VarDecl tyname name uni fun a) (Term tyname name uni fun a)
+--                            | TypeBind a (TyVarDecl tyname a) (Type tyname uni a)
+--                            | DatatypeBind a (Datatype tyname name uni fun a)
+
+instance PrettyTm tyname name uni fun => Pretty (Binding tyname name uni fun ann) where
+  pretty bind = case bind of
+    TermBind _ s vdec t -> (pretty vdec <+> eq) <?> pretty t
+      where
+        eq | PlutusIR.Strict <- s = "[!]="
+           | otherwise            = "[~]="
+    TypeBind _ tydec a -> (pretty tydec <+> "=") <?> pretty a
+    DatatypeBind _ dt -> pretty dt
+
+-- data Datatype tyname name uni fun a = Datatype a (TyVarDecl tyname a) [TyVarDecl tyname a] name [VarDecl tyname name uni fun a]
+
+instance PrettyTy tyname uni => Pretty (TyDecl tyname uni ann) where
+  prettyPrec p (TyDecl _ x k) = pParen (p > 0) $ pretty x <+> ":" <+> pretty k
+
+instance Pretty tyname => Pretty (TyVarDecl tyname ann) where
+  prettyPrec p (TyVarDecl _ x k) = pParen (p > 0) $ ppTyBind (x, k)
+
+instance (PrettyTy tyname uni, Pretty name) => Pretty (VarDecl tyname name uni fun ann) where
+  prettyPrec p (VarDecl _ x a) = pParen (p > 0) $ pretty x <+> ":" <+> pretty a
+
+instance PrettyTm tyname name uni fun => Pretty (Datatype tyname name uni fun ann) where
+  pretty (Datatype _ tydec pars name cs) =
+    vcat [ "data" <+> pretty tydec <+> fsep (map pretty pars) <+> "/" <+> pretty name <+> "where"
+         , nest 2 $ vcat $ map pretty cs ]
+
+instance PrettyTm tyname name uni fun => Pretty (Term tyname name uni fun ann) where
+  prettyPrec p t = case t of
+    Let _ rec binds body -> pParen (p > 0) $ sep [kw <+> vcat (map pretty $ toList binds), "in" <+> pretty body]
+      where
+        kw | Rec <- rec = "letrec"
+           | otherwise  = "let"
+    Var _ x              -> pretty x
+    TyAbs{}              -> ppAbstr p ppTyBind "Λ" (viewLam t)
+      where
+        viewLam (TyAbs _ x k b) = first ((x, k):) $ viewLam b
+        viewLam b               = ([], b)
+    LamAbs{}             -> ppAbstr p (prettyPrec 1) "λ" (viewLam t)
+      where
+        viewLam (LamAbs _ x a t) = first (VarDecl undefined x a:) $ viewLam t
+        viewLam t                = ([], t)
+    Apply{}              -> ppApp p t
+    TyInst{}             -> ppApp p t
+    Constant _ c         -> pretty c
+    Builtin _ b          -> pretty b
+    Error _ ty           -> pParen (p > 0) $ "error" <+> ":" <+> pretty ty
+    IWrap _ a b t        -> ppApp' p "Wrap" [Left a, Left b, Right t]
+    Unwrap _ t           -> ppApp' p "unwrap" [Right t]
+
+instance Pretty a => Pretty (Set a) where
+  pretty = braces . fsep . punctuate comma . map pretty . Set.toList
+
+instance {-# OVERLAPPABLE #-} Pretty a => Pretty [a] where
+  pretty = brackets . fsep . punctuate comma . map pretty
+
+instance Pretty a => Pretty (SnocList a) where
+  pretty = angles . fsep . punctuate comma . map pretty . toList
+
+instance Pretty TyCtxEntry where
+  pretty (n ::: k)        = ppTyBind (n, k)
+  pretty (TyCtxDat d)     = pretty d
+  pretty (TyCtxRecDat ds) = pretty ds
+
+instance Pretty DDat where
+  pretty (DDat r n k pars cons) = (if r then "recdata" else "data") <+> ppTyBind (n, k) <+> fsep (map pretty pars) <+> "where" <?> (braces . fsep . punctuate comma $ map pretty cons)
+
+instance Pretty DCon where
+  pretty (DCon ds) = pretty ds
+
+ppApp :: PrettyTm tyname name uni fun => Int -> Term tyname name uni fun ann -> Doc
+ppApp p t = uncurry (ppApp' p . prettyPrec 10) (viewApp t)
+
+ppApp' :: PrettyTm tyname name uni fun => Int -> Doc -> [Either (Type tyname uni ann) (Term tyname name uni fun ann)] -> Doc
+ppApp' p hd args = pParen (p > 10) $ hd <?> fsep (map ppArg args)
+  where
+    ppArg (Left a)  = "@" <> prettyPrec 11 a
+    ppArg (Right t) = prettyPrec 11 t
+
+viewApp :: Term tyname name uni fun ann -> (Term tyname name uni fun ann, [Either (Type tyname uni ann) (Term tyname name uni fun ann)])
+viewApp t = go t []
+  where
+    go (Apply _ t s)  args = go t (Right s : args)
+    go (TyInst _ t a) args = go t (Left a : args)
+    go t args              = (t, args)
+
+ppSubst :: Pretty a => Subst a -> Doc
+ppSubst subst = braces $ fsep $ punctuate comma [ pretty d | d <- toList subst ]
+
+angles :: Doc -> Doc
+angles d = hcat ["<", d, ">"]
+
+instance Pretty DTyp where
+  prettyPrec p t = case t of
+    DTVar x []     -> pretty x
+    DTVar x ts     -> pParen (p > 10) $ pretty x <?> fsep (map (prettyPrec 11) ts)
+    DTFun s t      -> pParen (p > 5) $ prettyPrec 6 s <?> ("->" <+> prettyPrec 5 t)
+    DTLam x k t    -> pParen (p > 0) $ "Λ" <+> (ppTyBind (x, k) <> ".") <+> pretty t
+    DTForall x Type{} (DTVar x' [])
+      | x == x'    -> "⊥"
+    DTForall x k t -> pParen (p > 0) $ "∀" <+> (ppTyBind (x, k) <> ".") <+> pretty t
+    DTWk w t       -> pParen (p > 10) $ "Wk" <+> pretty w <+> prettyPrec 11 t
+    DTyBuiltin k   -> pParen (p > 10) $ "Builtin" <+> prettyPrec 11 k
+
+instance Pretty DArg where
+  prettyPrec _ (TyArg t) = "@" <> prettyPrec 11 t
+  prettyPrec p (DArg d)  = prettyPrec p d
+
+instance Pretty Int where
+  pretty = text . show
+
+instance Pretty Index where
+  pretty (Index i) = text . show $ i
+
+instance Pretty Weakening where
+  pretty (Wk w) = pretty w
+
+instance (Pretty a, Pretty b) => Pretty (a, b) where
+  pretty (a, b) = parens $ sep [pretty a <> comma, pretty b]
+
+instance (Pretty a, Pretty b, Pretty c) => Pretty (a, b, c) where
+  pretty (a, b, c) = parens $ sep [pretty a <> comma, pretty b <> comma, pretty c]
+
+instance Pretty Dom where
+  prettyPrec p0 d = locs $ case d of
+    DTop{..}   -> ("T" <> brackets ((pretty ty <> ",") <+> pretty depth))
+    DError{}   -> "error"
+    DTySusp{}  -> pParen (p > 0) $ hsep ["Λ", hcat [fsep args, "."]] <?> prettyPrec 11 body
+      where
+        (args, body) = view d
+        ppBind x Type{} = pretty x
+        ppBind x k      = parens $ pretty x <+> ":" <+> pretty k
+        view (DTySusp x k _ b) = first (ppBind x k:) $ view b
+        view b                 = ([], b)
+    DSusp{..} -> hcat ["~", prettyPrec 11 inner]
+    DTrace{} -> "trace"
+    DLoc{..}   -> pretty location
+    DLam x ty substD substT body _ -> locs $ angles $ sep [ hcat [ppSubst substD, ","], hcat [ppSubst substT, ","]
+                                                          , ("λ" <+> hcat [parens $ pretty x <+> ":" <+> pretty ty, "."]) <?> pretty body ]
+    DConstr{..} -> pParen (p > 10) $ (text ("Con" ++ show constr) <> brackets (pretty dat)) <+> fsep (map (prettyPrec 11) $ toList argsD)
+    DUnion ds    -> pParen (p > 10) $ brains "|" $ map (prettyPrec 10) ds
+    DIf{} -> "DIf"
+    DMatch t _ -> "DMatch" <> brackets (pretty t)
+    DWeaken w t -> pParen (p > 10) $ "Wk" <+> pretty w <+> prettyPrec 11 t
+    where
+      p = if null ls then p0 else 0
+      ls | DWeaken{} <- d = []
+         | DUnion{} <- d  = []
+         | otherwise      = Set.toList $ topLevelLocations d
+      brains s (x : xs) = sep (x : map (s <+>) xs)
+      brains _ []       = error "impossible"
+      locs doc
+        | null ls   = doc
+        | otherwise = pParen (p0 > 10) $ hsep [doc, "@", braces $ fsep $ punctuate comma $ map pretty ls]
+        where
+
+instance Pretty CoverageIndex where
+  pretty covidx = pretty . map fst . Map.toList $ covidx ^. coverageMetadata
+
+deriving via a instance Pretty a => Pretty (NonNegative a)
+
+instance (Pretty k, Pretty v) => Pretty (Map k v) where
+  pretty = pretty . Map.toList
+
+instance Pretty Doc where
+  pretty = id
+
+instance {-# OVERLAPPING #-} Pretty String where
+  pretty = text
+
+instance Pretty Bool where
+  pretty = text . show
+
+instance Pretty a => Pretty (Maybe a) where
+  prettyPrec _ Nothing  = "Nothing"
+  prettyPrec p (Just x) = pParen (p > 10) $ "Just" <+> prettyPrec 11 x
+
+instance Pretty () where
+  pretty () = "()"
+
+instance (Pretty name, Pretty (Some (ValueOf uni)), Pretty fun) => Pretty (UPLC.Program name uni fun ann) where
+  prettyPrec p (UPLC.Program _ _ t) = prettyPrec p t
+
+instance (Pretty name, Pretty (Some (ValueOf uni)), Pretty fun) => Pretty (UPLC.Term name uni fun ann) where
+  prettyPrec p t = case t of
+    UPLC.Var _ x      -> pretty x
+    UPLC.Constant _ c -> pretty c
+    UPLC.Builtin _ b  -> pretty b
+    UPLC.Error _      -> text "error"
+    UPLC.LamAbs{}     -> pParen (p Prelude.> 0) $ ("λ" <+> fsep (map pretty args) <+> "->") <?> pretty body
+      where
+        (args, body) = viewLam t
+        viewLam (UPLC.LamAbs _ x b) = first (x:) $ viewLam b
+        viewLam b                   = ([], b)
+    UPLC.Apply{} -> pParen (p Prelude.> 10) $ prettyPrec 10 hd <?> fsep (map (prettyPrec 11) args)
+      where
+        (hd, args) = viewApp t []
+        viewApp (UPLC.Apply _ a b) args = viewApp a (b : args)
+        viewApp a args                  = (a, args)
+    _ -> hcat (fds ++ [prettyPrec 11 body])
+      where
+        (fds, body) = viewForce t
+        viewForce (UPLC.Force _ t) = first ("!":) $ viewForce t
+        viewForce (UPLC.Delay _ t) = first ("~":)  $ viewForce t
+        viewForce t                = ([], t)
+
+

--- a/plutus-contract/src/Plutus/Contract/Test/Coverage/Analysis/Types.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/Coverage/Analysis/Types.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE NumericUnderscores    #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE ViewPatterns          #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module Plutus.Contract.Test.Coverage.Analysis.Types where
+import Control.Arrow (first)
+import Control.DeepSeq
+import Data.Set (Set)
+import GHC.Generics (Generic)
+import GHC.Stack
+import PlutusCore.DeBruijn hiding (DeBruijn)
+import PlutusTx.Coverage
+
+import Plutus.Contract.Test.Coverage.Analysis.Common
+
+infixl 5 :>
+data SnocList a = Nil | SnocList a :> a
+  deriving (Functor, Foldable, Traversable, Eq, Ord, Show, Generic, NFData)
+
+instance Semigroup (SnocList a) where
+  xs <> Nil       = xs
+  xs <> (ys :> y) = (xs <> ys) :> y
+
+instance Monoid (SnocList a) where
+  mempty  = Nil
+  mappend = (<>)
+
+zipWithSnoc :: (a -> b -> c) -> SnocList a -> SnocList b -> SnocList c
+zipWithSnoc _ Nil _               = Nil
+zipWithSnoc _ _ Nil               = Nil
+zipWithSnoc f (xs :> x) (ys :> y) = zipWithSnoc f xs ys :> f x y
+
+-- *** Domain definitions
+-- data DCon ctx = DCon [DTyp ctx] deriving Show
+data DCon = DCon [DTyp]
+  deriving (Show, Eq, Generic, NFData)
+
+-- data DDat ctx = DDat (isRec : Bool) (x : NamedTyDeBruijn) (k : Kin) (pars : [NamedTyDeBruijn])
+--                      [DCon (ctx :> (if rec then Nil else x ::: k) :> (pars ::: _someKinds)]
+data DDat = DDat Bool NamedTyDeBruijn Kin [NamedTyDeBruijn] [DCon]
+  deriving (Show, Eq, Generic, NFData)
+
+data TyCtxEntry = NamedTyDeBruijn ::: Kin     -- db index always 0 (only used for the name for printing)
+                | TyCtxRecDat (SnocList DDat) -- (Mutually) recursive data types
+                | TyCtxDat DDat               -- Non-recursive data type
+    deriving (Show, Eq, Generic, NFData)
+
+-- Γ :> TyCtxRecDat ds  ==>  ds : Dat (Γ :> TyCtxRecDat ds)
+-- Γ :> TyCtxDat d      ==>  d  : Dat Γ
+type TyCtx = SnocList TyCtxEntry
+
+type Subst a = SnocList a
+
+data Dom = DTop { ty         :: DTyp
+                , depth      :: Int
+                , _locations :: Set CoverageAnnotation }
+
+         | DError
+
+         | DSusp { _locations :: Set CoverageAnnotation
+                 , inner      :: Dom }
+
+         | DTySusp { suspName   :: NamedTyDeBruijn
+                   , kind       :: Kin
+                   , _locations :: Set CoverageAnnotation
+                   , inner      :: Dom }
+
+         | DIf { argTy      :: DTyp
+               , _locations :: Set CoverageAnnotation }
+
+         | DTrace { argTy      :: DTyp
+                  , _locations :: Set CoverageAnnotation }
+
+         | DLoc { location :: CoverageAnnotation }
+
+         | DLam { lamName    :: NamedDeBruijn
+                , argTy      :: DTyp        -- DTyp ctx
+                , substD     :: Subst Dom   -- Subst _ctx (Dom ctx)
+                , substT     :: Subst DTyp  -- Subst _ctx (DTyp ctx)
+                , body       :: Trm         -- Trm (_ctx, x : argTy) -- remember that _ctx is really mixed type and term context - very confusing...
+                , _locations :: Set CoverageAnnotation }
+
+         | DConstr { dat        :: DTyp     -- Target type once fully applied
+                   , constr     :: Int
+                   , argsD      :: SnocList Dom
+                   , _locations :: Set CoverageAnnotation }
+
+         | DMatch { dat        :: DTyp
+                  , _locations :: Set CoverageAnnotation }
+
+         | DUnion [Dom] -- These are never DWeaken
+
+         | DWeaken { wk    :: Weakening
+                   , inner :: Dom }
+  deriving (Show, Generic, NFData)
+
+data DTyp = DTVar NamedTyDeBruijn [DTyp]
+          | DTFun DTyp DTyp
+          | DTLam { dtName :: NamedTyDeBruijn, dtKind :: Kin, dtBody :: DTyp }
+          | DTForall { dtName :: NamedTyDeBruijn, dtKind :: Kin, dtBody :: DTyp }
+          | DTWk { dtWk :: Weakening , dtBody :: DTyp }
+          | DTyBuiltin Kin -- we don't care which
+  deriving (Show, Eq, Generic, NFData)
+
+data DArg = TyArg DTyp | DArg Dom
+  deriving (Show)
+
+-- strictness?
+newtype Weakening = Wk [(Index, Index)] -- increasing in k, (k, n) means weaken by n at index k (cumulative)
+  deriving (Show, Eq, Generic)
+  deriving newtype NFData
+
+wkIndex :: HasCallStack => Weakening -> Index -> Index
+wkIndex (Wk w) i = i + sum [ n | (k, n) <- w, i >= k ]
+
+wkBy :: HasCallStack => Index -> Weakening
+wkBy n | n == 0    = Wk []
+       | otherwise = Wk [(0, n)]
+
+shiftWeakening :: HasCallStack => Weakening -> Weakening
+shiftWeakening (Wk w) = Wk $ map (first succ) w
+
+instance Semigroup Weakening where
+  Wk w <> (Wk w') = Wk $ foldr merge w' (map (unweaken w') w)
+    where
+      unweaken [] (k, i)           = [(k, i)]
+      unweaken ((k', i'):w) (k, i)
+        | k' <= k   = unweaken w (if i' > k then k' else max k' (k - i'), i)
+        | otherwise = [(k, i)]
+
+      merge w1@((k1, n1) : w1') w2@((k2, n2) : w2')
+        | k1 == k2  = (k1, n1 + n2) : merge w1' w2'
+        | k1 < k2   = (k1, n1) : merge w1' w2
+        | otherwise = (k2, n2) : merge w1 w2'
+      merge [] w2 = w2
+      merge w1 [] = w1
+
+instance Monoid Weakening where
+  mempty = Wk []
+  mappend = (<>)
+
+-- Some helper functions
+topLevelLocations :: HasCallStack => Dom -> Set CoverageAnnotation
+topLevelLocations (DUnion ds)   = foldMap topLevelLocations ds
+topLevelLocations (DWeaken _ d) = topLevelLocations d
+topLevelLocations DError        = mempty
+topLevelLocations DLoc{}        = mempty
+topLevelLocations d             = _locations d

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -39,6 +39,7 @@ library
         Plutus.Contracts.Future
         Plutus.Contracts.Game
         Plutus.Contracts.GameStateMachine
+        Plutus.Contracts.GameStateMachine.Coverage
         Plutus.Contracts.Governance
         Plutus.Contracts.MultiSig
         Plutus.Contracts.MultiSigStateMachine

--- a/plutus-use-cases/src/Plutus/Contracts/GameStateMachine.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/GameStateMachine.hs
@@ -26,6 +26,8 @@ module Plutus.Contracts.GameStateMachine(
     contract
     , typedValidator
     , GameParam(..)
+    , GameState(..)
+    , GameInput(..)
     , GuessToken
     , mkValidator
     , mintingPolicy
@@ -34,7 +36,6 @@ module Plutus.Contracts.GameStateMachine(
     , GameStateMachineSchema
     , GameError
     , token
-    , covIdx
     ) where
 
 import Control.Lens (makeClassyPrisms)
@@ -54,8 +55,6 @@ import Plutus.Contract.Secrets (SecretArgument, escape_sha2_256, extractSecret)
 import Plutus.Contract.StateMachine (State (State, stateData, stateValue), Void)
 import Plutus.Contract.StateMachine qualified as SM
 import PlutusTx qualified
-import PlutusTx.Code (getCovIdx)
-import PlutusTx.Coverage (CoverageIndex)
 import PlutusTx.Prelude (Bool (False, True), BuiltinByteString, Eq, Maybe (Just, Nothing), sha2_256, toBuiltin,
                          traceIfFalse, ($), (&&), (-), (.), (<$>), (<>), (==), (>>))
 import Schema (ToSchema)
@@ -228,11 +227,6 @@ typedValidator = Scripts.mkTypedValidatorParam @GameStateMachine
     $$(PlutusTx.compile [|| wrap ||])
     where
         wrap = Scripts.wrapValidator
-
--- TODO: Ideas welcome for how to make this interface suck less.
--- Doing it this way actually generates coverage locations that we don't care about(!)
-covIdx :: GameParam -> CoverageIndex
-covIdx gp = getCovIdx ($$(PlutusTx.compile [|| mkValidator ||]) `PlutusTx.applyCode` PlutusTx.liftCode gp)
 
 mintingPolicy :: GameParam -> Scripts.MintingPolicy
 mintingPolicy gp = Scripts.forwardingMintingPolicy $ typedValidator gp

--- a/plutus-use-cases/src/Plutus/Contracts/GameStateMachine/Coverage.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/GameStateMachine/Coverage.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:coverage-all #-}
+module Plutus.Contracts.GameStateMachine.Coverage(
+    covIndex
+  ) where
+
+import Ledger
+import Plutus.Contract.Test.Coverage.Analysis
+import Plutus.Contracts.GameStateMachine
+import PlutusTx qualified
+import PlutusTx.Code
+import PlutusTx.Coverage
+import PlutusTx.Prelude (check)
+
+cc :: CompiledCode (GameParam -> GameState -> GameInput -> ScriptContext -> ())
+cc = $$(PlutusTx.compile [|| \a b c d -> check (mkValidator a b c d) ||])
+
+covIndex :: CoverageIndex
+covIndex = computeRefinedCoverageIndex cc
+

--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/Pool.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/Pool.hs
@@ -101,7 +101,6 @@ lpTicker LiquidityPool{..}  = TokenName hash
       ((x1, y1), (x2, y2))
         | cA < cB   = ((csA, tokA), (csB, tokB))
         | otherwise = ((csB, tokB), (csA, tokA))
-
       h1   = sha2_256 $ unTokenName y1
       h2   = sha2_256 $ unTokenName y2
       h3   = sha2_256 $ unCurrencySymbol x1

--- a/plutus-use-cases/test/Spec/Auction.hs
+++ b/plutus-use-cases/test/Spec/Auction.hs
@@ -331,7 +331,7 @@ check_propAuctionWithCoverage = do
     withMaxSuccess 1000 $
       propRunActionsWithOptions @AuctionModel
         (set minLogLevel Critical options) covopts (const (pure True))
-  writeCoverageReport "Auction" covIdx cr
+  writeCoverageReport "Auction" cr
 
 tests :: TestTree
 tests =

--- a/plutus-use-cases/test/Spec/GameStateMachine.hs
+++ b/plutus-use-cases/test/Spec/GameStateMachine.hs
@@ -28,6 +28,7 @@ module Spec.GameStateMachine
   , prop_GameCrashTolerance
   , certification
   , covIndex
+  , gameParam
   ) where
 
 import Control.Exception hiding (handle)
@@ -36,6 +37,7 @@ import Control.Monad
 import Control.Monad.Freer.Extras.Log (LogLevel (..))
 import Data.Data
 import Data.Maybe
+import Prettyprinter
 import Test.QuickCheck as QC hiding (checkCoverage, (.&&.))
 import Test.Tasty hiding (after)
 import Test.Tasty.HUnit qualified as HUnit
@@ -53,7 +55,8 @@ import Plutus.Contract.Test.Certification
 import Plutus.Contract.Test.ContractModel
 import Plutus.Contract.Test.ContractModel.CrashTolerance
 import Plutus.Contract.Test.Coverage
-import Plutus.Contracts.GameStateMachine as G
+import Plutus.Contracts.GameStateMachine as G hiding (Guess)
+import Plutus.Contracts.GameStateMachine.Coverage
 import Plutus.Trace.Emulator as Trace
 import PlutusTx qualified
 import PlutusTx.Coverage
@@ -218,10 +221,7 @@ check_prop_Game_with_coverage = do
     propRunActionsWithOptions @GameModel defaultCheckOptionsContractModel
                                          covopts
                                          (const (pure True))
-  writeCoverageReport "GameStateMachine" covIndex cr
-
-covIndex :: CoverageIndex
-covIndex = covIdx gameParam
+  writeCoverageReport "GameStateMachine" cr
 
 propGame' :: LogLevel -> Actions GameModel -> Property
 propGame' l = propRunActionsWithOptions
@@ -360,7 +360,7 @@ runTestsWithCoverage = do
   defaultMain (coverageTests ref)
     `catch` \(e :: SomeException) -> do
                 report <- readCoverageRef ref
-                putStrLn . show $ pprCoverageReport (covIdx gameParam) report
+                putStrLn . show $ pretty (CoverageReport covIndex report)
                 throwIO e
   where
     coverageTests ref = testGroup "game state machine tests"
@@ -465,7 +465,7 @@ certification :: Certification GameModel
 certification = defaultCertification {
     certNoLockedFunds      = Just noLockProof,
     certUnitTests          = Just unitTest,
-    certCoverageIndex      = covIdx gameParam,
+    certCoverageIndex      = covIndex,
     certCrashTolerance     = Just Instance
   }
   where

--- a/plutus-use-cases/test/Spec/Tutorial/Escrow.hs
+++ b/plutus-use-cases/test/Spec/Tutorial/Escrow.hs
@@ -241,4 +241,4 @@ check_propEscrowWithCoverage = do
   cr <- quickCheckWithCoverage stdArgs (set coverageIndex covIdx $ defaultCoverageOptions) $ \covopts ->
     withMaxSuccess 1000 $ propRunActionsWithOptions @EscrowModel defaultCheckOptionsContractModel
                                                     covopts (const (pure True))
-  writeCoverageReport "Escrow" covIdx cr
+  writeCoverageReport "Escrow" cr

--- a/plutus-use-cases/test/Spec/Tutorial/Escrow5.hs
+++ b/plutus-use-cases/test/Spec/Tutorial/Escrow5.hs
@@ -230,4 +230,4 @@ check_propEscrowWithCoverage :: IO ()
 check_propEscrowWithCoverage = do
   cr <- quickCheckWithCoverage stdArgs (set coverageIndex covIdx $ defaultCoverageOptions) $ \covopts ->
     withMaxSuccess 1000 $ propRunActionsWithOptions @EscrowModel defaultCheckOptionsContractModel covopts (const (pure True))
-  writeCoverageReport "Escrow" covIdx cr
+  writeCoverageReport "Escrow" cr

--- a/plutus-use-cases/test/Spec/Tutorial/Escrow6.hs
+++ b/plutus-use-cases/test/Spec/Tutorial/Escrow6.hs
@@ -248,4 +248,4 @@ check_propEscrowWithCoverage :: IO ()
 check_propEscrowWithCoverage = do
   cr <- quickCheckWithCoverage stdArgs (set coverageIndex covIdx $ defaultCoverageOptions) $ \covopts ->
     withMaxSuccess 1000 $ propRunActionsWithOptions @EscrowModel defaultCheckOptionsContractModel covopts (const (pure True))
-  writeCoverageReport "Escrow" covIdx cr
+  writeCoverageReport "Escrow" cr

--- a/plutus-use-cases/test/Spec/Uniswap.hs
+++ b/plutus-use-cases/test/Spec/Uniswap.hs
@@ -38,23 +38,21 @@ import Ledger.Value qualified as Value
 import Data.Data
 import Data.Foldable
 import Data.List
-import Data.Maybe
-import Data.Text qualified as Text
-
 import Data.Map (Map)
 import Data.Map qualified as Map
+import Data.Maybe
+import Data.Monoid (Last (..))
+import Data.Semigroup qualified as Semigroup
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.String
-
+import Data.Text qualified as Text
 import Data.Void
 
+import Prettyprinter
 import Test.QuickCheck hiding ((.&&.))
 import Test.Tasty
 import Test.Tasty.QuickCheck (testProperty)
-
-import Data.Monoid (Last (..))
-import Data.Semigroup qualified as Semigroup
 
 import Ledger.Constraints
 
@@ -162,6 +160,7 @@ tokenNames :: [String]
 tokenNames = ["A", "B", "C", "D"]
 
 instance ContractModel UniswapModel where
+  -- TODO: add negative tests!
   data Action UniswapModel = SetupTokens
                            -- ^ Give some tokens to wallets `w1..w4`
                            | Start
@@ -254,6 +253,7 @@ instance ContractModel UniswapModel where
         (tA, tB) <- elements [(t1, t2), (t2, t1)]
         return . bad $ RemoveLiquidity w tA tB a
 
+      -- TODO: make an evil version of this endpoint
       close = do
         w <- elements $ wallets \\ [w1]
         PoolIndex t1 t2 <- elements $ s ^. contractState . pools . to Map.keys
@@ -478,7 +478,7 @@ instance ContractModel UniswapModel where
 
   perform h tokenSem s act = case act of
     SetupTokens -> do
-      delay 20
+      delay 40
       Trace.observableState (h SetupKey) >>= \case
         Just (Semigroup.Last cur) -> sequence_ [ registerToken tn (Value.assetClass (Currency.currencySymbol cur) $ fromString tn) | tn <- ["A", "B", "C", "D"]]
         _                         -> Trace.throwError $ GenericError "failed to create currency"
@@ -598,12 +598,17 @@ prop_CheckNoLockedFundsProofFast :: Property
 prop_CheckNoLockedFundsProofFast = checkNoLockedFundsProofFast noLockProof
 
 check_propUniswapWithCoverage :: IO ()
-check_propUniswapWithCoverage = do
-  cr <- quickCheckWithCoverage stdArgs (set endpointCoverageReq epReqs $ set coverageIndex covIdx $ defaultCoverageOptions) $ \covopts ->
-    withMaxSuccess 1000 $ propRunActionsWithOptions @UniswapModel defaultCheckOptionsContractModel covopts (const (pure True))
-  writeCoverageReport "Uniswap" covIdx cr
+check_propUniswapWithCoverage = void $ do
+  cr <- quickCheckWithCoverage (stdArgs { maxSuccess = 1000 })
+                                 (set endpointCoverageReq epReqs $ set coverageIndex covIdx $ defaultCoverageOptions)
+                                 $ \covopts -> propRunActionsWithOptions @UniswapModel
+                                              defaultCheckOptionsContractModel
+                                              covopts
+                                              (const (pure True))
+  writeCoverageReport "Uniswap" cr
   where
     epReqs t ep
+      | True = 0
       | t == Trace.walletInstanceTag w1 = 0
       | ep == "create"                  = 20
       | ep == "swap"                    = 15
@@ -634,8 +639,8 @@ runTestsWithCoverage = do
   ref <- newCoverageRef
   defaultMain (coverageTests ref)
     `catch` \(e :: SomeException) -> do
-                report <- readCoverageRef ref
-                putStrLn . show $ pprCoverageReport covIdx report
+                covdata <- readCoverageRef ref
+                putStrLn . show $ pretty (CoverageReport covIdx covdata)
                 throwIO e
   where
     coverageTests ref = testGroup "game state machine tests"

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -4,7 +4,7 @@ Fee:        -
 Mint:       Ada:      Lovelace:  1000000000
 Signatures  -
 Inputs:
-  
+
 
 
 Outputs:
@@ -837,6 +837,15 @@ Inputs:
     Tx:     ef0ca0fb043642529818003be5a6cac88aac499e4f8f1cbc3bdb35db2b7f6958
     Output #20
 
+
+  ---- Input 1 ----
+  Destination:  Script: 102c7955ae5b2204e8c6f72824b4175a738277ddba4467ab4d2e467a
+  Value:
+    Ada:      Lovelace:  8000000
+  Source:
+    Tx:     7bc71cf23fb7a99c2daf65ce1d46883eb611c34bad9ade4e30628a388b42eed8
+    Output #2
+    Script: 59d6880100003323232332232323232323232323...
 
   ---- Input 2 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)


### PR DESCRIPTION
This PR introduces a tool that finds program locations in validators whose exectution always lead to validator failure. Separating out such locations greatly improves the readability of coverage reports.

This PR does not include the extensive test-suite comprised of QuickCheck tests that we've used to validate the analysis (c.f. branch `Coverage-static-analysis` on the Quviq fork of this repo) as we are in the process of moving the generators to the plutus-core repo.

The tests will come in a separate PR later.

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
