### PR TITLE
Reintegrate the chain-index queries for querying txs by id and spent tx outputs from reference

### DIFF
--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Api.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Api.hs
@@ -25,9 +25,10 @@ import Data.OpenApi qualified as OpenApi
 import Data.Proxy (Proxy (..))
 import GHC.Generics (Generic)
 import Ledger (AssetClass, Datum, DatumHash, MintingPolicy, MintingPolicyHash, Redeemer, RedeemerHash, StakeValidator,
-               StakeValidatorHash, Validator, ValidatorHash)
+               StakeValidatorHash, TxId, Validator, ValidatorHash)
 import Ledger.Credential (Credential)
 import Ledger.Tx (ChainIndexTxOut, TxOutRef)
+import Plutus.ChainIndex.Tx (ChainIndexTx)
 import Plutus.ChainIndex.Types (Diagnostics, Tip)
 import Servant qualified
 import Servant.API (Description, Get, JSON, NoContent, Post, Put, ReqBody, (:<|>), (:>))
@@ -145,10 +146,13 @@ data TxosResponse = TxosResponse
 type API
     = "healthcheck" :> Description "Is the server alive?" :> Get '[JSON] NoContent
     :<|> "from-hash" :> FromHashAPI
-    :<|> "unspent-tx-out" :> Description "Get an unspent transaction output from its reference." :> ReqBody '[JSON] TxOutRef :> Post '[JSON] ChainIndexTxOut
+    :<|> "tx-out" :> Description "Get a transaction output from its reference." :> ReqBody '[JSON] TxOutRef :> Post '[JSON] ChainIndexTxOut
+    :<|> "unspent-tx-out" :> Description "Get a unspent transaction output from its reference." :> ReqBody '[JSON] TxOutRef :> Post '[JSON] ChainIndexTxOut
+    :<|> "tx" :> Description "Get a transaction from its id." :> ReqBody '[JSON] TxId :> Post '[JSON] ChainIndexTx
     :<|> "is-utxo" :> Description "Check if the reference is an UTxO." :> ReqBody '[JSON] TxOutRef :> Post '[JSON] IsUtxoResponse
     :<|> "utxo-at-address" :> Description "Get all UTxOs at an address." :> ReqBody '[JSON] UtxoAtAddressRequest :> Post '[JSON] UtxosResponse
     :<|> "utxo-with-currency" :> Description "Get all UTxOs with a currency." :> ReqBody '[JSON] UtxoWithCurrencyRequest :> Post '[JSON] UtxosResponse
+    :<|> "txs" :> Description "Get transactions from a list of their ids." :> ReqBody '[JSON] [TxId] :> Post '[JSON] [ChainIndexTx]
     :<|> "txo-at-address" :> Description "Get TxOs at an address." :> ReqBody '[JSON] TxoAtAddressRequest :> Post '[JSON] TxosResponse
     :<|> "tip" :> Description "Get the current synced tip." :> Get '[JSON] Tip
     :<|> "collect-garbage" :> Description "Collect chain index garbage to free up space." :> Put '[JSON] NoContent

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/DbSchema.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/DbSchema.hs
@@ -77,6 +77,17 @@ instance Table RedeemerRowT where
     data PrimaryKey RedeemerRowT f = RedeemerRowId (Columnar f ByteString) deriving (Generic, Beamable)
     primaryKey = RedeemerRowId . _redeemerRowHash
 
