### PR TITLE
PLT-380 Replace TChan with bounded queue

### DIFF
--- a/plutus-streaming/src/Plutus/Streaming.hs
+++ b/plutus-streaming/src/Plutus/Streaming.hs
@@ -74,14 +74,7 @@ withChainSyncEventStream socketPath networkId point consumer = do
       -- FIXME this comes from the config file but Cardano.Api does not expose readNetworkConfig!
       epochSlots = EpochSlots 40
 
-      clientThread = do
-        connectToLocalNode connectInfo localNodeClientProtocols
-        -- the only reason connectToLocalNode can terminate successfully is if it
-        -- doesn't find an intersection, we report that case to the
-        -- consumer as an exception
-        throw NoIntersectionFound
-
-  withAsync clientThread $ \a -> do
+  withAsync (connectToLocalNode connectInfo localNodeClientProtocols) $ \a -> do
     -- Make sure all exceptions in the client thread are passed to the consumer thread
     link a
     -- Run the consumer


### PR DESCRIPTION
Someone made me notice that I was using an unbounded tchan where I could get away with a mvar. Basically I want to have the two threads (the one running chain-sync and the stream consumer) in lock-step.

In the current version, blocks are pushed in the channel at full speed independently from the speed at which they are consumed, this can cause memory issues if the consumer is slower than the network (which is likely).