### PR TITLE
Remove reference to non-existing CHANGELOG for `plutus-streaming`

### DIFF
--- a/plutus-streaming/plutus-streaming.cabal
+++ b/plutus-streaming/plutus-streaming.cabal
@@ -3,7 +3,6 @@ name:               plutus-streaming
 version:            0.1.0.0
 author:             Andrea Bedini
 maintainer:         andrea.bedini@iohk.io
-extra-source-files: CHANGELOG.md
 
 common lang
   default-language:   Haskell2010

--- a/plutus-streaming/plutus-streaming.cabal
+++ b/plutus-streaming/plutus-streaming.cabal
@@ -1,8 +1,8 @@
-cabal-version:      2.4
-name:               plutus-streaming
-version:            0.1.0.0
-author:             Andrea Bedini
-maintainer:         andrea.bedini@iohk.io
+cabal-version: 2.4
+name:          plutus-streaming
+version:       0.1.0.0
+author:        Andrea Bedini
+maintainer:    andrea.bedini@iohk.io
 
 common lang
   default-language:   Haskell2010


### PR DESCRIPTION
Fixes haskell.nix build when depending on plutus-apps.
Otherwise it fails with an error about missing `CHANGELOG.md`.
Alternatively close this PR and add missing `CHANGELOG.md` file.
cc @andreabedini 

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
