### PR TITLE
Replaced the addTxIn constraint with mustSpendOutputFromTheScript

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Typed/Tx.hs
+++ b/plutus-contract/src/Plutus/Contract/Typed/Tx.hs
@@ -7,14 +7,11 @@
 -- | Functions for working with the contract interface using typed transactions.
 module Plutus.Contract.Typed.Tx where
 
-import Ledger.Constraints (TxConstraints)
-import Ledger.Constraints.TxConstraints (addTxIn)
-
-import Data.Foldable (foldl')
-import Data.Map qualified as Map
-
 import Ledger (TxOutRef)
+import Ledger.Constraints (TxConstraints, mustSpendOutputFromTheScript)
 import Ledger.Tx (ChainIndexTxOut)
+
+import Data.Map qualified as Map
 
 -- | Given the pay to script address of the 'Validator', collect from it
 --   all the outputs that match a predicate, using the 'RedeemerValue'.
@@ -37,4 +34,4 @@ collectFromScript ::
     -> i
     -> TxConstraints i o
 collectFromScript utxo redeemer =
-    foldl' (\b a -> addTxIn a redeemer b) mempty (Map.keys utxo)
+    foldMap (flip mustSpendOutputFromTheScript redeemer) $ Map.keys utxo

--- a/plutus-ledger-constraints/src/Ledger/Constraints.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints.hs
@@ -17,6 +17,7 @@ module Ledger.Constraints(
     , TC.mustMintValueWithRedeemer
     , TC.mustSpendAtLeast
     , TC.mustSpendPubKeyOutput
+    , TC.mustSpendOutputFromTheScript
     , TC.mustSpendScriptOutput
     , TC.mustSpendScriptOutputWithMatchingDatumAndValue
     , TC.mustValidateIn


### PR DESCRIPTION
The `addTxIn` is defined in a way to mostly be used as an accumulator in a fold. Better way is to simply define it as a smart constructor for creating a constraint, and constraints can be combined using the Semigroup instances.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
