### PR TITLE
PLT-106: Add an executable for dumping script evaluation events

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,6 +14,7 @@ packages: doc
           plutus-pab
           plutus-pab-executables
           plutus-playground-server
+          plutus-script-evaluation-test
           plutus-script-utils
           plutus-tx-constraints
           plutus-use-cases

--- a/plutus-script-evaluation-test/dump-script-events/Main.hs
+++ b/plutus-script-evaluation-test/dump-script-events/Main.hs
@@ -1,0 +1,20 @@
+module Main (main) where
+
+import Options.Applicative qualified as O
+import Plutus.Script.Evaluation.Dump (dumpScriptEvents)
+import Plutus.Script.Evaluation.Options (parserInfo)
+
+{-
+Example:
+
+cabal v2-run plutus-script-evaluation-test:dump-script-events -- \
+  --socket-path $HOME/cardano/db/node.socket \
+  --config $HOME/cardano/mainnet-config.json \
+  --mainnet \
+  --blocks-per-file 2000 \
+  --dir $HOME/cardano-dump
+
+-}
+
+main :: IO ()
+main = dumpScriptEvents =<< O.execParser parserInfo

--- a/plutus-script-evaluation-test/plutus-script-evaluation-test.cabal
+++ b/plutus-script-evaluation-test/plutus-script-evaluation-test.cabal
@@ -1,0 +1,61 @@
+cabal-version:      2.4
+name:               plutus-script-evaluation-test
+version:            0.1.0.0
+
+common lang
+    default-language: Haskell2010
+    default-extensions:
+        DeriveFoldable
+        DeriveFunctor
+        DeriveGeneric
+        DeriveLift
+        DeriveTraversable
+        ExplicitForAll
+        GeneralizedNewtypeDeriving
+        ImportQualifiedPost
+        LambdaCase
+        NamedFieldPuns
+        ScopedTypeVariables
+        StandaloneDeriving
+    ghc-options:
+        -Wall
+        -Widentities
+        -Wincomplete-record-updates
+        -Wincomplete-uni-patterns
+        -Wmissing-import-lists
+        -Wnoncanonical-monad-instances
+        -Wredundant-constraints
+        -Wunused-packages
+
+library testlib
+    import: lang
+    hs-source-dirs:   testlib
+    exposed-modules:
+        Plutus.Script.Evaluation.Dump
+        Plutus.Script.Evaluation.Options
+        Plutus.Script.Evaluation.Types
+    build-depends:
+        PyF,
+        base >=4.9 && <5,
+        base16-bytestring,
+        cardano-api,
+        cardano-binary,
+        cardano-ledger-alonzo,
+        extra,
+        filepath,
+        optparse-applicative,
+        plutus-streaming,
+        serialise,
+        streaming,
+        text,
+        time,
+        transformers
+
+executable dump-script-events
+    import: lang
+    hs-source-dirs:   dump-script-events
+    main-is:          Main.hs
+    build-depends:
+        base >=4.9 && <5,
+        optparse-applicative,
+        testlib

