### PR TITLE
plutus-contract: Modifying addOutputs in emulator

### DIFF
--- a/plutus-contract/src/Wallet/Emulator/Wallet.hs
+++ b/plutus-contract/src/Wallet/Emulator/Wallet.hs
@@ -489,7 +489,7 @@ splitOffAdaOnlyValue vl = if Value.isAdaOnlyValue vl || ada < Ledger.minAdaTxOut
         ada = Ada.fromValue vl - Ledger.minAdaTxOut
 
 addOutput :: PaymentPubKey -> Maybe StakePubKey -> Value -> Tx -> Tx
-addOutput pk sk vl tx = tx & over Tx.outputs (pkos ++) where
+addOutput pk sk vl tx = tx & over Tx.outputs (++ pkos) where
     pkos = (\v -> Tx.pubKeyTxOut v pk sk) <$> splitOffAdaOnlyValue vl
 
 addCollateral

--- a/plutus-contract/test/Spec/Contract.hs
+++ b/plutus-contract/test/Spec/Contract.hs
@@ -218,7 +218,7 @@ tests =
                 tx <- submitTx payment
                 let txOuts = fmap fst $ Ledger.getCardanoTxOutRefs tx
                 -- tell the tx out' datum hash that was specified by 'mustPayWithDatumToPubKey'
-                tell [txOutDatumHash (txOuts !! 1)]
+                tell [txOutDatumHash (head txOuts)]
 
               datum = Datum $ PlutusTx.toBuiltinData (23 :: Integer)
               isExpectedDatumHash [Just hash] = hash == datumHash datum
@@ -245,7 +245,7 @@ tests =
               datum2 = Datum $ PlutusTx.toBuiltinData (42 :: Integer)
 
           in run "mustPayWithDatumToPubKey doesn't throw 'InOutTypeMismatch' error"
-            ( assertNoFailedTransactions ) $ do
+            assertNoFailedTransactions $ do
               _ <- activateContract w1 c1 tag
               void (Trace.waitNSlots 2)
               _ <- activateContract w2 c2 tag
@@ -257,9 +257,9 @@ tests =
                 let payment = Constraints.mustPayToPubKey w2PubKeyHash
                                                           (Ada.adaValueOf 10)
                 tx <- submitTx payment
-                -- There should be 2 utxos. We suppose the first belongs to the
-                -- wallet calling the contract and the second one to W2.
-                let utxo = head $ fmap snd $ Ledger.getCardanoTxOutRefs tx
+                -- There should be 2 utxos. We suppose the first belongs to W2
+                -- and the second one belongs to the wallet calling the contract.
+                let utxo = (fmap snd $ Ledger.getCardanoTxOutRefs tx) !! 1
                 -- We wait for W1's utxo to change status. It should be of
                 -- status confirmed unspent.
                 s <- awaitTxOutStatusChange utxo

--- a/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions.txt
@@ -10,45 +10,45 @@ Slot 00001: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 3c376d383360
 Slot 00001: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 3c376d383360ddc44271308f02ddb2a12f1cef21beb994afca459a5b1adeb877, BlockNumber 0). UTxO state was added to the end.
 Slot 00001: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 3c376d383360ddc44271308f02ddb2a12f1cef21beb994afca459a5b1adeb877, BlockNumber 0). UTxO state was added to the end.
 Slot 00001: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 3c376d383360ddc44271308f02ddb2a12f1cef21beb994afca459a5b1adeb877, BlockNumber 0). UTxO state was added to the end.
-Slot 00001: W[1]: TxSubmit: 0f1bdcf1dada1558382086c8021192180466cdfb7d9ba3bb76f767f60e1a6df6
-Slot 00001: TxnValidate 0f1bdcf1dada1558382086c8021192180466cdfb7d9ba3bb76f767f60e1a6df6
+Slot 00001: W[1]: TxSubmit: c1697bf2fa7491d19fadf904626e74dff29fa194ad8a717e71d2bddbe3b67f6c
+Slot 00001: TxnValidate c1697bf2fa7491d19fadf904626e74dff29fa194ad8a717e71d2bddbe3b67f6c
 Slot 00001: SlotAdd Slot 2
-Slot 00002: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 213cde67f32888aa20478ee9813aaa8b6aa4fae467e8e1c00321079d31013ac0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 213cde67f32888aa20478ee9813aaa8b6aa4fae467e8e1c00321079d31013ac0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 213cde67f32888aa20478ee9813aaa8b6aa4fae467e8e1c00321079d31013ac0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 213cde67f32888aa20478ee9813aaa8b6aa4fae467e8e1c00321079d31013ac0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 213cde67f32888aa20478ee9813aaa8b6aa4fae467e8e1c00321079d31013ac0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 213cde67f32888aa20478ee9813aaa8b6aa4fae467e8e1c00321079d31013ac0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 213cde67f32888aa20478ee9813aaa8b6aa4fae467e8e1c00321079d31013ac0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 213cde67f32888aa20478ee9813aaa8b6aa4fae467e8e1c00321079d31013ac0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 213cde67f32888aa20478ee9813aaa8b6aa4fae467e8e1c00321079d31013ac0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 213cde67f32888aa20478ee9813aaa8b6aa4fae467e8e1c00321079d31013ac0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[2]: TxSubmit: 88ebcd095b71ce9c5639ecd1fe54ef2b2ae2472f1191d65f412e2a6ba38eabb2
-Slot 00002: TxnValidate 88ebcd095b71ce9c5639ecd1fe54ef2b2ae2472f1191d65f412e2a6ba38eabb2
+Slot 00002: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId d70c937bb2b3975e90aaf548f2fa611a86cc5adbb06f81b985cf4b746e34e442, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId d70c937bb2b3975e90aaf548f2fa611a86cc5adbb06f81b985cf4b746e34e442, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId d70c937bb2b3975e90aaf548f2fa611a86cc5adbb06f81b985cf4b746e34e442, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId d70c937bb2b3975e90aaf548f2fa611a86cc5adbb06f81b985cf4b746e34e442, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId d70c937bb2b3975e90aaf548f2fa611a86cc5adbb06f81b985cf4b746e34e442, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId d70c937bb2b3975e90aaf548f2fa611a86cc5adbb06f81b985cf4b746e34e442, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId d70c937bb2b3975e90aaf548f2fa611a86cc5adbb06f81b985cf4b746e34e442, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId d70c937bb2b3975e90aaf548f2fa611a86cc5adbb06f81b985cf4b746e34e442, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId d70c937bb2b3975e90aaf548f2fa611a86cc5adbb06f81b985cf4b746e34e442, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId d70c937bb2b3975e90aaf548f2fa611a86cc5adbb06f81b985cf4b746e34e442, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[2]: TxSubmit: ec23776d76a95b6a3e6e619a552a87c7d145b56cb37112559f71c8aad8d04337
+Slot 00002: TxnValidate ec23776d76a95b6a3e6e619a552a87c7d145b56cb37112559f71c8aad8d04337
 Slot 00002: SlotAdd Slot 3