+data TxRowT f = TxRow
+    { _txRowTxId :: Columnar f ByteString
+    , _txRowTx   :: Columnar f ByteString
+    } deriving (Generic, Beamable)
+
+type TxRow = TxRowT Identity
+
+instance Table TxRowT where
+    data PrimaryKey TxRowT f = TxRowId (Columnar f ByteString) deriving (Generic, Beamable)
+    primaryKey = TxRowId . _txRowTxId
+
 data AddressRowT f = AddressRow
     { _addressRowCred   :: Columnar f ByteString
     , _addressRowOutRef :: Columnar f ByteString
@@ -164,6 +175,7 @@ data Db f = Db
     { datumRows          :: f (TableEntity DatumRowT)
     , scriptRows         :: f (TableEntity ScriptRowT)
     , redeemerRows       :: f (TableEntity RedeemerRowT)
+    , txRows             :: f (TableEntity TxRowT)
     , utxoOutRefRows     :: f (TableEntity UtxoRowT)
     , addressRows        :: f (TableEntity AddressRowT)
     , assetClassRows     :: f (TableEntity AssetClassRowT)
@@ -176,6 +188,7 @@ type AllTables (c :: * -> Constraint) f =
     ( c (f (TableEntity DatumRowT))
     , c (f (TableEntity ScriptRowT))
     , c (f (TableEntity RedeemerRowT))
+    , c (f (TableEntity TxRowT))
     , c (f (TableEntity UtxoRowT))
     , c (f (TableEntity AddressRowT))
     , c (f (TableEntity AssetClassRowT))
@@ -195,6 +208,7 @@ checkedSqliteDb = defaultMigratableDbSettings
     { datumRows   = renameCheckedEntity (const "datums")
     , scriptRows  = renameCheckedEntity (const "scripts")
     , redeemerRows = renameCheckedEntity (const "redeemers")
+    , txRows = renameCheckedEntity (const "txs")
     , utxoOutRefRows = renameCheckedEntity (const "utxo_out_refs")
     , addressRows = renameCheckedEntity (const "addresses")
     , assetClassRows = renameCheckedEntity (const "asset_classes")
@@ -278,6 +292,11 @@ instance HasDbType (RedeemerHash, Redeemer) where
     type DbType (RedeemerHash, Redeemer) = RedeemerRow
     toDbValue (hash, redeemer) = RedeemerRow (toDbValue hash) (toDbValue redeemer)
     fromDbValue (RedeemerRow hash redeemer) = (fromDbValue hash, fromDbValue redeemer)
+
+instance HasDbType (TxId, ChainIndexTx) where
+    type DbType (TxId, ChainIndexTx) = TxRow
+    toDbValue (txId, tx) = TxRow (toDbValue txId) (toDbValue tx)
+    fromDbValue (TxRow txId tx) = (fromDbValue txId, fromDbValue tx)
 
 instance HasDbType (Credential, TxOutRef) where
     type DbType (Credential, TxOutRef) = AddressRow

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Effects.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Effects.hs
@@ -11,11 +11,14 @@ module Plutus.ChainIndex.Effects(
     , mintingPolicyFromHash
     , stakeValidatorFromHash
     , redeemerFromHash
+    , txOutFromRef
     , unspentTxOutFromRef
+    , txFromTxId
     , utxoSetMembership
     , utxoSetAtAddress
     , utxoSetWithCurrency
     , txoSetAtAddress
+    , txsFromTxIds
     , getTip
     -- * Control effect
     , ChainIndexControlEffect(..)
@@ -29,10 +32,11 @@ module Plutus.ChainIndex.Effects(
 import Control.Monad.Freer.Extras.Pagination (PageQuery)
 import Control.Monad.Freer.TH (makeEffect)
 import Ledger (AssetClass, Datum, DatumHash, MintingPolicy, MintingPolicyHash, Redeemer, RedeemerHash, StakeValidator,
-               StakeValidatorHash, Validator, ValidatorHash)
+               StakeValidatorHash, TxId, Validator, ValidatorHash)
 import Ledger.Credential (Credential)
 import Ledger.Tx (ChainIndexTxOut, TxOutRef)
 import Plutus.ChainIndex.Api (IsUtxoResponse, TxosResponse, UtxosResponse)
+import Plutus.ChainIndex.Tx (ChainIndexTx)
 import Plutus.ChainIndex.Types (ChainSyncBlock, Diagnostics, Point, Tip)
 
 data ChainIndexQueryEffect r where
@@ -55,6 +59,12 @@ data ChainIndexQueryEffect r where
     -- | Get the TxOut from a TxOutRef (if available)
     UnspentTxOutFromRef :: TxOutRef -> ChainIndexQueryEffect (Maybe ChainIndexTxOut)
 
+    -- | Get the TxOut from a TxOutRef (if available)
+    TxOutFromRef :: TxOutRef -> ChainIndexQueryEffect (Maybe ChainIndexTxOut)
+
+    -- | Get the transaction for a tx ID
+    TxFromTxId :: TxId -> ChainIndexQueryEffect (Maybe ChainIndexTx)
+
     -- | Whether a tx output is part of the UTXO set
     UtxoSetMembership :: TxOutRef -> ChainIndexQueryEffect IsUtxoResponse
 
@@ -66,6 +76,9 @@ data ChainIndexQueryEffect r where
     -- Note that requesting unspent outputs containing Ada should not return
     -- anything, as this request will always return all unspent outputs.
     UtxoSetWithCurrency :: PageQuery TxOutRef -> AssetClass -> ChainIndexQueryEffect UtxosResponse
+
+    -- | Get the transactions for a list of tx IDs.
+    TxsFromTxIds :: [TxId] -> ChainIndexQueryEffect [ChainIndexTx]
 
     -- | Outputs located at addresses with the given credential.
     TxoSetAtAddress :: PageQuery TxOutRef -> Credential -> ChainIndexQueryEffect TxosResponse

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Emulator/DiskState.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Emulator/DiskState.hs
@@ -146,9 +146,11 @@ fromTx tx =
 diagnostics :: DiskState -> Diagnostics
 diagnostics DiskState{_DataMap, _ScriptMap, _TxMap, _RedeemerMap, _AddressMap, _AssetClassMap} =
     Diagnostics
-        { numScripts = toInteger $ Map.size _ScriptMap
+        { numTransactions = toInteger $ Map.size _TxMap
+        , numScripts = toInteger $ Map.size _ScriptMap
         , numAddresses = toInteger $ Map.size $ _unCredentialMap _AddressMap
         , numAssetClasses = toInteger $ Map.size $ _unAssetClassMap _AssetClassMap
+        , someTransactions = take 10 $ fmap fst $ Map.toList _TxMap
         -- These 2 are filled in Handlers.hs
         , numUnmatchedInputs = 0
         , numUnspentOutputs = 0

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Server.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Server.hs
@@ -61,10 +61,13 @@ serveChainIndex ::
 serveChainIndex =
     pure NoContent
     :<|> serveFromHashApi
+    :<|> (E.txOutFromRef >=> handleMaybe)
     :<|> (E.unspentTxOutFromRef >=> handleMaybe)
+    :<|> (E.txFromTxId >=> handleMaybe)
     :<|> E.utxoSetMembership
     :<|> (\(UtxoAtAddressRequest pq c) -> E.utxoSetAtAddress (fromMaybe def pq) c)
     :<|> (\(UtxoWithCurrencyRequest pq c) -> E.utxoSetWithCurrency (fromMaybe def pq) c)
+    :<|> E.txsFromTxIds
     :<|> (\(TxoAtAddressRequest pq c) -> E.txoSetAtAddress (fromMaybe def pq) c)
     :<|> E.getTip
     :<|> E.collectGarbage *> pure NoContent

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Types.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Types.hs
@@ -264,11 +264,13 @@ liftTxOutStatus = void
 
 data Diagnostics =
     Diagnostics
-        { numScripts         :: Integer
+        { numTransactions    :: Integer
+        , numScripts         :: Integer
         , numAddresses       :: Integer
         , numAssetClasses    :: Integer
         , numUnspentOutputs  :: Int
         , numUnmatchedInputs :: Int
+        , someTransactions   :: [TxId]
         }
         deriving stock (Eq, Ord, Show, Generic)
         deriving anyclass (ToJSON, FromJSON, OpenApi.ToSchema)

--- a/plutus-chain-index-core/test/Plutus/ChainIndex/Emulator/HandlersSpec.hs
+++ b/plutus-chain-index-core/test/Plutus/ChainIndex/Emulator/HandlersSpec.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE MonoLocalBinds    #-}
-{-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE TypeApplications  #-}
@@ -12,7 +11,7 @@ import Control.Lens
 import Control.Monad (forM)
 import Control.Monad.Freer (Eff, interpret, reinterpret, runM)
 import Control.Monad.Freer.Error (Error, runError)
-import Control.Monad.Freer.Extras (LogMessage, LogMsg (..), handleLogWriter)
+import Control.Monad.Freer.Extras (LogMessage, LogMsg, handleLogWriter)
 import Control.Monad.Freer.State (State, runState)
 import Control.Monad.Freer.Writer (runWriter)
 import Control.Monad.IO.Class (liftIO)
@@ -22,14 +21,14 @@ import Data.Sequence (Seq)
 import Data.Set qualified as S
 import Generators qualified as Gen
 import Ledger (outValue)
-import Plutus.ChainIndex (ChainIndexLog, Page (pageItems), PageQuery (PageQuery), appendBlocks, unspentTxOutFromRef,
-                          utxoSetWithCurrency)
-import Plutus.ChainIndex.Api (UtxosResponse (UtxosResponse))
+import Plutus.ChainIndex (ChainIndexLog, ChainSyncBlock (Block), Page (pageItems), PageQuery (PageQuery),
+                          TxProcessOption (TxProcessOption, tpoStoreTx), appendBlocks, citxTxId, txFromTxId,
+                          unspentTxOutFromRef, utxoSetMembership, utxoSetWithCurrency)
+import Plutus.ChainIndex.Api (UtxosResponse (UtxosResponse), isUtxo)
 import Plutus.ChainIndex.ChainIndexError (ChainIndexError)
 import Plutus.ChainIndex.Effects (ChainIndexControlEffect, ChainIndexQueryEffect)
 import Plutus.ChainIndex.Emulator.Handlers (ChainIndexEmulatorState, handleControl, handleQuery)
 import Plutus.ChainIndex.Tx (_ValidTx, citxOutputs)
-import Plutus.ChainIndex.Types (ChainSyncBlock (..))
 import Plutus.V1.Ledger.Value (AssetClass (AssetClass), flattenValue)
 
 import Hedgehog (Property, assert, forAll, property, (===))
@@ -40,7 +39,10 @@ import Util (utxoSetFromBlockAddrs)
 tests :: TestTree
 tests = do
   testGroup "chain index emulator handlers"
-    [ testGroup "utxoSetAtAddress"
+    [ testGroup "txFromTxId"
+      [ testProperty "get tx from tx id" txFromTxIdSpec
+      ]
+    , testGroup "utxoSetAtAddress"
       [ testProperty "each txOutRef should be unspent" eachTxOutRefAtAddressShouldBeUnspentSpec
       ]
     , testGroup "unspentTxOutFromRef"
@@ -50,7 +52,27 @@ tests = do
       [ testProperty "each txOutRef should be unspent" eachTxOutRefWithCurrencyShouldBeUnspentSpec
       , testProperty "should restrict to non-ADA currencies" cantRequestForTxOutRefsWithAdaSpec
       ]
+    , testGroup "BlockProcessOption"
+      [ testProperty "do not store txs" doNotStoreTxs
+      ]
+
     ]
+
+-- | Tests we can correctly query a tx in the database using a tx id. We also
+-- test with an non-existant tx id.
+txFromTxIdSpec :: Property
+txFromTxIdSpec = property $ do
+  (tip, block@(fstTx:_)) <- forAll $ Gen.evalTxGenState Gen.genNonEmptyBlock
+  unknownTxId <- forAll Gen.genRandomTxId
+  txs <- liftIO $ runEmulatedChainIndex mempty $ do
+    appendBlocks [Block tip (map (, def) block)]
+    tx <- txFromTxId (view citxTxId fstTx)
+    tx' <- txFromTxId unknownTxId
+    pure (tx, tx')
+
+  case txs of
+    Right (Just tx, Nothing) -> fstTx === tx
+    _                        -> Hedgehog.assert False
 
 -- | After generating and appending a block in the chain index, verify that
 -- querying the chain index with each of the addresses in the block returns
@@ -61,7 +83,7 @@ eachTxOutRefAtAddressShouldBeUnspentSpec = property $ do
 
   result <- liftIO $ runEmulatedChainIndex mempty $ do
     -- Append the generated block in the chain index
-    appendBlocks [(Block tip (map (, def) block))]
+    appendBlocks [Block tip (map (, def) block)]
     utxoSetFromBlockAddrs block
 
   case result of
@@ -77,13 +99,13 @@ eachTxOutRefAtAddressShouldHaveTxOutSpec = property $ do
 
   result <- liftIO $ runEmulatedChainIndex mempty $ do
     -- Append the generated block in the chain index
-    appendBlocks [(Block tip (map (, def) block))]
+    appendBlocks [Block tip (map (, def) block)]
     utxos <- utxoSetFromBlockAddrs block
     traverse unspentTxOutFromRef (concat utxos)
 
   case result of
     Left _        -> Hedgehog.assert False
-    Right utxouts -> Hedgehog.assert $ and $ map isJust utxouts
+    Right utxouts -> Hedgehog.assert $ all isJust utxouts
 
 -- | After generating and appending a block in the chain index, verify that
 -- querying the chain index with each of the asset classes in the block returns
@@ -99,7 +121,7 @@ eachTxOutRefWithCurrencyShouldBeUnspentSpec = property $ do
 
   result <- liftIO $ runEmulatedChainIndex mempty $ do
     -- Append the generated block in the chain index
-    appendBlocks [(Block tip (map (, def) block))]
+    appendBlocks [Block tip (map (, def) block)]
 
     forM assetClasses $ \ac -> do
       let pq = PageQuery 200 Nothing
@@ -119,7 +141,7 @@ cantRequestForTxOutRefsWithAdaSpec = property $ do
 
   result <- liftIO $ runEmulatedChainIndex mempty $ do
     -- Append the generated block in the chain index
-    appendBlocks [(Block tip (map (, def) block))]
+    appendBlocks [Block tip (map (, def) block)]
 
     let pq = PageQuery 200 Nothing
     UtxosResponse _ utxoRefs <- utxoSetWithCurrency pq (AssetClass ("", ""))
@@ -128,6 +150,22 @@ cantRequestForTxOutRefsWithAdaSpec = property $ do
   case result of
     Left _         -> Hedgehog.assert False
     Right utxoRefs -> Hedgehog.assert $ null utxoRefs
+
+-- | Do not store txs through BlockProcessOption.
+-- The UTxO set must still be stored.
+-- But cannot be fetched through addresses as addresses are not stored.
+doNotStoreTxs :: Property
+doNotStoreTxs = property $ do
+  ((tip, block), state) <- forAll $ Gen.runTxGenState Gen.genNonEmptyBlock
+  result <- liftIO $ runEmulatedChainIndex mempty $ do
+    appendBlocks [Block tip (map (, TxProcessOption{tpoStoreTx=False}) block)]
+    tx <- txFromTxId (view citxTxId (head block))
+    utxosFromAddr <- utxoSetFromBlockAddrs block
+    utxosStored <- traverse utxoSetMembership (S.toList (view Gen.txgsUtxoSet state))
+    pure (tx, concat utxosFromAddr, utxosStored)
+  case result of
+    Right (Nothing, [], utxosStored) -> Hedgehog.assert $ and (isUtxo <$> utxosStored)
+    _                                -> Hedgehog.assert False
 
 -- | Run an emulated chain index effect against a starting state
 runEmulatedChainIndex

--- a/plutus-contract/src/Plutus/Contract.hs
+++ b/plutus-contract/src/Plutus/Contract.hs
@@ -53,7 +53,9 @@ module Plutus.Contract(
     , Request.validatorFromHash
     , Request.mintingPolicyFromHash
     , Request.stakeValidatorFromHash
+    , Request.txOutFromRef
     , Request.unspentTxOutFromRef
+    , Request.txFromTxId
     , Request.utxoRefMembership
     , Request.utxoRefsAt
     , Request.utxoRefsWithCurrency

--- a/plutus-contract/src/Plutus/Contract/Effects.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects.hs
@@ -29,10 +29,13 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     _ValidatorFromHash,
     _MintingPolicyFromHash,
     _RedeemerFromHash,
+    _TxOutFromRef,
+    _TxFromTxId,
     _UnspentTxOutFromRef,
     _UtxoSetMembership,
     _UtxoSetAtAddress,
     _UtxoSetWithCurrency,
+    _TxsFromTxIds,
     _TxoSetAtAddress,
     _GetTip,
     -- * Plutus application backend response effect types
@@ -59,6 +62,7 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     _ValidatorHashResponse,
     _MintingPolicyHashResponse,
     _RedeemerHashResponse,
+    _TxOutRefResponse,
     _UnspentTxOutResponse,
     _TxIdResponse,
     _UtxoSetMembershipResponse,
@@ -211,11 +215,14 @@ chainIndexMatches q r = case (q, r) of
     (MintingPolicyFromHash{}, MintingPolicyHashResponse{})   -> True
     (StakeValidatorFromHash{}, StakeValidatorHashResponse{}) -> True
     (RedeemerFromHash{}, RedeemerHashResponse{})             -> True
+    (TxOutFromRef{}, TxOutRefResponse{})                     -> True
+    (TxFromTxId{}, TxIdResponse{})                           -> True
     (UnspentTxOutFromRef{}, UnspentTxOutResponse{})          -> True
     (UtxoSetMembership{}, UtxoSetMembershipResponse{})       -> True
     (UtxoSetAtAddress{}, UtxoSetAtResponse{})                -> True
     (UtxoSetWithCurrency{}, UtxoSetWithCurrencyResponse{})   -> True
     (TxoSetAtAddress{}, TxoSetAtResponse{})                  -> True
+    (TxsFromTxIds{}, TxIdsResponse{})                        -> True
     (GetTip{}, GetTipResponse{})                             -> True
     _                                                        -> False
 
@@ -228,10 +235,13 @@ data ChainIndexQuery =
   | MintingPolicyFromHash MintingPolicyHash
   | StakeValidatorFromHash StakeValidatorHash
   | RedeemerFromHash RedeemerHash
+  | TxOutFromRef TxOutRef
   | UnspentTxOutFromRef TxOutRef
+  | TxFromTxId TxId
   | UtxoSetMembership TxOutRef
   | UtxoSetAtAddress (PageQuery TxOutRef) Credential
   | UtxoSetWithCurrency (PageQuery TxOutRef) AssetClass
+  | TxsFromTxIds [TxId]
   | TxoSetAtAddress (PageQuery TxOutRef) Credential
   | GetTip
     deriving stock (Eq, Show, Generic)
@@ -244,10 +254,13 @@ instance Pretty ChainIndexQuery where
         MintingPolicyFromHash h    -> "requesting minting policy from hash" <+> pretty h
         StakeValidatorFromHash h   -> "requesting stake validator from hash" <+> pretty h
         RedeemerFromHash h         -> "requesting redeemer from hash" <+> pretty h
+        TxOutFromRef r             -> "requesting utxo from utxo reference" <+> pretty r
         UnspentTxOutFromRef r      -> "requesting utxo from utxo reference" <+> pretty r
+        TxFromTxId i               -> "requesting chain index tx from id" <+> pretty i
         UtxoSetMembership txOutRef -> "whether tx output is part of the utxo set" <+> pretty txOutRef
         UtxoSetAtAddress _ c       -> "requesting utxos located at addresses with the credential" <+> pretty c
         UtxoSetWithCurrency _ ac   -> "requesting utxos containing the asset class" <+> pretty ac
+        TxsFromTxIds i             -> "requesting chain index txs from ids" <+> pretty i
         TxoSetAtAddress _ c        -> "requesting txos located at addresses with the credential" <+> pretty c
         GetTip                     -> "requesting the tip of the chain index"
 
@@ -259,6 +272,7 @@ data ChainIndexResponse =
   | ValidatorHashResponse (Maybe Validator)
   | MintingPolicyHashResponse (Maybe MintingPolicy)
   | StakeValidatorHashResponse (Maybe StakeValidator)
+  | TxOutRefResponse (Maybe ChainIndexTxOut)
   | UnspentTxOutResponse (Maybe ChainIndexTxOut)
   | RedeemerHashResponse (Maybe Redeemer)
   | TxIdResponse (Maybe ChainIndexTx)
@@ -278,6 +292,7 @@ instance Pretty ChainIndexResponse where
         MintingPolicyHashResponse m -> "Chain index minting policy from hash response:" <+> pretty m
         StakeValidatorHashResponse m -> "Chain index stake validator from hash response:" <+> pretty m
         RedeemerHashResponse r -> "Chain index redeemer from hash response:" <+> pretty r
+        TxOutRefResponse t -> "Chain index utxo from utxo ref response:" <+> pretty t
         UnspentTxOutResponse t -> "Chain index utxo from utxo ref response:" <+> pretty t
         TxIdResponse t -> "Chain index tx from tx id response:" <+> pretty (_citxTxId <$> t)
         UtxoSetMembershipResponse (IsUtxoResponse tip b) ->

--- a/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
+++ b/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
@@ -227,11 +227,14 @@ handleChainIndexQueries = RequestHandler $ \chainIndexQuery ->
         MintingPolicyFromHash h    -> MintingPolicyHashResponse <$> ChainIndexEff.mintingPolicyFromHash h
         StakeValidatorFromHash h   -> StakeValidatorHashResponse <$> ChainIndexEff.stakeValidatorFromHash h
         RedeemerFromHash h         -> RedeemerHashResponse <$> ChainIndexEff.redeemerFromHash h
+        TxOutFromRef txOutRef      -> TxOutRefResponse <$> ChainIndexEff.txOutFromRef txOutRef
+        TxFromTxId txid            -> TxIdResponse <$> ChainIndexEff.txFromTxId txid
         UnspentTxOutFromRef ref    -> UnspentTxOutResponse <$> ChainIndexEff.unspentTxOutFromRef ref
         UtxoSetMembership txOutRef -> UtxoSetMembershipResponse <$> ChainIndexEff.utxoSetMembership txOutRef
         UtxoSetAtAddress pq c      -> UtxoSetAtResponse <$> ChainIndexEff.utxoSetAtAddress pq c
         UtxoSetWithCurrency pq ac  -> UtxoSetWithCurrencyResponse <$> ChainIndexEff.utxoSetWithCurrency pq ac
         TxoSetAtAddress pq c       -> TxoSetAtResponse <$> ChainIndexEff.txoSetAtAddress pq c
+        TxsFromTxIds txids         -> TxIdsResponse <$> ChainIndexEff.txsFromTxIds txids
         GetTip                     -> GetTipResponse <$> ChainIndexEff.getTip
 
 handleOwnInstanceIdQueries ::

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -576,11 +576,14 @@ handleChainIndexEffect = runChainIndexEffects @t . \case
     MintingPolicyFromHash h   -> ChainIndex.mintingPolicyFromHash h
     StakeValidatorFromHash h  -> ChainIndex.stakeValidatorFromHash h
     RedeemerFromHash h        -> ChainIndex.redeemerFromHash h
+    TxOutFromRef ref          -> ChainIndex.txOutFromRef ref
+    TxFromTxId txid           -> ChainIndex.txFromTxId txid
     UnspentTxOutFromRef ref   -> ChainIndex.unspentTxOutFromRef ref
     UtxoSetMembership ref     -> ChainIndex.utxoSetMembership ref
     UtxoSetAtAddress pq addr  -> ChainIndex.utxoSetAtAddress pq addr
     UtxoSetWithCurrency pq ac -> ChainIndex.utxoSetWithCurrency pq ac
     TxoSetAtAddress pq addr   -> ChainIndex.txoSetAtAddress pq addr
+    TxsFromTxIds txids        -> ChainIndex.txsFromTxIds txids
     GetTip                    -> ChainIndex.getTip
 
 -- | Start a thread that prints log messages to the terminal when they come in.


### PR DESCRIPTION
Reintegrate the chain-index queries for querying txs by id and spent tx outputs from reference.

These were removed in a previous PR. However, a lot of downstream users were dependent on those. Thus, this PR reintegrates them, although it will probably make syncing slower. This is acceptable for the time being as we're working towards a configurable chain-index in the future.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