--- a/plutus-script-evaluation-test/testlib/Plutus/Script/Evaluation/Dump.hs
+++ b/plutus-script-evaluation-test/testlib/Plutus/Script/Evaluation/Dump.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
+module Plutus.Script.Evaluation.Dump
+  (dumpScriptEvents
+  ) where
+
+import Cardano.Api qualified as Cardano
+import Codec.Serialise qualified as CBOR
+import Control.Exception (handle, throwIO)
+import Control.Monad (unless)
+import Control.Monad.Trans.Except (runExceptT)
+import Control.Monad.Trans.State (evalStateT, get, put)
+import Data.ByteString.Base16 qualified as B16
+import Data.Foldable (traverse_)
+import Data.List (sortBy)
+import Data.Maybe (mapMaybe)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Data.Time.Clock (getCurrentTime)
+import Data.Time.Format.ISO8601 (iso8601Show)
+import Data.Word (Word64)
+import Plutus.Script.Evaluation.Options qualified as O
+import Plutus.Script.Evaluation.Types (Block, Checkpoint (Checkpoint), ScriptEvent, ScriptM,
+                                       StreamerState (StreamerState, ssCount, ssEvents))
+import Plutus.Streaming (ApplyBlockException, ChainSyncEvent (RollBackward, RollForward), ledgerStateEvents,
+                         withChainSyncEventStream)
+import PyF (fmt)
+import Streaming (MFunctor (hoist), MonadIO (liftIO), Of, Stream)
+import Streaming.Prelude qualified as S
+import System.Directory.Extra (listFiles, removeFile)
+import System.FilePath (isExtensionOf, takeBaseName, (<.>), (</>))
+import System.IO (hPrint, stderr)
+
+-- | Stream blocks from a local node, and periodically dump ledger events
+-- and checkpoint ledger state.
+dumpScriptEvents :: O.Options -> IO ()
+dumpScriptEvents opts = do
+  (env, ledgerStateAtGenesis) <-
+    either (fail . Text.unpack . Cardano.renderInitialLedgerStateError) pure
+      =<< runExceptT (Cardano.initialLedgerState (O.optsConfigPath opts))
+  let dir = O.optsDir opts
+      go :: [FilePath] -> IO ()
+      go fps = do
+        (chainPoint, ledgerState, onApplyBlockException) <- case fps of
+          -- No checkpoint to use, so start from Genesis.
+          [] -> pure (Cardano.ChainPointAtGenesis, ledgerStateAtGenesis, throwIO)
+          -- Try the latest checkpoint, and if we get an `ApplyBlockException` (which likely
+          -- means the checkpointed block was rolled back), try the next one.
+          latestStateFile : rest -> do
+            Checkpoint chainPoint ledgerState <- CBOR.readFileDeserialise latestStateFile
+            cleanupStateAndEventFiles dir latestStateFile
+            putStrLn
+              [fmt|
+Starting from checkpoint in {latestStateFile}
+  slot: {maybe "Genesis" show (Cardano.chainPointToSlotNo chainPoint)}
+  hash: {maybe "Genesis" renderBlockHash (Cardano.chainPointToHeaderHash chainPoint)}
+|]
+            pure (chainPoint, ledgerState, \(e :: ApplyBlockException) -> hPrint stderr e >> go rest)
+
+        handle onApplyBlockException
+          . withChainSyncEventStream
+            (O.optsSocketPath opts)
+            (O.optsNetworkId opts)
+            chainPoint
+          $ \blockStream -> do
+            let eventStream ::
+                  Stream
+                    (Of (ChainSyncEvent Block, (Cardano.LedgerState, [Cardano.LedgerEvent])))
+                    ScriptM
+                    ()
+                eventStream =
+                  hoist liftIO $
+                    ledgerStateEvents env ledgerState Cardano.QuickValidation blockStream
+            flip evalStateT (StreamerState 0 []) $
+              runStream dir (O.optsBlocksPerFile opts) (O.optsEventsPerFile opts) eventStream
+
+  go =<< listStateFiles dir
+
+runStream ::
+  forall r.
+  FilePath ->
+  -- | Blocks per file
+  Word64 ->
+  -- | Events per file
+  Word64 ->
+  Stream
+    (Of (ChainSyncEvent Block, (Cardano.LedgerState, [Cardano.LedgerEvent])))
+    ScriptM
+    r ->
+  ScriptM r
+runStream dir blocksPerFile eventsPerFile stream = do
+  S.mapM_ (uncurry (uncurry . checkpoint)) stream
+  where
+    checkpoint :: ChainSyncEvent Block -> Cardano.LedgerState -> [Cardano.LedgerEvent] -> ScriptM ()
+    checkpoint ev ledgerState ledgerEvents = case ev of
+      RollForward block _tip -> do
+        streamerState <- get
+        if ssCount streamerState >= blocksPerFile ||
+              fromIntegral (length (ssEvents streamerState)) >= eventsPerFile
+          then do
+            time <- liftIO getCurrentTime
+            let eventFile = dir </> iso8601Show time <.> eventsFileExt
+            let scriptEvents = ssEvents streamerState
+            unless (null scriptEvents) . liftIO $ CBOR.writeFileSerialise eventFile scriptEvents
+            -- Writing state (checkpoint) file after events file ensures the events of a
+            -- checkpoint are persisted.
+            let stateFile = dir </> iso8601Show time <.> stateFileExt
+                chainPoint = blockChainPoint block
+            liftIO $ CBOR.writeFileSerialise stateFile (Checkpoint chainPoint ledgerState)
+            put $ StreamerState 0 []
+            liftIO $
+              putStrLn
+                [fmt|
+Created new checkpoint in {stateFile}
+  number of blocks: {ssCount streamerState}
+  number of ledger events: {length ledgerEvents}
+  number of script evaluation events: {length scriptEvents}
+  slot: {maybe "Genesis" show (Cardano.chainPointToSlotNo chainPoint)}
+  hash: {maybe "Genesis" renderBlockHash (Cardano.chainPointToHeaderHash chainPoint)}
+|]
+          else do
+            put $
+              streamerState
+                { ssEvents = mapMaybe toScriptEvent ledgerEvents ++ ssEvents streamerState,
+                  ssCount = ssCount streamerState + 1
+                }
+      RollBackward {} ->
+        -- Nothing special needs to be done on `RollBackward`, since there's no harm
+        -- dumping events in blocks that are rolled back. In fact it's a good thing - it
+        -- gives us more data to test with.
+        pure ()
+
+stateFileExt, eventsFileExt :: String
+stateFileExt = "state"
+eventsFileExt = "event"
+
+blockChainPoint :: Block -> Cardano.ChainPoint
+blockChainPoint (Cardano.BlockInMode (Cardano.Block (Cardano.BlockHeader slot hash _) _) _) =
+  Cardano.ChainPoint slot hash
+
+toScriptEvent :: Cardano.LedgerEvent -> Maybe ScriptEvent
+toScriptEvent = error "Not implemented: need https://github.com/input-output-hk/cardano-node/pull/3984"
+  -- \case
+  --   Cardano.SuccessfulPlutusScript ds -> Just (ScriptEventSuccess ds)
+  --   Cardano.FailedPlutusScript ds     -> Just (ScriptEventFailure ds)
+  --   _                                 -> Nothing
+
+listStateFiles :: FilePath -> IO [FilePath]
+listStateFiles =
+  fmap (sortBy (flip compare) . filter (stateFileExt `isExtensionOf`)) . listFiles
+
+-- | Remove the state and event files whose timestamps are greater than the given state file
+cleanupStateAndEventFiles :: FilePath -> FilePath -> IO ()
+cleanupStateAndEventFiles dir stateFile = do
+  newerStateAndEventFiles <-
+    takeWhile (\f -> takeBaseName f > takeBaseName stateFile)
+      . filter (\f -> stateFileExt `isExtensionOf` f || eventsFileExt `isExtensionOf` f)
+      <$> listFiles dir
+  traverse_ removeFile newerStateAndEventFiles
+
+renderBlockHash :: Cardano.Hash Cardano.BlockHeader -> Text.Text
+renderBlockHash = Text.decodeLatin1 . B16.encode . Cardano.serialiseToRawBytes