-Slot 00003: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 3dfe7716fc00b0134238900765487a88ace544e354ff2a77b28d2a0b5ec8e351, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 3dfe7716fc00b0134238900765487a88ace544e354ff2a77b28d2a0b5ec8e351, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 3dfe7716fc00b0134238900765487a88ace544e354ff2a77b28d2a0b5ec8e351, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 3dfe7716fc00b0134238900765487a88ace544e354ff2a77b28d2a0b5ec8e351, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 3dfe7716fc00b0134238900765487a88ace544e354ff2a77b28d2a0b5ec8e351, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 3dfe7716fc00b0134238900765487a88ace544e354ff2a77b28d2a0b5ec8e351, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 3dfe7716fc00b0134238900765487a88ace544e354ff2a77b28d2a0b5ec8e351, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 3dfe7716fc00b0134238900765487a88ace544e354ff2a77b28d2a0b5ec8e351, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 3dfe7716fc00b0134238900765487a88ace544e354ff2a77b28d2a0b5ec8e351, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 3dfe7716fc00b0134238900765487a88ace544e354ff2a77b28d2a0b5ec8e351, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[3]: TxSubmit: 2453166a562aa57ea76d8509dea8817d30288c0f730fe30ac6cc26b026532442
-Slot 00003: TxnValidate 2453166a562aa57ea76d8509dea8817d30288c0f730fe30ac6cc26b026532442
+Slot 00003: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId beb5429f8b7ac003d1064247d8b9af07f0ed474b43177dae113060e03778c4a7, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId beb5429f8b7ac003d1064247d8b9af07f0ed474b43177dae113060e03778c4a7, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId beb5429f8b7ac003d1064247d8b9af07f0ed474b43177dae113060e03778c4a7, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId beb5429f8b7ac003d1064247d8b9af07f0ed474b43177dae113060e03778c4a7, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId beb5429f8b7ac003d1064247d8b9af07f0ed474b43177dae113060e03778c4a7, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId beb5429f8b7ac003d1064247d8b9af07f0ed474b43177dae113060e03778c4a7, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId beb5429f8b7ac003d1064247d8b9af07f0ed474b43177dae113060e03778c4a7, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId beb5429f8b7ac003d1064247d8b9af07f0ed474b43177dae113060e03778c4a7, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId beb5429f8b7ac003d1064247d8b9af07f0ed474b43177dae113060e03778c4a7, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId beb5429f8b7ac003d1064247d8b9af07f0ed474b43177dae113060e03778c4a7, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[3]: TxSubmit: 1b09f013eaf11d5d6229e7f7940c14506732e6a6d10348585f089fd21235c2af
+Slot 00003: TxnValidate 1b09f013eaf11d5d6229e7f7940c14506732e6a6d10348585f089fd21235c2af
 Slot 00003: SlotAdd Slot 4
-Slot 00004: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 2b12819680693bfe9b6bc0b3e478ef3dbe519b7259d632d95ac03fdba83dc035, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 2b12819680693bfe9b6bc0b3e478ef3dbe519b7259d632d95ac03fdba83dc035, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 2b12819680693bfe9b6bc0b3e478ef3dbe519b7259d632d95ac03fdba83dc035, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 2b12819680693bfe9b6bc0b3e478ef3dbe519b7259d632d95ac03fdba83dc035, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 2b12819680693bfe9b6bc0b3e478ef3dbe519b7259d632d95ac03fdba83dc035, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 2b12819680693bfe9b6bc0b3e478ef3dbe519b7259d632d95ac03fdba83dc035, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 2b12819680693bfe9b6bc0b3e478ef3dbe519b7259d632d95ac03fdba83dc035, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 2b12819680693bfe9b6bc0b3e478ef3dbe519b7259d632d95ac03fdba83dc035, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 2b12819680693bfe9b6bc0b3e478ef3dbe519b7259d632d95ac03fdba83dc035, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 2b12819680693bfe9b6bc0b3e478ef3dbe519b7259d632d95ac03fdba83dc035, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b463f803c477114a81a4cfcdc97fb5edd9048ac49dc5477c4ccfd71d11a28f24, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b463f803c477114a81a4cfcdc97fb5edd9048ac49dc5477c4ccfd71d11a28f24, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b463f803c477114a81a4cfcdc97fb5edd9048ac49dc5477c4ccfd71d11a28f24, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b463f803c477114a81a4cfcdc97fb5edd9048ac49dc5477c4ccfd71d11a28f24, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b463f803c477114a81a4cfcdc97fb5edd9048ac49dc5477c4ccfd71d11a28f24, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b463f803c477114a81a4cfcdc97fb5edd9048ac49dc5477c4ccfd71d11a28f24, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b463f803c477114a81a4cfcdc97fb5edd9048ac49dc5477c4ccfd71d11a28f24, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b463f803c477114a81a4cfcdc97fb5edd9048ac49dc5477c4ccfd71d11a28f24, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b463f803c477114a81a4cfcdc97fb5edd9048ac49dc5477c4ccfd71d11a28f24, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b463f803c477114a81a4cfcdc97fb5edd9048ac49dc5477c4ccfd71d11a28f24, BlockNumber 3). UTxO state was added to the end.
 Slot 00004: SlotAdd Slot 5
 Slot 00005: W[7]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.
 Slot 00005: W[8]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.

--- a/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions2.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions2.txt
@@ -10,58 +10,58 @@ Slot 00001: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 3c376d383360
 Slot 00001: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 3c376d383360ddc44271308f02ddb2a12f1cef21beb994afca459a5b1adeb877, BlockNumber 0). UTxO state was added to the end.
 Slot 00001: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 3c376d383360ddc44271308f02ddb2a12f1cef21beb994afca459a5b1adeb877, BlockNumber 0). UTxO state was added to the end.
 Slot 00001: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 3c376d383360ddc44271308f02ddb2a12f1cef21beb994afca459a5b1adeb877, BlockNumber 0). UTxO state was added to the end.
-Slot 00001: W[1]: TxSubmit: f64bcade4a66b408fc28841c0a2de16f4b3a6618f7fbf757f89b2fb96f6cf273
-Slot 00001: TxnValidate f64bcade4a66b408fc28841c0a2de16f4b3a6618f7fbf757f89b2fb96f6cf273
+Slot 00001: W[1]: TxSubmit: 9d975bf4089b063d14d0a99ae9b10b3a0184320899d22a45239febf175ba9c2c
+Slot 00001: TxnValidate 9d975bf4089b063d14d0a99ae9b10b3a0184320899d22a45239febf175ba9c2c
 Slot 00001: SlotAdd Slot 2
