### PR TITLE
PLT-502 Add locale `LC_ALL=C.utf8` to nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -150,6 +150,8 @@ haskell.project.shellFor {
   withHoogle = false;
 
   shellHook = ''
+    export LC_ALL=C.utf8
+    
     ${pre-commit-check.shellHook}
   ''
   # Work around https://github.com/NixOS/nix/issues/3345, which makes

--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,7 @@
 }:
 let
   inherit (packages) pkgs plutus-apps plutus-playground pab-nami-demo docs webCommon;
-  inherit (pkgs) stdenv lib utillinux python3 nixpkgs-fmt;
+  inherit (pkgs) stdenv lib utillinux python3 nixpkgs-fmt glibcLocales;
   inherit (plutus-apps) haskell stylish-haskell sphinxcontrib-haddock sphinx-markdown-tables sphinxemoji nix-pre-commit-hooks cabal-fmt;
 
   # Feed cardano-wallet, cardano-cli & cardano-node to our shell.

--- a/shell.nix
+++ b/shell.nix
@@ -150,8 +150,6 @@ haskell.project.shellFor {
   withHoogle = false;
 
   shellHook = ''
-    export LC_ALL=C.utf8
-    
     ${pre-commit-check.shellHook}
   ''
   # Work around https://github.com/NixOS/nix/issues/3345, which makes

--- a/shell.nix
+++ b/shell.nix
@@ -165,4 +165,10 @@ haskell.project.shellFor {
   + ''
     export WEB_COMMON_SRC=${webCommon.cleanSrc}
   '';
+
+  # This is no longer set automatically as of more recent `haskell.nix` revisions,
+  # but is useful for users with LANG settings.
+  LOCALE_ARCHIVE = lib.optionalString
+    (stdenv.hostPlatform.libc == "glibc")
+    "${glibcLocales}/lib/locale/locale-archive";
 }


### PR DESCRIPTION
- Enforced `LC_ALL=C.utf8` in the nix-shell to avoid encoding problems on hosts with non-utf8 locales.