--- a/plutus-script-evaluation-test/testlib/Plutus/Script/Evaluation/Options.hs
+++ b/plutus-script-evaluation-test/testlib/Plutus/Script/Evaluation/Options.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE ApplicativeDo   #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StrictData      #-}
+
+module Plutus.Script.Evaluation.Options (Options (..),
+  options,
+  parserInfo) where
+
+import Cardano.Api qualified as Cardano
+import Data.Word (Word64)
+import Options.Applicative qualified as O
+
+data Options = Options
+  { optsConfigPath    :: FilePath,
+    optsSocketPath    :: FilePath,
+    optsNetworkId     :: Cardano.NetworkId,
+    optsBlocksPerFile :: Word64,
+    optsEventsPerFile :: Word64,
+    optsDir           :: FilePath
+  }
+  deriving (Show)
+
+options :: O.Parser Options
+options = do
+  optsSocketPath <-
+    O.strOption $
+      mconcat
+        [ O.long "socket-path",
+          O.metavar "SOCKET_PATH",
+          O.help "Node socket path"
+        ]
+  optsConfigPath <-
+    O.strOption $
+      mconcat
+        [ O.long "config",
+          O.metavar "CONFIG_PATH",
+          O.help "Node config path"
+        ]
+  optsNetworkId <- networkIdParser
+  optsBlocksPerFile <-
+    O.option O.auto $
+      mconcat
+        [ O.long "blocks-per-file",
+          O.metavar "BLOCKS_PER_FILE",
+          O.help "Write events in this many blocks per file (unless events-per-file is exceeded)"
+        ]
+  optsEventsPerFile <-
+    O.option O.auto $
+      mconcat
+        [ O.long "events-per-file",
+          O.metavar "EVENTS_PER_FILE",
+          O.value maxBound,
+          O.help "Write approximately this many events per file (unless blocks-per-file is exceeded)"
+        ]
+  optsDir <-
+    O.strOption $
+      mconcat
+        [ O.short 'd',
+          O.long "dir",
+          O.metavar "DIR",
+          O.help "Data dump directory"
+        ]
+  pure Options {..}
+
+parserInfo :: O.ParserInfo Options
+parserInfo =
+      O.info
+        (options O.<**> O.helper)
+        mempty
+
+networkIdParser :: O.Parser Cardano.NetworkId
+networkIdParser =
+  pMainnet' O.<|> fmap Cardano.Testnet testnetMagicParser
+  where
+    pMainnet' :: O.Parser Cardano.NetworkId
+    pMainnet' =
+      O.flag'
+        Cardano.Mainnet
+        $ mconcat
+          [ O.long "mainnet",
+            O.help "Use the mainnet magic id."
+          ]
+
+testnetMagicParser :: O.Parser Cardano.NetworkMagic
+testnetMagicParser =
+  Cardano.NetworkMagic
+    <$> ( O.option
+            O.auto
+            $ mconcat
+              [ O.long "testnet-magic",
+                O.metavar "NATURAL",
+                O.help "Specify a testnet magic id."
+              ]
+        )

