### PR TITLE
Make LocalNodeConnectionInfo available to streamer consumer

### DIFF
--- a/plutus-chain-index/app/Marconi.hs
+++ b/plutus-chain-index/app/Marconi.hs
@@ -266,7 +266,7 @@ main = do
       optionsSocketPath
       optionsNetworkId
       optionsChainPoint
-      (combinedIndexer optionsUtxoPath optionsDatumPath . logging trace)
+      (\_connInfo -> combinedIndexer optionsUtxoPath optionsDatumPath . logging trace)
       `catch` \NoIntersectionFound ->
         logError trace $
           renderStrict $

--- a/plutus-streaming/README.md
+++ b/plutus-streaming/README.md
@@ -24,6 +24,11 @@ id, ins and outs) and datums. Then it prints them to stdout in JSON format.
 This application uses folds the stream into a UTxoState as defined in
 plutus-chain-index-core.
 
+## Example 4
+
+This application prints (block hash, block slot, block epoch) to stdout. Obtaining the
+epoch number of a slot requires executing a local state query using `LocalNodeConnectInfo`.
+
 # Running the example applications
 
 You can run the example applications with cabal. Remember you need to have

--- a/plutus-streaming/examples/Example1.hs
+++ b/plutus-streaming/examples/Example1.hs
@@ -16,7 +16,7 @@ main :: IO ()
 main = do
   Options {optionsSocketPath, optionsNetworkId, optionsChainPoint} <- parseOptions
 