-Slot 00002: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId fddbf2288c7a8df967be26d11484ff8981119b7c1bfc28e0e20134d399bab9d0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId fddbf2288c7a8df967be26d11484ff8981119b7c1bfc28e0e20134d399bab9d0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId fddbf2288c7a8df967be26d11484ff8981119b7c1bfc28e0e20134d399bab9d0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId fddbf2288c7a8df967be26d11484ff8981119b7c1bfc28e0e20134d399bab9d0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId fddbf2288c7a8df967be26d11484ff8981119b7c1bfc28e0e20134d399bab9d0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId fddbf2288c7a8df967be26d11484ff8981119b7c1bfc28e0e20134d399bab9d0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId fddbf2288c7a8df967be26d11484ff8981119b7c1bfc28e0e20134d399bab9d0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId fddbf2288c7a8df967be26d11484ff8981119b7c1bfc28e0e20134d399bab9d0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId fddbf2288c7a8df967be26d11484ff8981119b7c1bfc28e0e20134d399bab9d0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId fddbf2288c7a8df967be26d11484ff8981119b7c1bfc28e0e20134d399bab9d0, BlockNumber 1). UTxO state was added to the end.
-Slot 00002: W[2]: TxSubmit: a5346fd4dbbb8633cb6a6a0b171b02f77ac1b63a8923c1b4c26f3ae8e7fff00e
-Slot 00002: TxnValidate a5346fd4dbbb8633cb6a6a0b171b02f77ac1b63a8923c1b4c26f3ae8e7fff00e
+Slot 00002: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 78d5b88b896c25af48992862ded4b8e22169b7ea17ce091161edd0b7d1662508, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 78d5b88b896c25af48992862ded4b8e22169b7ea17ce091161edd0b7d1662508, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 78d5b88b896c25af48992862ded4b8e22169b7ea17ce091161edd0b7d1662508, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 78d5b88b896c25af48992862ded4b8e22169b7ea17ce091161edd0b7d1662508, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 78d5b88b896c25af48992862ded4b8e22169b7ea17ce091161edd0b7d1662508, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 78d5b88b896c25af48992862ded4b8e22169b7ea17ce091161edd0b7d1662508, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 78d5b88b896c25af48992862ded4b8e22169b7ea17ce091161edd0b7d1662508, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 78d5b88b896c25af48992862ded4b8e22169b7ea17ce091161edd0b7d1662508, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 78d5b88b896c25af48992862ded4b8e22169b7ea17ce091161edd0b7d1662508, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 78d5b88b896c25af48992862ded4b8e22169b7ea17ce091161edd0b7d1662508, BlockNumber 1). UTxO state was added to the end.
+Slot 00002: W[2]: TxSubmit: cae1f1e5d0dda08619c7cb4c8efc4824306976ac65ffb1eb863d91264334a401
+Slot 00002: TxnValidate cae1f1e5d0dda08619c7cb4c8efc4824306976ac65ffb1eb863d91264334a401
 Slot 00002: SlotAdd Slot 3
-Slot 00003: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 87851abbdaadcbe2861947a47af116051bc6824353337b213fecc39ce6cd4f22, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 87851abbdaadcbe2861947a47af116051bc6824353337b213fecc39ce6cd4f22, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 87851abbdaadcbe2861947a47af116051bc6824353337b213fecc39ce6cd4f22, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 87851abbdaadcbe2861947a47af116051bc6824353337b213fecc39ce6cd4f22, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 87851abbdaadcbe2861947a47af116051bc6824353337b213fecc39ce6cd4f22, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 87851abbdaadcbe2861947a47af116051bc6824353337b213fecc39ce6cd4f22, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 87851abbdaadcbe2861947a47af116051bc6824353337b213fecc39ce6cd4f22, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 87851abbdaadcbe2861947a47af116051bc6824353337b213fecc39ce6cd4f22, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 87851abbdaadcbe2861947a47af116051bc6824353337b213fecc39ce6cd4f22, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 87851abbdaadcbe2861947a47af116051bc6824353337b213fecc39ce6cd4f22, BlockNumber 2). UTxO state was added to the end.
-Slot 00003: W[3]: TxSubmit: ffc2a10bed4001bac3d30e3553767854606c91af10d410c055abfab598640026
-Slot 00003: TxnValidate ffc2a10bed4001bac3d30e3553767854606c91af10d410c055abfab598640026
+Slot 00003: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b336a1313ddeda3550d5af28b249508581d5e7e98808282e427b4902de4965b6, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b336a1313ddeda3550d5af28b249508581d5e7e98808282e427b4902de4965b6, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b336a1313ddeda3550d5af28b249508581d5e7e98808282e427b4902de4965b6, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b336a1313ddeda3550d5af28b249508581d5e7e98808282e427b4902de4965b6, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b336a1313ddeda3550d5af28b249508581d5e7e98808282e427b4902de4965b6, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b336a1313ddeda3550d5af28b249508581d5e7e98808282e427b4902de4965b6, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b336a1313ddeda3550d5af28b249508581d5e7e98808282e427b4902de4965b6, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b336a1313ddeda3550d5af28b249508581d5e7e98808282e427b4902de4965b6, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b336a1313ddeda3550d5af28b249508581d5e7e98808282e427b4902de4965b6, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b336a1313ddeda3550d5af28b249508581d5e7e98808282e427b4902de4965b6, BlockNumber 2). UTxO state was added to the end.
+Slot 00003: W[3]: TxSubmit: 800e020175106a53bbb513fee409a98fd6e14824912579de6da776e66fd3fff3
+Slot 00003: TxnValidate 800e020175106a53bbb513fee409a98fd6e14824912579de6da776e66fd3fff3
 Slot 00003: SlotAdd Slot 4