--- a/plutus-script-evaluation-test/testlib/Plutus/Script/Evaluation/Types.hs
+++ b/plutus-script-evaluation-test/testlib/Plutus/Script/Evaluation/Types.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE StrictData       #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Plutus.Script.Evaluation.Types
+  ( ScriptEvent (..),
+    Checkpoint (..),
+    StreamerState (..),
+    ScriptM,
+    Block,
+    encodeChainPoint,
+    decodeChainPoint,
+  )
+where
+
+import Cardano.Api qualified as Cardano
+import Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (toCBOR))
+import Cardano.Ledger.Alonzo.TxInfo qualified as Alonzo
+import Codec.Serialise qualified as CBOR
+import Codec.Serialise.Decoding qualified as CBOR
+import Codec.Serialise.Encoding qualified as CBOR
+import Control.Monad.Trans.State (StateT)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Proxy (Proxy (Proxy))
+import Data.Word (Word64)
+
+-- | A script evaluation that happens on-chain, which either succeeded or failed.
+data ScriptEvent
+  = ScriptEventSuccess [Alonzo.PlutusDebug]
+  | ScriptEventFailure (NonEmpty Alonzo.PlutusDebug)
+
+instance CBOR.Serialise ScriptEvent where
+  encode = \case
+    ScriptEventSuccess ds -> CBOR.encodeListLen 2 <> CBOR.encodeWord 0 <> toCBOR ds
+    ScriptEventFailure ds -> CBOR.encodeListLen 2 <> CBOR.encodeWord 1 <> toCBOR ds
+
+  decode = do
+    CBOR.decodeListLenOf 2
+    CBOR.decodeWord >>= \case
+      0 -> ScriptEventSuccess <$> fromCBOR
+      1 -> ScriptEventFailure <$> fromCBOR
+      _ -> fail "unknown tag"
+
+-- | A checkpoint from which the streamer can resume.
+data Checkpoint = Checkpoint
+  { cChainPoint  :: Cardano.ChainPoint,
+    cLedgerState :: Cardano.LedgerState
+  }
+
+instance CBOR.Serialise Checkpoint where
+  encode (Checkpoint _chainPoint _ledgerState) =
+    error "Not implemented: need https://github.com/input-output-hk/cardano-node/pull/3993"
+    -- mconcat
+    --   [CBOR.encodeListLen 2, encodeChainPoint chainPoint, Cardano.encodeLedgerState ledgerState]
+  decode =
+    error "Not implemented: need https://github.com/input-output-hk/cardano-node/pull/3993"
+    -- do
+    --   CBOR.decodeListLenOf 2
+    --   Checkpoint <$> decodeChainPoint <*> Cardano.decodeLedgerState
+
+encodeChainPoint :: Cardano.ChainPoint -> CBOR.Encoding
+encodeChainPoint p = CBOR.encode $ case p of
+  Cardano.ChainPointAtGenesis  -> Nothing
+  Cardano.ChainPoint slot hash -> Just (slot, Cardano.serialiseToRawBytes hash)
+
+decodeChainPoint :: CBOR.Decoder s Cardano.ChainPoint
+decodeChainPoint =
+  CBOR.decode >>= \case
+    Nothing -> pure Cardano.ChainPointAtGenesis
+    Just (slot, hashRawBytes) ->
+      maybe
+        (fail "decodeChainPoint: Unable to decode block hash")
+        (pure . Cardano.ChainPoint slot)
+        ( Cardano.deserialiseFromRawBytes
+            (Cardano.proxyToAsType (Proxy @(Cardano.Hash Cardano.BlockHeader)))
+            hashRawBytes
+        )
+
+-- | State we maintain when consuming the stream of ledger state and events
+data StreamerState = StreamerState
+  { ssCount  :: Word64,
+    ssEvents :: [ScriptEvent]
+  }
+
+type ScriptM = StateT StreamerState IO
+
+type Block = Cardano.BlockInMode Cardano.CardanoMode