-  withChainSyncEventStream optionsSocketPath optionsNetworkId optionsChainPoint $
+  withChainSyncEventStream optionsSocketPath optionsNetworkId optionsChainPoint . const $
     S.stdoutLn
       . S.map
         ( \case

--- a/plutus-streaming/examples/Example2.hs
+++ b/plutus-streaming/examples/Example2.hs
@@ -45,7 +45,7 @@ main :: IO ()
 main = do
   Options {optionsSocketPath, optionsNetworkId, optionsChainPoint} <- parseOptions
 
-  withChainSyncEventStream optionsSocketPath optionsNetworkId optionsChainPoint $
+  withChainSyncEventStream optionsSocketPath optionsNetworkId optionsChainPoint . const $
     printJson
       . S.map -- Each ChainSyncEvent
         ( fmap -- Inside the payload of RollForward events

--- a/plutus-streaming/examples/Example3.hs
+++ b/plutus-streaming/examples/Example3.hs
@@ -49,5 +49,5 @@ main :: IO ()
 main = do
   Options {optionsSocketPath, optionsNetworkId, optionsChainPoint} <- parseOptions
 
-  withChainSyncEventStream optionsSocketPath optionsNetworkId optionsChainPoint $
+  withChainSyncEventStream optionsSocketPath optionsNetworkId optionsChainPoint . const $
     S.print . utxoState

--- a/plutus-streaming/examples/Example4.hs
+++ b/plutus-streaming/examples/Example4.hs
@@ -1,0 +1,70 @@
+module Main where
+
+import Cardano.Api qualified as Cardano
+import Common (Options (Options, optionsChainPoint, optionsNetworkId, optionsSocketPath), parseOptions)
+import Control.Monad.Trans.State (StateT, evalStateT, get)
+import Data.ByteString.Base16 qualified as Base16
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Plutus.Streaming (ChainSyncEvent (RollBackward, RollForward), withChainSyncEventStream)
+import Streaming (MFunctor (hoist), MonadIO (liftIO))
+import Streaming.Prelude qualified as S
+
+--
+-- Main
+--
+
+main :: IO ()
+main = do
+  Options {optionsSocketPath, optionsNetworkId, optionsChainPoint} <- parseOptions
+
+  withChainSyncEventStream optionsSocketPath optionsNetworkId optionsChainPoint $ \connectInfo stream -> do
+    evalStateT (S.stdoutLn . S.mapM (toHashSlotEpoch connectInfo) $ hoist liftIO stream)
+      =<< getEraHistory connectInfo
+  where
+    toHashSlotEpoch ::
+      Cardano.LocalNodeConnectInfo Cardano.CardanoMode ->
+      ChainSyncEvent (Cardano.BlockInMode Cardano.CardanoMode) ->
+      StateT (Cardano.EraHistory Cardano.CardanoMode) IO String
+    toHashSlotEpoch connectInfo event = do
+      eraHistory <- get
+      let go onPastHorizon slot hash history =
+            case Cardano.slotToEpoch slot history of
+              Left pastHorizonErr -> onPastHorizon pastHorizonErr
+              Right (epoch, _, _) -> do
+                pure $
+                  "Block hash: "
+                    <> show (renderBlockHash hash)
+                    <> ", slot: "
+                    <> show slot
+                    <> ", epoch: "
+                    <> show epoch
+          toHashSlotEpoch' slot hash =
+            go
+              ( \_pastHorizonErr ->
+                  -- When we get `PastHorizonException` the first time, update the `EraHistory`
+                  -- and retry. If we get it the second time, then fail.
+                  go (\err -> fail $ "Past horizon: " <> show err) slot hash =<< getEraHistory connectInfo
+              )
+              slot
+              hash
+              eraHistory
+      case event of
+        RollForward (Cardano.BlockInMode (Cardano.Block (Cardano.BlockHeader slot hash _) _txs) _era) _ct ->
+          ("RollForward: " <>) <$> toHashSlotEpoch' slot hash
+        RollBackward (Cardano.ChainPoint slot hash) _ ->
+          ("RollBackward: " <>) <$> toHashSlotEpoch' slot hash
+        RollBackward Cardano.ChainPointAtGenesis _ ->
+          pure "RollBackward to Genesis"
+
+getEraHistory ::
+  (MonadIO m, MonadFail m) =>
+  Cardano.LocalNodeConnectInfo Cardano.CardanoMode ->
+  m (Cardano.EraHistory Cardano.CardanoMode)
+getEraHistory connectInfo = do
+  history <- liftIO $ Cardano.executeLocalStateQueryExpr connectInfo Nothing $ \_ ->
+    Cardano.queryExpr (Cardano.QueryEraHistory Cardano.CardanoModeIsMultiEra)
+  either (\err -> fail $ "Failed to get era history: " <> show err) pure history
+
+renderBlockHash :: Cardano.Hash Cardano.BlockHeader -> Text.Text
+renderBlockHash = Text.decodeLatin1 . Base16.encode . Cardano.serialiseToRawBytes

--- a/plutus-streaming/plutus-streaming.cabal
+++ b/plutus-streaming/plutus-streaming.cabal
@@ -36,7 +36,6 @@ library
     , base               >=4.9 && <5
     , cardano-api
     , ouroboros-network
-    , stm
     , streaming
 
 executable plutus-streaming-example-1
@@ -96,3 +95,23 @@ executable plutus-streaming-example-3
     , plutus-chain-index-core
     , plutus-streaming
     , streaming
+
+executable plutus-streaming-example-4
+  import:         lang
+  hs-source-dirs: examples
+  main-is:        Example4.hs
+  other-modules:
+    Common
+    Orphans
+
+  build-depends:
+    , aeson
+    , base                  >=4.9 && <5
+    , base16-bytestring
+    , bytestring
+    , cardano-api
+    , optparse-applicative
+    , plutus-streaming
+    , streaming
+    , text
+    , transformers

--- a/plutus-streaming/src/Plutus/Streaming.hs
+++ b/plutus-streaming/src/Plutus/Streaming.hs
@@ -42,7 +42,10 @@ withChainSyncEventStream ::
   -- | The point on the chain to start streaming from
   ChainPoint ->
   -- | The stream consumer
-  (Stream (Of (ChainSyncEvent (BlockInMode CardanoMode))) IO r -> IO b) ->
+  ( LocalNodeConnectInfo CardanoMode ->
+    Stream (Of (ChainSyncEvent (BlockInMode CardanoMode))) IO r ->
+    IO b
+  ) ->
   IO b
 withChainSyncEventStream socketPath networkId point consumer = do
   -- The chain-sync client runs in a different thread passing the blocks it
@@ -90,7 +93,7 @@ withChainSyncEventStream socketPath networkId point consumer = do
     -- Make sure all exceptions in the client thread are passed to the consumer thread
     link a
     -- Run the consumer
-    consumer $ S.repeatM $ takeMVar nextBlockVar
+    consumer connectInfo $ S.repeatM $ takeMVar nextBlockVar
   -- Let's rethrow exceptions from the client thread unwrapped, so that the
   -- consumer does not have to know anything about async
   `catch` \(ExceptionInLinkedThread _ (SomeException e)) -> throw e


### PR DESCRIPTION
This makes it easier to do such things as obtaining the epoch number of a block, which requires executing a local state query. See Example4.hs.  cc @andreabedini 