### PR TITLE
Have plutus-ledger not depend on cardano-wallet-core

### DIFF
--- a/plutus-contract/src/Wallet/Emulator/Wallet.hs
+++ b/plutus-contract/src/Wallet/Emulator/Wallet.hs
@@ -105,7 +105,11 @@ instance FromHttpApiData Wallet where
   parseUrlPiece = pure . Wallet Nothing <=< parseUrlPiece
 
 toMockWallet :: MockWallet -> Wallet
-toMockWallet mw = Wallet (CW.mwPrintAs mw) . WalletId . CW.mwWalletId $ mw
+toMockWallet mw =
+  Wallet (CW.mwPrintAs mw)
+  . WalletId
+  . Cardano.Wallet.WalletId
+  . CW.mwWalletId $ mw
 
 knownWallets :: [Wallet]
 knownWallets = toMockWallet <$> CW.knownMockWallets
@@ -152,7 +156,8 @@ fromBase16 s = bimap show WalletId (fromText s)
 
 -- | The 'MockWallet' whose ID is the given wallet ID (if it exists)
 walletToMockWallet :: Wallet -> Maybe MockWallet
-walletToMockWallet (Wallet _ wid) = find ((==) wid . WalletId . CW.mwWalletId) CW.knownMockWallets
+walletToMockWallet (Wallet _ wid) =
+  find ((==) wid . WalletId . Cardano.Wallet.WalletId . CW.mwWalletId) CW.knownMockWallets
 
 -- | The public key of a mock wallet.  (Fails if the wallet is not a mock wallet).
 mockWalletPaymentPubKey :: Wallet -> PaymentPubKey

--- a/plutus-ledger/plutus-ledger.cabal
+++ b/plutus-ledger/plutus-ledger.cabal
@@ -99,7 +99,6 @@ library
         cardano-ledger-shelley,
         cardano-ledger-shelley-ma -any,
         cardano-slotting -any,
-        cardano-wallet-core -any,
         deepseq -any,
         cborg -any,
         containers -any,

--- a/plutus-ledger/src/Ledger/CardanoWallet.hs
+++ b/plutus-ledger/src/Ledger/CardanoWallet.hs
@@ -25,7 +25,6 @@ module Ledger.CardanoWallet(
     ) where
 
 import Cardano.Crypto.Wallet qualified as Crypto
-import Cardano.Wallet.Primitive.Types qualified as CW
 import Codec.Serialise (serialise)
 import Crypto.Hash qualified as Crypto
 import Data.Aeson (FromJSON, ToJSON)
@@ -58,7 +57,7 @@ instance Hashable MockPrivateKey where
 -- | Emulated wallet with a key and a passphrase
 data MockWallet =
     MockWallet
-        { mwWalletId   :: CW.WalletId
+        { mwWalletId   :: Crypto.Digest Crypto.Blake2b_160
         , mwPaymentKey :: MockPrivateKey
         , mwStakeKey   :: Maybe MockPrivateKey
         , mwPrintAs    :: Maybe String
@@ -84,8 +83,8 @@ fromSeedInternal seedGen bs = MockWallet{mwWalletId, mwPaymentKey, mwStakeKey, m
     missing = max 0 (32 - BS.length bs)
     bs' = bs <> BS.replicate missing 0
     k = seedGen bs'
-    mwWalletId = CW.WalletId
-        $ fromMaybe (error "Ledger.CardanoWallet.fromSeed: digestFromByteString")
+    mwWalletId =
+        fromMaybe (error "Ledger.CardanoWallet.fromSeed: digestFromByteString")
         $ Crypto.digestFromByteString
         $ Crypto.hashWith Crypto.Blake2b_160
         $ getLedgerBytes

--- a/plutus-pab/src/Cardano/Wallet/Mock/Handlers.hs
+++ b/plutus-pab/src/Cardano/Wallet/Mock/Handlers.hs
@@ -23,6 +23,7 @@ import Cardano.Node.Types (ChainSyncHandle)
 import Cardano.Protocol.Socket.Mock.Client qualified as MockClient
 import Cardano.Wallet.Mock.Types (MultiWalletEffect (..), WalletEffects, WalletInfo (..), WalletMsg (..), Wallets,
                                   fromWalletState)
+import Cardano.Wallet.Primitive.Types as CWP
 import Control.Concurrent (MVar)
 import Control.Concurrent.MVar (putMVar, takeMVar)
 import Control.Lens (at, (?~))
@@ -128,7 +129,7 @@ handleMultiWallet = \case
     CreateWallet funds -> do
         wallets <- get @Wallets
         mockWallet <- newWallet
-        let walletId = Wallet.WalletId (CW.mwWalletId mockWallet)
+        let walletId = Wallet.WalletId . CWP.WalletId $ CW.mwWalletId mockWallet
             wallets' = Map.insert walletId (Wallet.fromMockWallet mockWallet) wallets
             pkh = CW.paymentPubKeyHash mockWallet
         put wallets'


### PR DESCRIPTION
Avoid depending on cardano-wallet-core in `plutus-ledger` to make downstream consumption of only that package easier.

This would help at least us over at https://github.com/input-output-hk/hydra-poc as we are not using anything else from `plutus-apps` right now.

Maybe this does not make sense as you will be adding more wallet-related things to `plutus-ledger`.

We may be able to refactor / vendor out the relevant usage of `plutus-ledger` alltogether.