--- a/plutus-streaming/plutus-streaming.cabal
+++ b/plutus-streaming/plutus-streaming.cabal
@@ -39,9 +39,11 @@ library
         base >=4.9 && <5,
         async,
         cardano-api,
+        containers,
         ouroboros-network,
         stm,
         streaming,
+        text
 
 executable plutus-streaming-example-1
     import: lang

--- a/plutus-streaming/src/Plutus/Streaming.hs
+++ b/plutus-streaming/src/Plutus/Streaming.hs
@@ -1,25 +1,33 @@
 module Plutus.Streaming
   ( withChainSyncEventStream,
+    ledgerStateEvents,
     ChainSyncEvent (..),
     ChainSyncEventException (..),
+    ApplyBlockException (..),
   )
 where
 
-import Cardano.Api (BlockInMode, CardanoMode, ChainPoint, ChainSyncClient (ChainSyncClient), ChainTip,
-                    ConsensusModeParams (CardanoModeParams), EpochSlots (EpochSlots),
-                    LocalChainSyncClient (LocalChainSyncClient),
+import Cardano.Api (Block (Block), BlockHeader (BlockHeader), BlockInMode (BlockInMode), CardanoMode,
+                    ChainPoint (ChainPoint, ChainPointAtGenesis), ChainSyncClient (ChainSyncClient), ChainTip,
+                    ConsensusModeParams (CardanoModeParams), Env, EpochSlots (EpochSlots), LedgerEvent, LedgerState,
+                    LedgerStateError, LocalChainSyncClient (LocalChainSyncClient),
                     LocalNodeClientProtocols (LocalNodeClientProtocols, localChainSyncClient, localStateQueryClient, localTxSubmissionClient),
                     LocalNodeConnectInfo (LocalNodeConnectInfo, localConsensusModeParams, localNodeNetworkId, localNodeSocketPath),
-                    NetworkId, connectToLocalNode)
+                    NetworkId, SlotNo, ValidationMode, applyBlock, connectToLocalNode, envSecurityParam,
+                    renderLedgerStateError)
 import Cardano.Api.ChainSync.Client (ClientStIdle (SendMsgFindIntersect, SendMsgRequestNext),
                                      ClientStIntersect (ClientStIntersect, recvMsgIntersectFound, recvMsgIntersectNotFound),
                                      ClientStNext (ClientStNext, recvMsgRollBackward, recvMsgRollForward))
 import Control.Concurrent.Async (link, withAsync)
 import Control.Concurrent.STM (TChan, atomically, dupTChan, newBroadcastTChanIO, readTChan, writeTChan)
 import Control.Exception (Exception, throw)
+import Data.Sequence (Seq ((:<|)))
+import Data.Sequence qualified as Seq
+import Data.Text qualified as Text
 import GHC.Generics (Generic)
 import Streaming (Of, Stream)
 import Streaming.Prelude qualified as S
+import Unsafe.Coerce (unsafeCoerce)
 
 data ChainSyncEvent a
   = RollForward a ChainTip
@@ -31,6 +39,15 @@ data ChainSyncEventException
   deriving (Show)
 
 instance Exception ChainSyncEventException
+
+newtype ApplyBlockException = ApplyBlockException LedgerStateError
+
+instance Show ApplyBlockException where
+  show (ApplyBlockException e) = Text.unpack (renderLedgerStateError e)
+
+instance Exception ApplyBlockException
+
+type History a = Seq (SlotNo, a)
 
 -- | `withChainSyncEventStream` uses the chain-sync mini-protocol to
 -- connect to a locally running node and fetch blocks from the given
@@ -72,7 +89,7 @@ withChainSyncEventStream socketPath networkId point consumer = do
           }
 
       -- FIXME this comes from the config file but Cardano.Api does not expose readNetworkConfig!