-Slot 00004: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 08bb94f97c85ae372b3de39aacb87f513607d398541f2e3a7251272392ef85b2, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 08bb94f97c85ae372b3de39aacb87f513607d398541f2e3a7251272392ef85b2, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 08bb94f97c85ae372b3de39aacb87f513607d398541f2e3a7251272392ef85b2, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 08bb94f97c85ae372b3de39aacb87f513607d398541f2e3a7251272392ef85b2, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 08bb94f97c85ae372b3de39aacb87f513607d398541f2e3a7251272392ef85b2, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 08bb94f97c85ae372b3de39aacb87f513607d398541f2e3a7251272392ef85b2, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 08bb94f97c85ae372b3de39aacb87f513607d398541f2e3a7251272392ef85b2, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 08bb94f97c85ae372b3de39aacb87f513607d398541f2e3a7251272392ef85b2, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 08bb94f97c85ae372b3de39aacb87f513607d398541f2e3a7251272392ef85b2, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 08bb94f97c85ae372b3de39aacb87f513607d398541f2e3a7251272392ef85b2, BlockNumber 3). UTxO state was added to the end.
-Slot 00004: W[1]: TxSubmit: 5d0ef1e08f9ee8cb9550b77373836a6cbc69307437a4756079f767035c8b0ba1
-Slot 00004: TxnValidate 5d0ef1e08f9ee8cb9550b77373836a6cbc69307437a4756079f767035c8b0ba1
+Slot 00004: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId ab8337b7329748b03894a2450235af5845091e53db1ee3ab019c8944edc055d5, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId ab8337b7329748b03894a2450235af5845091e53db1ee3ab019c8944edc055d5, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId ab8337b7329748b03894a2450235af5845091e53db1ee3ab019c8944edc055d5, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId ab8337b7329748b03894a2450235af5845091e53db1ee3ab019c8944edc055d5, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId ab8337b7329748b03894a2450235af5845091e53db1ee3ab019c8944edc055d5, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId ab8337b7329748b03894a2450235af5845091e53db1ee3ab019c8944edc055d5, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId ab8337b7329748b03894a2450235af5845091e53db1ee3ab019c8944edc055d5, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId ab8337b7329748b03894a2450235af5845091e53db1ee3ab019c8944edc055d5, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId ab8337b7329748b03894a2450235af5845091e53db1ee3ab019c8944edc055d5, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId ab8337b7329748b03894a2450235af5845091e53db1ee3ab019c8944edc055d5, BlockNumber 3). UTxO state was added to the end.
+Slot 00004: W[1]: TxSubmit: 985d0c932a43fd86f0ac78e6cd825747723f55cbb4c0eee588bbdad0e80b8cc9
+Slot 00004: TxnValidate 985d0c932a43fd86f0ac78e6cd825747723f55cbb4c0eee588bbdad0e80b8cc9
 Slot 00004: SlotAdd Slot 5
