### PR TITLE
Export full PABEnvironment

### DIFF
--- a/plutus-pab/src/Plutus/PAB/Core.hs
+++ b/plutus-pab/src/Plutus/PAB/Core.hs
@@ -39,7 +39,7 @@ module Plutus.PAB.Core
     , EffectHandlers(..)
     , runPAB
     , runPAB'
-    , PABEnvironment(appEnv)
+    , PABEnvironment(..)
     -- * Contracts and instances
     , reportContractState
     , activateContract
@@ -67,7 +67,6 @@ module Plutus.PAB.Core
     , activeContracts
     , finalResult
     , waitUntilFinished
-    , blockchainEnv
     , valueAt
     , askUserEnv
     , askBlockchainEnv


### PR DESCRIPTION
Export all the content of PABEnvironment so that other alternative monads may orchestrate the execution of DApp applications and smart contracts and yet make use of the native monad to invoke PAB primitives for managing smart contracts etc.

Example of usage in https://github.com/agocorona/DAppFlow/blob/main/pabtest.hs#L227-L238

For that purpose, the alternative monad need to store and set the entire PABEnvironment before invoking such primitives. so all the PABEnvironment should be reachable externally to get/set his value

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
