### PR TITLE
PLT-106: Read Env from node config file for streamer

### DIFF
--- a/plutus-streaming/README.md
+++ b/plutus-streaming/README.md
@@ -38,5 +38,5 @@ $ cabal run -- plutus-streaming-example-1 --socket-path /tmp/node.socket --mainn
 Passing a starting point
 
 ```
-$ cabal run -- plutus-streaming-example-1 --socket-path /tmp/node.socket --slot-no 53427524 --block-hash 5e2bde4e504a9888a4f218dafc79a7619083f97d48684fcdba9dc78190df8f99
+$ cabal run -- plutus-streaming-example-1 --config /tmp/mainnet-config.json --socket-path /tmp/node.socket --slot-no 53427524 --block-hash 5e2bde4e504a9888a4f218dafc79a7619083f97d48684fcdba9dc78190df8f99
 ```

--- a/plutus-streaming/examples/Common.hs
+++ b/plutus-streaming/examples/Common.hs
@@ -15,7 +15,8 @@ import Streaming.Prelude qualified as S
 --
 
 data Options = Options
-  { optionsSocketPath :: String,
+  { optionsConfigPath :: String,
+    optionsSocketPath :: String,
     optionsNetworkId  :: Cardano.Api.NetworkId,
     optionsChainPoint :: Cardano.Api.ChainPoint
   }
@@ -24,7 +25,8 @@ data Options = Options
 optionsParser :: Parser Options
 optionsParser =
   Options
-    <$> strOption (long "socket-path" <> help "Node socket path")
+    <$> strOption (long "config" <> help "Node socket path")
+    <*> strOption (long "socket-path" <> help "Node socket path")
     <*> networkIdParser
     <*> chainPointParser
 
@@ -74,4 +76,3 @@ workaround k Cardano.Api.ShelleyEraInCardanoMode = k Cardano.Api.ShelleyEraInCar
 workaround k Cardano.Api.AllegraEraInCardanoMode = k Cardano.Api.AllegraEraInCardanoMode
 workaround k Cardano.Api.MaryEraInCardanoMode    = k Cardano.Api.MaryEraInCardanoMode
 workaround k Cardano.Api.AlonzoEraInCardanoMode  = k Cardano.Api.AlonzoEraInCardanoMode
-

--- a/plutus-streaming/examples/Example1.hs
+++ b/plutus-streaming/examples/Example1.hs
@@ -1,7 +1,8 @@
 module Main where
 
 import Cardano.Api qualified
-import Common (Options (Options, optionsChainPoint, optionsNetworkId, optionsSocketPath), parseOptions)
+import Common (Options (Options, optionsChainPoint, optionsConfigPath, optionsNetworkId, optionsSocketPath),
+               parseOptions)
 import Data.Aeson.Text qualified as Aeson
 import Data.Text.Lazy qualified as TL
 import Orphans ()
@@ -14,9 +15,9 @@ import Streaming.Prelude qualified as S
 
 main :: IO ()
 main = do
-  Options {optionsSocketPath, optionsNetworkId, optionsChainPoint} <- parseOptions
+  Options {optionsConfigPath, optionsSocketPath, optionsNetworkId, optionsChainPoint} <- parseOptions
 
-  withChainSyncEventStream optionsSocketPath optionsNetworkId optionsChainPoint $
+  withChainSyncEventStream optionsConfigPath optionsSocketPath optionsNetworkId optionsChainPoint $
     S.stdoutLn
       . S.map
         ( \case

--- a/plutus-streaming/examples/Example2.hs
+++ b/plutus-streaming/examples/Example2.hs
@@ -1,8 +1,8 @@
 module Main where
 
 import Cardano.Api qualified
-import Common (Options (Options, optionsChainPoint, optionsNetworkId, optionsSocketPath), parseOptions, printJson,
-               workaround)
+import Common (Options (Options, optionsChainPoint, optionsConfigPath, optionsNetworkId, optionsSocketPath),
+               parseOptions, printJson, workaround)
 import Data.Foldable (toList)
 import Ledger qualified
 import Orphans ()
@@ -43,9 +43,9 @@ datums tx = do
 
 main :: IO ()
 main = do
-  Options {optionsSocketPath, optionsNetworkId, optionsChainPoint} <- parseOptions
+  Options {optionsConfigPath, optionsSocketPath, optionsNetworkId, optionsChainPoint} <- parseOptions
 
-  withChainSyncEventStream optionsSocketPath optionsNetworkId optionsChainPoint $
+  withChainSyncEventStream optionsConfigPath optionsSocketPath optionsNetworkId optionsChainPoint $
     printJson
       . S.map -- Each ChainSyncEvent
         ( fmap -- Inside the payload of RollForward events

--- a/plutus-streaming/examples/Example3.hs
+++ b/plutus-streaming/examples/Example3.hs
@@ -1,7 +1,8 @@
 module Main where
 
 import Cardano.Api qualified
-import Common (Options (Options, optionsChainPoint, optionsNetworkId, optionsSocketPath), parseOptions)
+import Common (Options (Options, optionsChainPoint, optionsConfigPath, optionsNetworkId, optionsSocketPath),
+               parseOptions)
 import Plutus.ChainIndex (TxUtxoBalance)
 import Plutus.ChainIndex.Compatibility qualified as CI
 import Plutus.ChainIndex.TxUtxoBalance qualified as TxUtxoBalance
@@ -47,7 +48,7 @@ utxoState =
 
 main :: IO ()
 main = do
-  Options {optionsSocketPath, optionsNetworkId, optionsChainPoint} <- parseOptions
+  Options {optionsConfigPath, optionsSocketPath, optionsNetworkId, optionsChainPoint} <- parseOptions
 
-  withChainSyncEventStream optionsSocketPath optionsNetworkId optionsChainPoint $
+  withChainSyncEventStream optionsConfigPath optionsSocketPath optionsNetworkId optionsChainPoint $
     S.print . utxoState

--- a/plutus-streaming/plutus-streaming.cabal
+++ b/plutus-streaming/plutus-streaming.cabal
@@ -42,6 +42,8 @@ library
         ouroboros-network,
         stm,
         streaming,
+        text,
+        transformers,
 
 executable plutus-streaming-example-1
     import: lang


### PR DESCRIPTION
cardano-api does not expose `readNetworkConfig` but we can use `initialLedgerState` and discard the `LedgerState`, which doesn't really do any extra work if we don't need the `LedgerState`. This is better than hardcoding - using the wrong `EpochSlots` could cause blocks to have the wrong `SlotNo`s.