-Slot 00005: W[7]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 29ee1e4e7bfe392bc39a831f458dd161e563b5adc55b45e669abe7de0aca1f51, BlockNumber 4). UTxO state was added to the end.
-Slot 00005: W[8]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 29ee1e4e7bfe392bc39a831f458dd161e563b5adc55b45e669abe7de0aca1f51, BlockNumber 4). UTxO state was added to the end.
-Slot 00005: W[6]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 29ee1e4e7bfe392bc39a831f458dd161e563b5adc55b45e669abe7de0aca1f51, BlockNumber 4). UTxO state was added to the end.
-Slot 00005: W[4]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 29ee1e4e7bfe392bc39a831f458dd161e563b5adc55b45e669abe7de0aca1f51, BlockNumber 4). UTxO state was added to the end.
-Slot 00005: W[2]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 29ee1e4e7bfe392bc39a831f458dd161e563b5adc55b45e669abe7de0aca1f51, BlockNumber 4). UTxO state was added to the end.
-Slot 00005: W[1]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 29ee1e4e7bfe392bc39a831f458dd161e563b5adc55b45e669abe7de0aca1f51, BlockNumber 4). UTxO state was added to the end.
-Slot 00005: W[10]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 29ee1e4e7bfe392bc39a831f458dd161e563b5adc55b45e669abe7de0aca1f51, BlockNumber 4). UTxO state was added to the end.
-Slot 00005: W[9]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 29ee1e4e7bfe392bc39a831f458dd161e563b5adc55b45e669abe7de0aca1f51, BlockNumber 4). UTxO state was added to the end.
-Slot 00005: W[3]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 29ee1e4e7bfe392bc39a831f458dd161e563b5adc55b45e669abe7de0aca1f51, BlockNumber 4). UTxO state was added to the end.
-Slot 00005: W[5]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 29ee1e4e7bfe392bc39a831f458dd161e563b5adc55b45e669abe7de0aca1f51, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W[7]: InsertionSuccess: New tip is Tip(Slot 5, BlockId baae0c739b022535afc819055a2864deb00b61ff375fe877f5a98187020091e1, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W[8]: InsertionSuccess: New tip is Tip(Slot 5, BlockId baae0c739b022535afc819055a2864deb00b61ff375fe877f5a98187020091e1, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W[6]: InsertionSuccess: New tip is Tip(Slot 5, BlockId baae0c739b022535afc819055a2864deb00b61ff375fe877f5a98187020091e1, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W[4]: InsertionSuccess: New tip is Tip(Slot 5, BlockId baae0c739b022535afc819055a2864deb00b61ff375fe877f5a98187020091e1, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W[2]: InsertionSuccess: New tip is Tip(Slot 5, BlockId baae0c739b022535afc819055a2864deb00b61ff375fe877f5a98187020091e1, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W[1]: InsertionSuccess: New tip is Tip(Slot 5, BlockId baae0c739b022535afc819055a2864deb00b61ff375fe877f5a98187020091e1, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W[10]: InsertionSuccess: New tip is Tip(Slot 5, BlockId baae0c739b022535afc819055a2864deb00b61ff375fe877f5a98187020091e1, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W[9]: InsertionSuccess: New tip is Tip(Slot 5, BlockId baae0c739b022535afc819055a2864deb00b61ff375fe877f5a98187020091e1, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W[3]: InsertionSuccess: New tip is Tip(Slot 5, BlockId baae0c739b022535afc819055a2864deb00b61ff375fe877f5a98187020091e1, BlockNumber 4). UTxO state was added to the end.
+Slot 00005: W[5]: InsertionSuccess: New tip is Tip(Slot 5, BlockId baae0c739b022535afc819055a2864deb00b61ff375fe877f5a98187020091e1, BlockNumber 4). UTxO state was added to the end.
 Slot 00005: SlotAdd Slot 6
 Slot 00006: W[7]: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.
 Slot 00006: W[8]: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.
@@ -83,9 +83,9 @@ Wallet 6:
 Wallet 4: 
     {, ""}: 100000000
 Wallet 2: 
-    {, ""}: 99767883
+    {, ""}: 99810343
 Wallet 1: 
-    {, ""}: 99596090
+    {, ""}: 99602118
 Wallet 10: 
     {, ""}: 100000000
 Wallet 9: 

--- a/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
@@ -37,7 +37,7 @@ Slot 1: W[2]: Balancing an unbalanced transaction:
                 Validity range:
                   (-∞ , POSIXTime 1596059111000 ]
 Slot 1: W[2]: Finished balancing:
-                Tx dee79916a36a7e8b9b75515fa2423e973a1c793dae88ec48801845de954b0c5d:
+                Tx a47338f2e04333d624ffb373332eb94ecbe1ab85f1e874b2eb1c916dbf57da84:
                   {inputs:
                      - ef0ca0fb043642529818003be5a6cac88aac499e4f8f1cbc3bdb35db2b7f6958!20
 
@@ -47,10 +47,10 @@ Slot 1: W[2]: Finished balancing:
                     - ef0ca0fb043642529818003be5a6cac88aac499e4f8f1cbc3bdb35db2b7f6958!20
 
                   outputs:
-                    - Value (Map [(,Map [("",9817867)])]) addressed to
-                      PubKeyCredential: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c087f250b86193ca7 (no staking credential)
                     - Value (Map [(,Map [("",10000000)])]) addressed to
                       ScriptCredential: 6bf030518a13158b50eb7ef9f29305e30ede2434f26861e110b6ea38 (no staking credential)
+                    - Value (Map [(,Map [("",9817867)])]) addressed to
+                      PubKeyCredential: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c087f250b86193ca7 (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [(,Map [("",182133)])])
                   mps:
@@ -60,9 +60,9 @@ Slot 1: W[2]: Finished balancing:
                     "\128\164\244[V\184\141\DC19\218#\188L<u\236m2\148<\b\DEL%\v\134\EM<\167"}
 Slot 1: 00000000-0000-4000-8000-000000000003 {Wallet W[4]}:
           Contract instance started
-Slot 1: W[2]: Signing tx: dee79916a36a7e8b9b75515fa2423e973a1c793dae88ec48801845de954b0c5d
-Slot 1: W[2]: Submitting tx: dee79916a36a7e8b9b75515fa2423e973a1c793dae88ec48801845de954b0c5d
-Slot 1: W[2]: TxSubmit: dee79916a36a7e8b9b75515fa2423e973a1c793dae88ec48801845de954b0c5d
+Slot 1: W[2]: Signing tx: a47338f2e04333d624ffb373332eb94ecbe1ab85f1e874b2eb1c916dbf57da84
+Slot 1: W[2]: Submitting tx: a47338f2e04333d624ffb373332eb94ecbe1ab85f1e874b2eb1c916dbf57da84
+Slot 1: W[2]: TxSubmit: a47338f2e04333d624ffb373332eb94ecbe1ab85f1e874b2eb1c916dbf57da84
 Slot 1: 00000000-0000-4000-8000-000000000003 {Wallet W[4]}:
           Receive endpoint call on 'contribute' for Object (fromList [("contents",Array [Object (fromList [("getEndpointDescription",String "contribute")]),Object (fromList [("unEndpointValue",Object (fromList [("contribValue",Object (fromList [("getValue",Array [Array [Object (fromList [("unCurrencySymbol",String "")]),Array [Array [Object (fromList [("unTokenName",String "")]),Number 2500000.0]]]])]))]))])]),("tag",String "ExposeEndpointResp")])
 Slot 1: 00000000-0000-4000-8000-000000000003 {Wallet W[4]}:
@@ -87,7 +87,7 @@ Slot 1: W[3]: Balancing an unbalanced transaction:
                 Validity range:
                   (-∞ , POSIXTime 1596059111000 ]
 Slot 1: W[3]: Finished balancing:
-                Tx 498320559c9cc22aa41787f53b156445468912f5d6ccb91513ef5305c7fe1a7a:
+                Tx 0e0409a352192418bacff81338e88b4dabc6d7537f5c76402b492cc090c94893:
                   {inputs:
                      - ef0ca0fb043642529818003be5a6cac88aac499e4f8f1cbc3bdb35db2b7f6958!0
 
@@ -97,10 +97,10 @@ Slot 1: W[3]: Finished balancing:
                     - ef0ca0fb043642529818003be5a6cac88aac499e4f8f1cbc3bdb35db2b7f6958!0
 
                   outputs:
-                    - Value (Map [(,Map [("",9817867)])]) addressed to
-                      PubKeyCredential: 2e0ad60c3207248cecd47dbde3d752e0aad141d6b8f81ac2c6eca27c (no staking credential)
                     - Value (Map [(,Map [("",10000000)])]) addressed to
                       ScriptCredential: 6bf030518a13158b50eb7ef9f29305e30ede2434f26861e110b6ea38 (no staking credential)
+                    - Value (Map [(,Map [("",9817867)])]) addressed to
+                      PubKeyCredential: 2e0ad60c3207248cecd47dbde3d752e0aad141d6b8f81ac2c6eca27c (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [(,Map [("",182133)])])
                   mps:
@@ -108,9 +108,9 @@ Slot 1: W[3]: Finished balancing:
                   validity range: Interval {ivFrom = LowerBound NegInf True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) False}
                   data:
                     ".\n\214\f2\a$\140\236\212}\189\227\215R\224\170\209A\214\184\248\SUB\194\198\236\162|"}
-Slot 1: W[3]: Signing tx: 498320559c9cc22aa41787f53b156445468912f5d6ccb91513ef5305c7fe1a7a
-Slot 1: W[3]: Submitting tx: 498320559c9cc22aa41787f53b156445468912f5d6ccb91513ef5305c7fe1a7a
-Slot 1: W[3]: TxSubmit: 498320559c9cc22aa41787f53b156445468912f5d6ccb91513ef5305c7fe1a7a
+Slot 1: W[3]: Signing tx: 0e0409a352192418bacff81338e88b4dabc6d7537f5c76402b492cc090c94893
+Slot 1: W[3]: Submitting tx: 0e0409a352192418bacff81338e88b4dabc6d7537f5c76402b492cc090c94893
+Slot 1: W[3]: TxSubmit: 0e0409a352192418bacff81338e88b4dabc6d7537f5c76402b492cc090c94893
 Slot 1: W[4]: Balancing an unbalanced transaction:
                 Tx:
                   Tx 67d36219de9657d44cd20633bdac09ebf592c79d41f556a90b3abbbaae7c185d:
@@ -131,7 +131,7 @@ Slot 1: W[4]: Balancing an unbalanced transaction:
                 Validity range:
                   (-∞ , POSIXTime 1596059111000 ]
 Slot 1: W[4]: Finished balancing:
-                Tx e1864c44268c2aed4be720c31be879622eeb52a94b05a1f9c121410c34142367:
+                Tx 9b3a1f951e788ba61c5b26fb8abb23560c30891aa00c55a98317805f429633b0:
                   {inputs:
                      - ef0ca0fb043642529818003be5a6cac88aac499e4f8f1cbc3bdb35db2b7f6958!10
 
@@ -139,10 +139,10 @@ Slot 1: W[4]: Finished balancing:
                     - ef0ca0fb043642529818003be5a6cac88aac499e4f8f1cbc3bdb35db2b7f6958!10
 
                   outputs:
-                    - Value (Map [(,Map [("",7323895)])]) addressed to
-                      PubKeyCredential: 557d23c0a533b4d295ac2dc14b783a7efc293bc23ede88a6fefd203d (no staking credential)
                     - Value (Map [(,Map [("",2500000)])]) addressed to
                       ScriptCredential: 6bf030518a13158b50eb7ef9f29305e30ede2434f26861e110b6ea38 (no staking credential)
+                    - Value (Map [(,Map [("",7323895)])]) addressed to
+                      PubKeyCredential: 557d23c0a533b4d295ac2dc14b783a7efc293bc23ede88a6fefd203d (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [(,Map [("",176105)])])
                   mps:
@@ -150,23 +150,23 @@ Slot 1: W[4]: Finished balancing:
                   validity range: Interval {ivFrom = LowerBound NegInf True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) False}
                   data:
                     "U}#\192\165\&3\180\210\149\172-\193Kx:~\252);\194>\222\136\166\254\253 ="}
-Slot 1: W[4]: Signing tx: e1864c44268c2aed4be720c31be879622eeb52a94b05a1f9c121410c34142367
-Slot 1: W[4]: Submitting tx: e1864c44268c2aed4be720c31be879622eeb52a94b05a1f9c121410c34142367
-Slot 1: W[4]: TxSubmit: e1864c44268c2aed4be720c31be879622eeb52a94b05a1f9c121410c34142367
-Slot 1: TxnValidate e1864c44268c2aed4be720c31be879622eeb52a94b05a1f9c121410c34142367
-Slot 1: TxnValidate 498320559c9cc22aa41787f53b156445468912f5d6ccb91513ef5305c7fe1a7a
-Slot 1: TxnValidate dee79916a36a7e8b9b75515fa2423e973a1c793dae88ec48801845de954b0c5d
+Slot 1: W[4]: Signing tx: 9b3a1f951e788ba61c5b26fb8abb23560c30891aa00c55a98317805f429633b0
+Slot 1: W[4]: Submitting tx: 9b3a1f951e788ba61c5b26fb8abb23560c30891aa00c55a98317805f429633b0
+Slot 1: W[4]: TxSubmit: 9b3a1f951e788ba61c5b26fb8abb23560c30891aa00c55a98317805f429633b0
+Slot 1: TxnValidate 9b3a1f951e788ba61c5b26fb8abb23560c30891aa00c55a98317805f429633b0
+Slot 1: TxnValidate 0e0409a352192418bacff81338e88b4dabc6d7537f5c76402b492cc090c94893
+Slot 1: TxnValidate a47338f2e04333d624ffb373332eb94ecbe1ab85f1e874b2eb1c916dbf57da84
 Slot 20: 00000000-0000-4000-8000-000000000000 {Wallet W[1]}:
            Contract log: String "Collecting funds"
 Slot 20: W[1]: Balancing an unbalanced transaction:
                  Tx:
-                   Tx 622dded86c87983b3782e4d24981659b1c5bea0102fcbbf784cf106fc2634cd3:
+                   Tx 8fb70239443b20452621db996c868f35e63355cc2bb00a53e7fae0f8d017ec8a:
                      {inputs:
-                        - 498320559c9cc22aa41787f53b156445468912f5d6ccb91513ef5305c7fe1a7a!1
+                        - 0e0409a352192418bacff81338e88b4dabc6d7537f5c76402b492cc090c94893!0
                           <>
-                        - dee79916a36a7e8b9b75515fa2423e973a1c793dae88ec48801845de954b0c5d!1
+                        - 9b3a1f951e788ba61c5b26fb8abb23560c30891aa00c55a98317805f429633b0!0
                           <>
-                        - e1864c44268c2aed4be720c31be879622eeb52a94b05a1f9c121410c34142367!1
+                        - a47338f2e04333d624ffb373332eb94ecbe1ab85f1e874b2eb1c916dbf57da84!0
                           <>
                      collateral inputs:
                      outputs:
@@ -178,25 +178,25 @@ Slot 20: W[1]: Balancing an unbalanced transaction:
                      data:}
                  Requires signatures:
                  Utxo index:
-                   ( 498320559c9cc22aa41787f53b156445468912f5d6ccb91513ef5305c7fe1a7a!1
+                   ( 0e0409a352192418bacff81338e88b4dabc6d7537f5c76402b492cc090c94893!0
                    , - Value (Map [(,Map [("",10000000)])]) addressed to
                        ScriptCredential: 6bf030518a13158b50eb7ef9f29305e30ede2434f26861e110b6ea38 (no staking credential) )
-                   ( dee79916a36a7e8b9b75515fa2423e973a1c793dae88ec48801845de954b0c5d!1
-                   , - Value (Map [(,Map [("",10000000)])]) addressed to
-                       ScriptCredential: 6bf030518a13158b50eb7ef9f29305e30ede2434f26861e110b6ea38 (no staking credential) )
-                   ( e1864c44268c2aed4be720c31be879622eeb52a94b05a1f9c121410c34142367!1
+                   ( 9b3a1f951e788ba61c5b26fb8abb23560c30891aa00c55a98317805f429633b0!0
                    , - Value (Map [(,Map [("",2500000)])]) addressed to
+                       ScriptCredential: 6bf030518a13158b50eb7ef9f29305e30ede2434f26861e110b6ea38 (no staking credential) )
+                   ( a47338f2e04333d624ffb373332eb94ecbe1ab85f1e874b2eb1c916dbf57da84!0
+                   , - Value (Map [(,Map [("",10000000)])]) addressed to
                        ScriptCredential: 6bf030518a13158b50eb7ef9f29305e30ede2434f26861e110b6ea38 (no staking credential) )
                  Validity range:
                    [ POSIXTime 1596059111000 , POSIXTime 1596059120999 ]
 Slot 20: W[1]: Finished balancing:
-                 Tx 2613d95ba3509d7d84926b4c401732edd770e3a77b8ca2f52e2e81a517436b5a:
+                 Tx e216c3723b081530b62929a74b8af62f189e8c654351fe63e9a4503871fadbad:
                    {inputs:
-                      - 498320559c9cc22aa41787f53b156445468912f5d6ccb91513ef5305c7fe1a7a!1
+                      - 0e0409a352192418bacff81338e88b4dabc6d7537f5c76402b492cc090c94893!0
                         <>
-                      - dee79916a36a7e8b9b75515fa2423e973a1c793dae88ec48801845de954b0c5d!1
+                      - 9b3a1f951e788ba61c5b26fb8abb23560c30891aa00c55a98317805f429633b0!0
                         <>
-                      - e1864c44268c2aed4be720c31be879622eeb52a94b05a1f9c121410c34142367!1
+                      - a47338f2e04333d624ffb373332eb94ecbe1ab85f1e874b2eb1c916dbf57da84!0
                         <>
                    collateral inputs:
                      - ef0ca0fb043642529818003be5a6cac88aac499e4f8f1cbc3bdb35db2b7f6958!50
@@ -210,9 +210,9 @@ Slot 20: W[1]: Finished balancing:
                    signatures:
                    validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 20})) True, ivTo = UpperBound (Finite (Slot {getSlot = 29})) True}
                    data:}
-Slot 20: W[1]: Signing tx: 2613d95ba3509d7d84926b4c401732edd770e3a77b8ca2f52e2e81a517436b5a
-Slot 20: W[1]: Submitting tx: 2613d95ba3509d7d84926b4c401732edd770e3a77b8ca2f52e2e81a517436b5a
-Slot 20: W[1]: TxSubmit: 2613d95ba3509d7d84926b4c401732edd770e3a77b8ca2f52e2e81a517436b5a
+Slot 20: W[1]: Signing tx: e216c3723b081530b62929a74b8af62f189e8c654351fe63e9a4503871fadbad
+Slot 20: W[1]: Submitting tx: e216c3723b081530b62929a74b8af62f189e8c654351fe63e9a4503871fadbad
+Slot 20: W[1]: TxSubmit: e216c3723b081530b62929a74b8af62f189e8c654351fe63e9a4503871fadbad
 Slot 20: 00000000-0000-4000-8000-000000000000 {Wallet W[1]}:
            Contract instance stopped (no errors)
-Slot 20: TxnValidate 2613d95ba3509d7d84926b4c401732edd770e3a77b8ca2f52e2e81a517436b5a
+Slot 20: TxnValidate e216c3723b081530b62929a74b8af62f189e8c654351fe63e9a4503871fadbad

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -551,11 +551,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       e1864c44268c2aed4be720c31be879622eeb52a94b05a1f9c121410c34142367
+TxId:       9b3a1f951e788ba61c5b26fb8abb23560c30891aa00c55a98317805f429633b0
 Fee:        Ada:      Lovelace:  176105
 Mint:       -
 Signatures  PubKey: c0a4b02f44c212ba6c1197df5a5cf8bd1a3dceef...
-              Signature: 584074326889cacbab9c37f9bfa6d0dfe7398b30...
+              Signature: 5840a69994f80d0a7bb32c0770982c22835cb3ba...
 Inputs:
   ---- Input 0 ----
   Destination:  PaymentPubKeyHash: 557d23c0a533b4d295ac2dc14b783a7efc293bc2... (Wallet 5f5a4f5f465580a5500b9a9cede7f4e014a37ea8)
@@ -569,14 +569,14 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PaymentPubKeyHash: 557d23c0a533b4d295ac2dc14b783a7efc293bc2... (Wallet 5f5a4f5f465580a5500b9a9cede7f4e014a37ea8)
-  Value:
-    Ada:      Lovelace:  7323895
-
-  ---- Output 1 ----
   Destination:  Script: 6bf030518a13158b50eb7ef9f29305e30ede2434f26861e110b6ea38
   Value:
     Ada:      Lovelace:  2500000
+
+  ---- Output 1 ----
+  Destination:  PaymentPubKeyHash: 557d23c0a533b4d295ac2dc14b783a7efc293bc2... (Wallet 5f5a4f5f465580a5500b9a9cede7f4e014a37ea8)
+  Value:
+    Ada:      Lovelace:  7323895
 
 
 Balances Carried Forward:
@@ -625,11 +625,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  2500000
 
 ==== Slot #1, Tx #1 ====
-TxId:       498320559c9cc22aa41787f53b156445468912f5d6ccb91513ef5305c7fe1a7a
+TxId:       0e0409a352192418bacff81338e88b4dabc6d7537f5c76402b492cc090c94893
 Fee:        Ada:      Lovelace:  182133
 Mint:       -
 Signatures  PubKey: 4cdc632449cde98d811f78ad2e2d15a278731bc5...
-              Signature: 58400085d64b8bf328a6147e58b5e05d7e3b178c...
+              Signature: 58401b7ac449aeee7df5171c28f889a808a7d718...
 Inputs:
   ---- Input 0 ----
   Destination:  PaymentPubKeyHash: 2e0ad60c3207248cecd47dbde3d752e0aad141d6... (Wallet c30efb78b4e272685c1f9f0c93787fd4b6743154)
@@ -652,14 +652,14 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PaymentPubKeyHash: 2e0ad60c3207248cecd47dbde3d752e0aad141d6... (Wallet c30efb78b4e272685c1f9f0c93787fd4b6743154)
-  Value:
-    Ada:      Lovelace:  9817867
-
-  ---- Output 1 ----
   Destination:  Script: 6bf030518a13158b50eb7ef9f29305e30ede2434f26861e110b6ea38
   Value:
     Ada:      Lovelace:  10000000
+
+  ---- Output 1 ----
+  Destination:  PaymentPubKeyHash: 2e0ad60c3207248cecd47dbde3d752e0aad141d6... (Wallet c30efb78b4e272685c1f9f0c93787fd4b6743154)
+  Value:
+    Ada:      Lovelace:  9817867
 
 
 Balances Carried Forward:
@@ -708,11 +708,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  12500000
 
 ==== Slot #1, Tx #2 ====
-TxId:       dee79916a36a7e8b9b75515fa2423e973a1c793dae88ec48801845de954b0c5d
+TxId:       a47338f2e04333d624ffb373332eb94ecbe1ab85f1e874b2eb1c916dbf57da84
 Fee:        Ada:      Lovelace:  182133
 Mint:       -
 Signatures  PubKey: 98c77c40ccc536e0d433874dae97d4a0787b10b3...
-              Signature: 5840c306486b0c63190388548ede0c4e9f0e86ba...
+              Signature: 58408540c0cde30e7370057e65fc83b7462cd7bd...
 Inputs:
   ---- Input 0 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
@@ -735,14 +735,14 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
-  Value:
-    Ada:      Lovelace:  9817867
-
-  ---- Output 1 ----
   Destination:  Script: 6bf030518a13158b50eb7ef9f29305e30ede2434f26861e110b6ea38
   Value:
     Ada:      Lovelace:  10000000
+
+  ---- Output 1 ----
+  Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
+  Value:
+    Ada:      Lovelace:  9817867
 
 
 Balances Carried Forward:
@@ -791,37 +791,37 @@ Balances Carried Forward:
     Ada:      Lovelace:  22500000
 
 ==== Slot #2, Tx #0 ====
-TxId:       2613d95ba3509d7d84926b4c401732edd770e3a77b8ca2f52e2e81a517436b5a
+TxId:       e216c3723b081530b62929a74b8af62f189e8c654351fe63e9a4503871fadbad
 Fee:        Ada:      Lovelace:  300581
 Mint:       -
 Signatures  PubKey: 8d9de88fbf445b7f6c3875a14daba94caee2ffcb...
-              Signature: 584035b5b634d3272f3efc85801c4a0a6a4cdb1e...
+              Signature: 5840268c33fd48118ef099ae1189056a960b46d8...
 Inputs:
   ---- Input 0 ----
   Destination:  Script: 6bf030518a13158b50eb7ef9f29305e30ede2434f26861e110b6ea38
   Value:
     Ada:      Lovelace:  10000000
   Source:
-    Tx:     498320559c9cc22aa41787f53b156445468912f5d6ccb91513ef5305c7fe1a7a
-    Output #1
+    Tx:     0e0409a352192418bacff81338e88b4dabc6d7537f5c76402b492cc090c94893
+    Output #0
     Script: 590b0c0100003323232323232323232323232323...
 
   ---- Input 1 ----
   Destination:  Script: 6bf030518a13158b50eb7ef9f29305e30ede2434f26861e110b6ea38
   Value:
-    Ada:      Lovelace:  10000000
+    Ada:      Lovelace:  2500000
   Source:
-    Tx:     dee79916a36a7e8b9b75515fa2423e973a1c793dae88ec48801845de954b0c5d
-    Output #1
+    Tx:     9b3a1f951e788ba61c5b26fb8abb23560c30891aa00c55a98317805f429633b0
+    Output #0
     Script: 590b0c0100003323232323232323232323232323...
 
   ---- Input 2 ----
   Destination:  Script: 6bf030518a13158b50eb7ef9f29305e30ede2434f26861e110b6ea38
   Value:
-    Ada:      Lovelace:  2500000
+    Ada:      Lovelace:  10000000
   Source:
-    Tx:     e1864c44268c2aed4be720c31be879622eeb52a94b05a1f9c121410c34142367
-    Output #1
+    Tx:     a47338f2e04333d624ffb373332eb94ecbe1ab85f1e874b2eb1c916dbf57da84
+    Output #0
     Script: 590b0c0100003323232323232323232323232323...
 
 

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -551,11 +551,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       f62128352c609d02e49d4e2e21652ee332586201b27b00d30975f07c4a6c8e40
+TxId:       3b5055fc43eede4efa1fbe02a510c23419a1948d57451062ffd698412ba37f0e
 Fee:        Ada:      Lovelace:  184113
 Mint:       -
 Signatures  PubKey: 8d9de88fbf445b7f6c3875a14daba94caee2ffcb...
-              Signature: 5840223a760e308721bbee1a7f540df48a826bd6...
+              Signature: 5840804ad7b98709bf0e5a6453486b8887016b36...
 Inputs:
   ---- Input 0 ----
   Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
@@ -578,14 +578,14 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
-  Value:
-    Ada:      Lovelace:  11815887
-
-  ---- Output 1 ----
   Destination:  Script: 4ff3210533e97f6593da228013279795e2819f16dd48ed5a1739975a
   Value:
     Ada:      Lovelace:  8000000
+
+  ---- Output 1 ----
+  Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
+  Value:
+    Ada:      Lovelace:  11815887
 
 
 Balances Carried Forward:

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -551,11 +551,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       eaa907930d7cee7b2751ae7f403668410a4bc0aac54d2fd4824fc2f5a97e9b3a
+TxId:       07ca437c6855dde17b3f6aa2360a8528f6a3675e812e08974b6f0770d0ca2cd7
 Fee:        Ada:      Lovelace:  211129
 Mint:       -
 Signatures  PubKey: 98c77c40ccc536e0d433874dae97d4a0787b10b3...
-              Signature: 5840885493b11cffc63223b661599f4123cc19ed...
+              Signature: 584034a6a9efd5bfb0a52ade5cbe175c7f412517...
 Inputs:
   ---- Input 0 ----
   Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
@@ -623,14 +623,14 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
-  Value:
-    Ada:      Lovelace:  9788871
-
-  ---- Output 1 ----
   Destination:  Script: 87287fdc5ae4aaa2072b64e0a51b409ea86061ed35d2e4eeef34c064
   Value:
     Ada:      Lovelace:  60000000
+
+  ---- Output 1 ----
+  Destination:  PaymentPubKeyHash: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c... (Wallet 7ce812d7a4770bbf58004067665c3a48f28ddd58)
+  Value:
+    Ada:      Lovelace:  9788871
 
 
 Balances Carried Forward:
@@ -679,32 +679,32 @@ Balances Carried Forward:
     Ada:      Lovelace:  60000000
 
 ==== Slot #2, Tx #0 ====
-TxId:       b71b44d143ea0945ee4da1f7175cf162312992dfe44afd977508cac2ca185245
+TxId:       b13ee4cbd2a420021c487bb1e4ca008ab1cba913d3255a8cc30d642ab1bfde66
 Fee:        Ada:      Lovelace:  452257
 Mint:       -
 Signatures  PubKey: 8d9de88fbf445b7f6c3875a14daba94caee2ffcb...
-              Signature: 58409cdfa7c5242f5d079066a9e74dcb1239cb14...
+              Signature: 5840c5b2032a694d389ee5a7f290e60c07ae0841...
 Inputs:
   ---- Input 0 ----
   Destination:  Script: 87287fdc5ae4aaa2072b64e0a51b409ea86061ed35d2e4eeef34c064
   Value:
     Ada:      Lovelace:  60000000
   Source:
-    Tx:     eaa907930d7cee7b2751ae7f403668410a4bc0aac54d2fd4824fc2f5a97e9b3a
-    Output #1
+    Tx:     07ca437c6855dde17b3f6aa2360a8528f6a3675e812e08974b6f0770d0ca2cd7
+    Output #0
     Script: 590e860100003323232323232323232323232323...
 
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
-  Value:
-    Ada:      Lovelace:  9547743
-
-  ---- Output 1 ----
   Destination:  Script: 87287fdc5ae4aaa2072b64e0a51b409ea86061ed35d2e4eeef34c064
   Value:
     Ada:      Lovelace:  50000000
+
+  ---- Output 1 ----
+  Destination:  PaymentPubKeyHash: a2c20c77887ace1cd986193e4e75babd8993cfd5... (Wallet 872cb83b5ee40eb23bfdab1772660c822a48d491)
+  Value:
+    Ada:      Lovelace:  9547743
 
 
 Balances Carried Forward:


### PR DESCRIPTION
plutus-contract emulator: Modifying addOutputs to replicate what cardano-wallet and cardano-node do, i.e., new outputs due to balancing are append to the list and not prepend.

Cherry-picked commit from:  https://github.com/etiennejf/plutus-apps/commit/27bbb47cd463b4054daadda40f31a9abaaaf2288

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
