### PR TITLE
PLT-255 Fixed plutus-pab integration test

### DIFF
--- a/plutus-chain-index/src/Plutus/ChainIndex/App.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/App.hs
@@ -28,7 +28,7 @@ import Plutus.ChainIndex.CommandLine (AppConfig (AppConfig, acCLIConfigOverrides
                                       applyOverrides, cmdWithHelpParser)
 import Plutus.ChainIndex.Compatibility (fromCardanoBlockNo)
 import Plutus.ChainIndex.Config qualified as Config
-import Plutus.ChainIndex.Events (measureEventByTxs, processEventsQueue)
+import Plutus.ChainIndex.Events (measureEventQueueSizeByTxs, processEventsQueue)
 import Plutus.ChainIndex.Lib (getTipSlot, storeChainSyncHandler, storeFromBlockNo, syncChainIndex, withRunRequirements)
 import Plutus.ChainIndex.Logging qualified as Logging
 import Plutus.ChainIndex.Server qualified as Server
@@ -82,7 +82,8 @@ runMainWithLog logger logConfig config = do
     logger slotNoStr
 
     -- Queue for processing events
-    eventsQueue <- newTBMQueueIO (Config.cicAppendTransactionQueueSize config) measureEventByTxs
+    let maxQueueSize = Config.cicAppendTransactionQueueSize config
+    eventsQueue <- newTBMQueueIO maxQueueSize (measureEventQueueSizeByTxs maxQueueSize)
     syncHandler
       <- storeChainSyncHandler eventsQueue
         & storeFromBlockNo (fromCardanoBlockNo $ Config.cicStoreFrom config)

--- a/plutus-pab-executables/README.md
+++ b/plutus-pab-executables/README.md
@@ -50,11 +50,8 @@ Can be used to run end-to-end tests using a private local testnet.
 
 2. Get config data:
 
-  Clone <https://github.com/input-output-hk/cardano-wallet/> to $DIR and set the
-  `SHELLEY_TEST_DATA` environment variable:
-
   ```
-  export SHELLEY_TEST_DATA=$DIR/lib/shelley/test/data/cardano-node-shelley
+  export SHELLEY_TEST_DATA=plutus-pab/local-cluster/cluster-data/cardano-node-shelley
   ```
 
 3. Run the local cluster:

--- a/plutus-pab/src/Cardano/Node/Client.hs
+++ b/plutus-pab/src/Cardano/Node/Client.hs
@@ -58,9 +58,15 @@ handleNodeClientClient params e = do
                   -- need to be sent via the wallet, not the mocked server node
                   -- (which is not actually running).
                   throwError TxSenderNotAvailable
-              Just handle -> liftIO $ onCardanoTx (MockClient.queueTx handle) (const $ error "Cardano.Node.Client: Expecting a mock tx, not an Alonzo tx when publishing it.") tx
+              Just handle ->
+                  liftIO $
+                      onCardanoTx (MockClient.queueTx handle)
+                                  (const $ error "Cardano.Node.Client: Expecting a mock tx, not an Alonzo tx when publishing it.")
+                                  tx
         GetClientSlot ->
-            either (liftIO . MockClient.getCurrentSlot) (liftIO . Client.getCurrentSlot) chainSyncHandle
+            either (liftIO . MockClient.getCurrentSlot)
+                   (liftIO . Client.getCurrentSlot)
+                   chainSyncHandle
         GetClientParams -> pure params
 
 -- | This does not seem to support resuming so it means that the slot tick will

--- a/plutus-pab/src/Plutus/PAB/Core.hs
+++ b/plutus-pab/src/Plutus/PAB/Core.hs
@@ -548,10 +548,11 @@ yieldedExportTxs instanceId = do
 
 currentSlot :: forall t env. PABAction t env (STM Slot)
 currentSlot = do
-    Instances.BlockchainEnv{Instances.beCurrentSlot} <- asks @(PABEnvironment t env) blockchainEnv
-    pure $ STM.readTVar beCurrentSlot
+    be <- asks @(PABEnvironment t env) blockchainEnv
+    pure $ Instances.currentSlot be
 
--- | Wait until the target slot number has been reached
+-- | Wait until the target slot number has been reached relative to the current
+-- slot.
 waitUntilSlot :: forall t env. Slot -> PABAction t env ()
 waitUntilSlot targetSlot = do
     tx <- currentSlot
@@ -559,6 +560,7 @@ waitUntilSlot targetSlot = do
         s <- tx
         guard (s >= targetSlot)
 
+-- | Wait for a certain number of slots relative to the current slot.
 waitNSlots :: forall t env. Int -> PABAction t env ()
 waitNSlots i = do
     current <- currentSlot >>= liftIO . STM.atomically
@@ -645,7 +647,7 @@ handleInstancesStateReader = \case
     Ask -> asks @(PABEnvironment t env) instancesState
 
 -- | Handle the 'TimeEffect' by reading the current slot number from
---   the blockchain env.
+-- the blockchain env.
 handleTimeEffect ::
     forall t env m effs.
     ( Member (Reader (PABEnvironment t env)) effs
@@ -656,6 +658,5 @@ handleTimeEffect ::
     ~> Eff effs
 handleTimeEffect = \case
     SystemTime -> do
-        Instances.BlockchainEnv{Instances.beCurrentSlot} <- asks @(PABEnvironment t env) blockchainEnv
-        liftIO $ STM.readTVarIO beCurrentSlot
-
+        be <- asks @(PABEnvironment t env) blockchainEnv
+        liftIO $ STM.atomically $ Instances.currentSlot be

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
@@ -14,7 +14,6 @@ import Cardano.Api (BlockInMode (..), ChainPoint (..))
 import Cardano.Api qualified as C
 import Cardano.Api.NetworkId.Extra (NetworkIdWrapper (NetworkIdWrapper))
 import Cardano.Node.Params qualified as Params
-import Cardano.Node.Types (NodeMode (..))
 import Cardano.Protocol.Socket.Client (ChainSyncEvent (..))
 import Cardano.Protocol.Socket.Client qualified as Client
 import Cardano.Protocol.Socket.Mock.Client qualified as MockClient
@@ -30,7 +29,8 @@ import Plutus.Trace.Emulator.ContractInstance (IndexedBlock (..), indexBlock)
 import Plutus.PAB.Types (Config (Config), DevelopmentOptions (DevelopmentOptions, pabResumeFrom, pabRollbackHistory),
                          developmentOptions, nodeServerConfig)
 
-import Cardano.Node.Types (PABServerConfig (PABServerConfig, pscNetworkId, pscNodeMode, pscSlotConfig, pscSocketPath))
+import Cardano.Node.Types (NodeMode (..),
+                           PABServerConfig (PABServerConfig, pscNetworkId, pscNodeMode, pscSlotConfig, pscSocketPath))
 import Control.Concurrent.STM (STM)
 import Control.Concurrent.STM qualified as STM
 import Control.Lens
@@ -38,6 +38,7 @@ import Control.Monad (forM_, void, when)
 import Control.Tracer (nullTracer)
 import Data.Foldable (foldl')
 import Data.Maybe (catMaybes, maybeToList)
+import Ledger.TimeSlot qualified as TimeSlot
 import Plutus.ChainIndex (BlockNumber (..), ChainIndexTx (..), ChainIndexTxOutputs (..), Depth (..),
                           InsertUtxoFailed (..), InsertUtxoSuccess (..), Point (..), ReduceBlockCountResult (..),
                           RollbackFailed (..), RollbackResult (..), Tip (..), TxConfirmedState (..), TxIdState (..),
@@ -64,11 +65,16 @@ startNodeClient config instancesState = do
     case pscNodeMode of
       MockNode -> do
         void $ MockClient.runChainSync socket slotConfig
-            (\block slot -> handleSyncAction $ processMockBlock instancesState env block slot)
+            (\block slot -> do STM.atomically $ STM.writeTVar (beCurrentSlot env) slot
+                               handleSyncAction $ processMockBlock instancesState env block slot
+            )
       AlonzoNode -> do
         let resumePoints = maybeToList $ toCardanoPoint resumePoint
         void $ Client.runChainSync socket nullTracer slotConfig networkId resumePoints
-          (\block -> handleSyncAction $ processChainSyncEvent instancesState env block)
+            (\block -> do slot <- TimeSlot.currentSlot slotConfig
+                          STM.atomically $ STM.writeTVar (beCurrentSlot env) slot
+                          handleSyncAction $ processChainSyncEvent instancesState env block
+            )
     pure env
 
 -- | Deal with sync action failures from running this STM action. For now, we
@@ -81,7 +87,7 @@ handleSyncAction action = do
     Right (Slot s, BlockNumber n) -> do
       stdGen <- newStdGen
       when (fst (randomR (0 :: Int, 10_000) stdGen) == 0) $
-        putStrLn $ "Current block: " <> show n <> ". Current slot: " <> show s
+        putStrLn $ "Current synced block: " <> show n <> ". Current synced slot: " <> show s
   either (error . show) (const $ pure ()) result
 
 updateInstances :: IndexedBlock -> InstanceClientEnv -> STM ()
@@ -92,8 +98,8 @@ updateInstances IndexedBlock{ibUtxoSpent, ibUtxoProduced} InstanceClientEnv{ceUt
     traverse (\OpenTxOutProducedRequest{otxProducingTxns} -> STM.tryPutTMVar otxProducingTxns txns) requests
 
 blockAndSlot :: BlockchainEnv -> STM (Slot, BlockNumber)
-blockAndSlot BlockchainEnv{beCurrentBlock, beCurrentSlot} =
-  (,) <$> STM.readTVar beCurrentSlot <*> STM.readTVar beCurrentBlock
+blockAndSlot BlockchainEnv{beLastSyncedBlockNo, beLastSyncedBlockSlot} =
+  (,) <$> STM.readTVar beLastSyncedBlockSlot <*> STM.readTVar beLastSyncedBlockNo
 
 -- | Process a chain sync event that we receive from the alonzo node client
 processChainSyncEvent
@@ -123,8 +129,8 @@ data SyncActionFailure
 
 -- | Roll back the chain to the given ChainPoint and slot.
 runRollback :: BlockchainEnv -> ChainPoint -> STM (Either SyncActionFailure (Slot, BlockNumber))
-runRollback env@BlockchainEnv{beCurrentSlot, beTxChanges, beTxOutChanges} chainPoint = do
-  currentSlot <- STM.readTVar beCurrentSlot
+runRollback env@BlockchainEnv{beLastSyncedBlockSlot, beTxChanges, beTxOutChanges} chainPoint = do
+  currentSlot <- STM.readTVar beLastSyncedBlockSlot
   txIdStateIndex <- STM.readTVar beTxChanges
   txOutBalanceStateIndex <- STM.readTVar beTxOutChanges
 
@@ -166,7 +172,7 @@ processBlock :: forall era. C.IsCardanoEra era
              -> STM (Either SyncActionFailure (Slot, BlockNumber))
 processBlock instancesState header env transactions era = do
   let C.BlockHeader (C.SlotNo slot) _ _ = header
-  STM.writeTVar (beCurrentSlot env) (fromIntegral slot)
+  STM.writeTVar (beLastSyncedBlockSlot env) (fromIntegral slot)
   if null transactions
      then Right <$> blockAndSlot env
      else do
@@ -188,12 +194,12 @@ updateTransactionState
   -> BlockchainEnv
   -> t (TxId, TxOutBalance, TxValidity)
   -> STM (Either SyncActionFailure (Slot, BlockNumber))
-updateTransactionState tip env@BlockchainEnv{beRollbackHistory, beTxChanges, beTxOutChanges, beCurrentBlock} xs = do
+updateTransactionState tip env@BlockchainEnv{beRollbackHistory, beTxChanges, beTxOutChanges, beLastSyncedBlockNo} xs = do
     txIdStateIndex <- STM.readTVar beTxChanges
     let txIdState = _usTxUtxoData $ utxoState txIdStateIndex
     txUtxoBalanceIndex <- STM.readTVar beTxOutChanges
     let txUtxoBalance = _usTxUtxoData $ utxoState txUtxoBalanceIndex
-    blockNumber <- STM.readTVar beCurrentBlock
+    blockNumber <- STM.readTVar beLastSyncedBlockNo
     let txIdState' = foldl' (insertNewTx blockNumber) txIdState xs
         txIdStateInsert  = insert (UtxoState txIdState' tip) txIdStateIndex
         txUtxoBalance' = txUtxoBalance <> foldMap (\(_, b, _) -> b) xs
@@ -203,7 +209,7 @@ updateTransactionState tip env@BlockchainEnv{beRollbackHistory, beTxChanges, beT
       (Right InsertUtxoSuccess{newIndex=newTxIdState}, Right InsertUtxoSuccess{newIndex=newTxOutBalance}) -> do -- TODO: Get tx out status another way
         STM.writeTVar beTxChanges    $ trimIx beRollbackHistory newTxIdState
         STM.writeTVar beTxOutChanges $ trimIx beRollbackHistory newTxOutBalance
-        STM.writeTVar beCurrentBlock (succ blockNumber)
+        STM.writeTVar beLastSyncedBlockNo (succ blockNumber)
         Right <$> blockAndSlot env
       (Left e, _) -> pure $ Left $ InsertUtxoStateFailure e
       (_, Left e) -> pure $ Left $ InsertUtxoStateFailure e
@@ -231,17 +237,17 @@ insertNewTx blockNumber TxIdState{txnsConfirmed, txnsDeleted} (txi, _, txValidit
 -- | Go through the transactions in a block, updating the 'BlockchainEnv'
 --   when any interesting addresses or transactions have changed.
 processMockBlock :: InstancesState -> BlockchainEnv -> Block -> Slot -> STM (Either SyncActionFailure (Slot, BlockNumber))
-processMockBlock instancesState env@BlockchainEnv{beCurrentSlot, beCurrentBlock} transactions slot = do
-  lastSlot <- STM.readTVar beCurrentSlot
+processMockBlock instancesState env@BlockchainEnv{beLastSyncedBlockSlot, beLastSyncedBlockNo} transactions slot = do
+  lastSlot <- STM.readTVar beLastSyncedBlockSlot
   when (slot > lastSlot) $ do
-    STM.writeTVar beCurrentSlot slot
+    STM.writeTVar beLastSyncedBlockSlot slot
 
   if null transactions
      then do
-       result <- (,) <$> STM.readTVar beCurrentSlot <*> STM.readTVar beCurrentBlock
+       result <- (,) <$> STM.readTVar beLastSyncedBlockSlot <*> STM.readTVar beLastSyncedBlockNo
        pure $ Right result
      else do
-      blockNumber <- STM.readTVar beCurrentBlock
+      blockNumber <- STM.readTVar beLastSyncedBlockNo
 
       instEnv <- S.instancesClientEnv instancesState
       updateInstances (indexBlock $ fmap fromOnChainTx transactions) instEnv


### PR DESCRIPTION
Should fix #451 and #473 

* Reorganized the placement of some functions

* Fixed the `awaitSlot` blockchain action in `plutus-pab` as it wasn't
  working. It was using as reference the slot of the last synced block
  instead of the actual current slot.

* Patched temporarly the PubKey contract so that it waits a bit before
  querying the chain-index. In the future, once we fix the discrepancy
  between information shared between plutus-pab and plutus-chain-index,
  this should be removed.

* Fixed the number of events that are processed by plutus-chain-index
  once we are in sync with the local node. The reason is that once we
  are fully in sync with the local node, we want to process as much
  information as possible and not wait for the queue to be filled.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