-      epochSlots = EpochSlots 40
+      epochSlots = EpochSlots 21600
 
       clientThread = do
         connectToLocalNode connectInfo localNodeClientProtocols
@@ -127,3 +144,70 @@ chainSyncStreamingClient point chan =
                   atomically $ writeTChan chan (RollBackward cp ct)
                   sendRequestNext
             }
+
+-- | This function works under the assumption that the stream of blocks it
+-- receives is valid. The function will trigger an exception if
+-- 1. a block it receives does not apply on top of the ledger state
+-- 2. a rollback goes past the security parameter
+-- FIXME, for the moment I kept this function pure but it requires us to do
+-- some up-front IO to obtain the initial ledger state from the network
+-- config file.
+ledgerStateEvents ::
+  forall m r.
+  Monad m =>
+  Env ->
+  LedgerState ->
+  ValidationMode ->
+  Stream (Of (ChainSyncEvent (BlockInMode CardanoMode))) m r ->
+  Stream (Of (ChainSyncEvent (BlockInMode CardanoMode), (LedgerState, [LedgerEvent]))) m r
+ledgerStateEvents env ls0 vm =
+  S.scanned step initialHistory projection
+  where
+    step ::
+      (History LedgerState, [LedgerEvent]) ->
+      ChainSyncEvent (BlockInMode CardanoMode) ->
+      (History LedgerState, [LedgerEvent])
+    step (history, _) (RollForward (BlockInMode blk _) _) =
+      unsafePushBlock history blk
+    step _ (RollBackward ChainPointAtGenesis _) =
+      initialHistory
+    step (history, _) (RollBackward (ChainPoint sn _) _) =
+      unsafeRollback history sn
+
+    initialHistory :: (History LedgerState, [LedgerEvent])
+    initialHistory = (Seq.singleton (0, ls0), [])
+
+    -- This function is unsafe because it might result in an empty history,
+    -- breaking the assumption of unsafePushBlock and projection
+    unsafeRollback :: History LedgerState -> SlotNo -> (History LedgerState, [LedgerEvent])
+    unsafeRollback history sn =
+      let history' = Seq.dropWhileL ((> sn) . fst) history
+       in (history', [])
+
+    -- This function is unsafe because it will assume the given block will
+    -- successfully apply on top of the ledger state.
+    unsafePushBlock :: History LedgerState -> Block era -> (History LedgerState, [LedgerEvent])
+    unsafePushBlock history@((_, ls) :<| _) blk@(Block (BlockHeader sn _ _) _) =
+      case applyBlock' env ls vm blk of
+        Left e ->
+          throw $ ApplyBlockException e
+        Right (LedgerStateEvents ls' lse) ->
+          let history' = fst $ Seq.splitAt (fromIntegral $ envSecurityParam env + 1) ((sn, ls') :<| history)
+           in (history', lse)
+    unsafePushBlock Seq.Empty _ = error "Impossible! History should never be empty"
+
+    projection :: (History LedgerState, [LedgerEvent]) -> (LedgerState, [LedgerEvent])
+    projection ((_, ls) :<| _, lse) = (ls, lse)
+    projection (Seq.Empty, _)       = error "Impossible! History should never be empty"
+
+data LedgerStateEvents = LedgerStateEvents LedgerState [LedgerEvent]
+
+-- This hack is because Cardano.Api does not export LedgerStateEvents.
+-- TODO: Remove once the cardano-node commit is past a9e5caa981cf2d71db430e64e72b89d86998d6c9
+applyBlock' ::
+  Env ->
+  LedgerState ->
+  ValidationMode ->
+  Block era ->
+  Either LedgerStateError LedgerStateEvents
+applyBlock' = unsafeCoerce applyBlock


### PR DESCRIPTION
The executable does the following:
- Stream and apply blocks
- Periodically writes `ChainPoint` and `LedgerState` into `timestamp.state` files, and writes `LedgerEvent`s into `timestamp.event` files
- Upon restart, it looks for the latest `state` file, and resumes streaming from that point. If it fails (because the checkpointed block was rolled back), it then tries the second latest `state` file

This PR has a few placeholders (`error`) because the `cardano-node` commit is too old, but I tested it locally on a newer `cardano-node` commit.

The implementation of `ledgerStateEvents` was provided by @andreabedini (with minor modification).