### PR TITLE
Use one derivingVar line

### DIFF
--- a/plutus-use-cases/src/Plutus/Contracts/Auction.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Auction.hs
@@ -90,9 +90,7 @@ data AuctionOutput =
         }
         deriving stock (Generic, Haskell.Show, Haskell.Eq)
         deriving anyclass (ToJSON, FromJSON)
-
-deriving via (GenericSemigroupMonoid AuctionOutput) instance (Haskell.Semigroup AuctionOutput)
-deriving via (GenericSemigroupMonoid AuctionOutput) instance (Haskell.Monoid AuctionOutput)
+        deriving (Haskell.Semigroup, Haskell.Monoid) via (GenericSemigroupMonoid AuctionOutput)
 
 auctionStateOut :: AuctionState -> AuctionOutput
 auctionStateOut s = Haskell.mempty { auctionState = Last (Just s) }


### PR DESCRIPTION
Using a single `derivingVar` line for `Semigroup` and `Monoid`. (Good for smart contracts template)
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
