### PR TITLE
QuickCheck-dynamic: Move Typeable constraint further downstream of class hierarchy

### DIFF
--- a/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic.hs
+++ b/quickcheck-dynamic/src/Test/QuickCheck/DynamicLogic.hs
@@ -146,7 +146,7 @@ bracket (first:rest) = ["  ["++first++", "] ++
 -- properties at controlled times, so they are likely to fail if
 -- invoked at other times.
 
-class StateModel s => DynLogicModel s where
+class (Typeable s, StateModel s) => DynLogicModel s where
     restricted :: Action s a -> Bool
     restricted _ = False
 


### PR DESCRIPTION
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
This solves an issue the hydra team were having with building a StateModel that depends on IOSim.
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
