### PR TITLE
Add script equivalence context test for the V2 context.

### DIFF
--- a/plutus-example/app/create-script-context.hs
+++ b/plutus-example/app/create-script-context.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 import Prelude
 
 import Cardano.Api
@@ -27,7 +28,8 @@ parseScriptContextCmd = parseGenerateDummy <|> parseGenerateTxBody
   parseGenerateDummy :: Parser ScriptContextCmd
   parseGenerateDummy =
     GenerateDummyScriptContextRedeemer
-      <$> strOption
+      <$> pPlutusScriptLanguage
+      <*> strOption
             ( long "out-file"
             <> metavar "FILE"
             <> help "Create a dummy script context redeemer. Redeeemer output filepath."
@@ -43,6 +45,7 @@ parseScriptContextCmd = parseGenerateDummy <|> parseGenerateTxBody
                     <> help "Create a script context from a tx body."
                     <> Opt.completer (Opt.bashCompleter "file")
                     )
+      <*> pPlutusScriptLanguage
       <*> pConsensusModeParams
       <*> pNetworkId
       <*> strOption ( long "out-file"
@@ -53,26 +56,44 @@ parseScriptContextCmd = parseGenerateDummy <|> parseGenerateTxBody
 
 data ScriptContextCmd
   = GenerateDummyScriptContextRedeemer
-      --LedgerPlutusVersion TODO: Babbage era. We should
-      -- parameterize on LedgerPlutusVersion.
+      AnyScriptLanguage --TODO: Replace type with LedgerPlutusVersion when it becomes available
       FilePath
   | GenerateScriptContextRedeemerTxBody
-     -- LedgerPlutusVersion
       FilePath
+      AnyScriptLanguage --TODO: Replace type with LedgerPlutusVersion when it becomes available
       AnyConsensusModeParams
       NetworkId
       FilePath
 
 runScriptContextCmd :: ScriptContextCmd -> IO ()
-runScriptContextCmd (GenerateDummyScriptContextRedeemer outFp) =
-  LB.writeFile outFp sampleTestV1ScriptContextDataJSON
-runScriptContextCmd (GenerateScriptContextRedeemerTxBody txbodyfile cModeParams nid outFp) = do
-      eTxBodyRedeemer <- runExceptT $ createAnyCustomRedeemerBsFromTxFp txbodyfile cModeParams nid
-      case eTxBodyRedeemer of
-        Left err -> error $ "Error creating redeemer from: " <> txbodyfile <>
-                            " Error: " <> show err
-        Right redeemer -> liftIO $ LB.writeFile outFp redeemer
+runScriptContextCmd (GenerateDummyScriptContextRedeemer (AnyScriptLanguage sVer) outFp) =
+  case sVer of
+    PlutusScriptLanguage PlutusScriptV1 -> LB.writeFile outFp sampleTestV1ScriptContextDataJSON
+    PlutusScriptLanguage PlutusScriptV2 -> LB.writeFile outFp sampleTestV2ScriptContextDataJSON
+    err -> error $ "GenerateDummyScriptContextRedeemer: cannot create a redeemer for a non-Plutus script." <>
+                   " Script type: " <> show err
+runScriptContextCmd (GenerateScriptContextRedeemerTxBody txbodyfile (AnyScriptLanguage sVer) cModeParams nid outFp) = do
+    case sVer of
+      SimpleScriptLanguage _ -> error "runScriptContextCmd: Not possible to specify a simple script"
+      PlutusScriptLanguage pScriptVer -> do
 
+        eTxBodyRedeemer <- runExceptT $ createAnyCustomRedeemerBsFromTxFp pScriptVer txbodyfile cModeParams nid
+        case eTxBodyRedeemer of
+          Left err -> error $ "Error creating redeemer from: " <> txbodyfile <>
+                              " Error: " <> show err
+          Right redeemer -> liftIO $ LB.writeFile outFp redeemer
+
+
+pPlutusScriptLanguage :: Parser AnyScriptLanguage
+pPlutusScriptLanguage =
+  Opt.flag' (AnyScriptLanguage $ PlutusScriptLanguage PlutusScriptV1)
+    (  Opt.long "plutus-v1"
+    <> Opt.help "Specify the version of the script context you are trying to recreate."
+    ) <|>
+  Opt.flag' (AnyScriptLanguage $ PlutusScriptLanguage PlutusScriptV2)
+    (  Opt.long "plutus-v2"
+    <> Opt.help "Specify the version of the script context you are trying to recreate."
+    )
 
 pConsensusModeParams :: Parser AnyConsensusModeParams
 pConsensusModeParams = asum

--- a/plutus-example/app/plutus-example.hs
+++ b/plutus-example/app/plutus-example.hs
@@ -16,6 +16,7 @@ import PlutusExample.PlutusVersion1.RedeemerContextScripts
 import PlutusExample.PlutusVersion1.Sum (sumScript)
 
 import PlutusExample.PlutusVersion2.MintingScript (v2mintingScript)
+import PlutusExample.PlutusVersion2.RedeemerContextEquivalence (v2ScriptContextEquivalenceScript)
 import PlutusExample.PlutusVersion2.RequireRedeemer (requireRedeemerScript)
 import PlutusExample.PlutusVersion2.StakeScript (v2StakeScript)
 
@@ -41,5 +42,6 @@ main = do
   _ <- writeFileTextEnvelope (v2dir </> "required-redeemer.plutus") Nothing requireRedeemerScript
   _ <- writeFileTextEnvelope (v2dir </> "minting-script.plutus") Nothing v2mintingScript
   _ <- writeFileTextEnvelope (v2dir </> "stake-script.plutus") Nothing v2StakeScript
+  _ <- writeFileTextEnvelope (v2dir </> "context-equivalence-test.plutus") Nothing v2ScriptContextEquivalenceScript
 
   return ()

--- a/plutus-example/plutus-example.cabal
+++ b/plutus-example/plutus-example.cabal
@@ -44,6 +44,7 @@ common maybe-Win32
 
 library
   import:          common-definitions
+  hs-source-dirs:  src
 
   if os(windows)
     build-depends: Win32
@@ -51,7 +52,6 @@ library
   if flag(unexpected_thunks)
     cpp-options: -DUNEXPECTED_THUNKS
 
-  hs-source-dirs:  src
   exposed-modules:
     PlutusExample.PlutusVersion1.AlwaysFails
     PlutusExample.PlutusVersion1.AlwaysSucceeds
@@ -62,6 +62,7 @@ library
     PlutusExample.PlutusVersion1.RedeemerContextScripts
     PlutusExample.PlutusVersion1.Sum
     PlutusExample.PlutusVersion2.MintingScript
+    PlutusExample.PlutusVersion2.RedeemerContextEquivalence
     PlutusExample.PlutusVersion2.RequireRedeemer
     PlutusExample.PlutusVersion2.StakeScript
     PlutusExample.ScriptContextChecker
@@ -78,6 +79,7 @@ library
     , cardano-api             >=1.35
     , cardano-cli             >=1.35
     , cardano-ledger-alonzo
+    , cardano-ledger-babbage
     , cardano-ledger-core
     , cardano-ledger-shelley
     , cardano-slotting

--- a/plutus-example/src/PlutusExample/PlutusVersion1/RedeemerContextScripts.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion1/RedeemerContextScripts.hs
@@ -16,7 +16,6 @@ module PlutusExample.PlutusVersion1.RedeemerContextScripts
   , pv1CustomRedeemerFromScriptData
   , scriptContextTestMintingScript
   , scriptContextTextPayingScript
-  , testScriptContextToScriptData
   ) where
 
 import Prelude hiding (($))
@@ -195,9 +194,6 @@ scriptContextTestMintingScript :: PlutusScript PlutusScriptV1
 scriptContextTestMintingScript = PlutusScriptSerialised . SBS.toShort $ LB.toStrict scriptContextTextMintingScript
 
 -- Helpers
-
-testScriptContextToScriptData :: PV1CustomRedeemer -> ScriptData
-testScriptContextToScriptData = fromPlutusData . PlutusTx.builtinDataToData . PlutusTx.toBuiltinData
 
 pv1CustomRedeemerFromScriptData :: ScriptData -> Either String PV1CustomRedeemer
 pv1CustomRedeemerFromScriptData sDat =

--- a/plutus-example/src/PlutusExample/PlutusVersion2/RedeemerContextEquivalence.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion2/RedeemerContextEquivalence.hs
@@ -1,0 +1,154 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeFamilies      #-}
+
+
+module PlutusExample.PlutusVersion2.RedeemerContextEquivalence
+  ( PV2CustomRedeemer (..)
+  , v2ScriptContextEquivalenceScript
+  , v2ScriptContextEquivalenceSbs
+  ) where
+
+import Prelude hiding (($))
+
+import Cardano.Api.Shelley
+import Prelude hiding (($), (&&))
+
+import Codec.Serialise
+import Data.ByteString.Lazy qualified as LBS
+import Data.ByteString.Short qualified as SBS
+
+
+import Plutus.Script.Utils.V2.Typed.Scripts.Validators as V2
+import Plutus.V2.Ledger.Api qualified as V2
+import Plutus.V2.Ledger.Contexts as V2
+import PlutusTx qualified
+import PlutusTx.Prelude as PlutusPrelude hiding (Semigroup (..), unless, (.))
+
+newtype MyCustomDatumV2 = MyCustomDatumV2 Integer
+
+data PV2CustomRedeemer
+  = PV2CustomRedeemer
+      { pv2Inputs      :: [V2.TxInInfo]
+      , pv2RefInputs   :: [V2.TxInInfo]
+      , pv2Outputs     :: [V2.TxOut]
+      , pv2Fee         :: V2.Value
+      , pv2Mint        :: V2.Value
+      , pv2DCert       :: [V2.DCert]
+      , pv2Wdrl        :: V2.Map V2.StakingCredential Integer
+      , pv2ValidRange  :: V2.POSIXTimeRange
+      , pv2Signatories :: [V2.PubKeyHash]
+      , pv2Redeemers   :: V2.Map ScriptPurpose V2.Redeemer
+      , pv2Data        :: V2.Map V2.DatumHash V2.Datum
+      } deriving (Prelude.Eq, Show)
+
+PlutusTx.unstableMakeIsData ''MyCustomDatumV2
+PlutusTx.unstableMakeIsData ''PV2CustomRedeemer
+
+-- @(PV2CustomRedeemer inputs refInputs outputs fee mint dCert wdrl validRange signatories redeemers data)
+
+{-# INLINABLE mkValidator #-}
+mkValidator :: MyCustomDatumV2 -> PV2CustomRedeemer -> V2.ScriptContext -> Bool
+mkValidator _ redeemer scriptContext =
+  -- These all work fine
+  inputsAreEquivalent redeemer txInfo PlutusPrelude.&&
+  referenceInputsAreEquivalent redeemer txInfo PlutusPrelude.&&
+  certsAreEquivalent redeemer txInfo PlutusPrelude.&&
+  reqSignersAreEquivalent redeemer txInfo PlutusPrelude.&&
+  datumHashMapsAreEquivalent redeemer txInfo PlutusPrelude.&&
+  outputsAreEquivalent redeemer txInfo PlutusPrelude.&&
+  correctNumberOfRedeemers redeemer txInfo
+  -- These below are failing
+  -- validtyIntervalsAreEquivalent redeemer txInfo
+  -- Inequality for validity interval doesnt work. Also the interval reported by the script context is a little ahead of
+  -- what is in the transaction
+  -- TODO: You can't check the fee with the build command due to how it's constructed
+  -- These below have not been tested
+  -- withdrawalsAreEquivalent redeemer txInfo
+ where
+  txInfo :: V2.TxInfo
+  txInfo = V2.scriptContextTxInfo scriptContext
+
+  inputsAreEquivalent :: PV2CustomRedeemer -> V2.TxInfo -> Bool
+  inputsAreEquivalent (PV2CustomRedeemer inputs _ _ _ _ _ _ _ _ _ _) tInfo =
+    (PlutusPrelude.map txInInfoResolved $ V2.txInfoInputs tInfo) PlutusPrelude.==
+    PlutusPrelude.map txInInfoResolved inputs
+
+  referenceInputsAreEquivalent :: PV2CustomRedeemer -> V2.TxInfo -> Bool
+  referenceInputsAreEquivalent (PV2CustomRedeemer _ refInputs _ _ _ _ _ _ _ _ _) tInfo =
+    (PlutusPrelude.map txInInfoResolved $ V2.txInfoReferenceInputs tInfo) PlutusPrelude.==
+    PlutusPrelude.map txInInfoResolved refInputs
+
+  outputsAreEquivalent :: PV2CustomRedeemer -> V2.TxInfo -> Bool
+  outputsAreEquivalent (PV2CustomRedeemer _ _ outputs _ _ _ _ _ _ _ _) tInfo =
+    let scOuts = V2.txInfoOutputs tInfo
+        scOutAddrs = PlutusPrelude.map V2.txOutAddress scOuts
+        scOutValue = PlutusPrelude.map V2.txOutValue scOuts
+        scOutDatums = PlutusPrelude.map V2.txOutDatum scOuts
+        scOutReferenceScripts = PlutusPrelude.map V2.txOutReferenceScript scOuts
+
+        redeemerOutAddrs = PlutusPrelude.map V2.txOutAddress outputs
+        redeemerOutValue = PlutusPrelude.map V2.txOutValue outputs
+        redeemerOutDatums = PlutusPrelude.map V2.txOutDatum outputs
+        redeemerOutReferenceScripts = PlutusPrelude.map V2.txOutReferenceScript outputs
+    in (scOutAddrs PlutusPrelude.== redeemerOutAddrs) PlutusPrelude.&&
+       (scOutDatums PlutusPrelude.== redeemerOutDatums) PlutusPrelude.&&
+       (scOutReferenceScripts PlutusPrelude.== redeemerOutReferenceScripts) PlutusPrelude.&&
+       -- We want to see if out tx out specified in our tx is equal to one of the txouts in the
+       -- script context. So we have a total of 4 outputs when we combine the outputs in the script
+       -- context and the redeemer. This would be the two "normal" outputs and the two "change outputs"
+       (PlutusPrelude.length (scOutValue PlutusPrelude.++ redeemerOutValue) PlutusPrelude.== 4) PlutusPrelude.&&
+       -- You would expect calling nub on the combined values, we should expect a length of 2. However
+       -- the change outputs will be different because of how we construct the redeemer. Essentially we
+       -- use an idential tx to generate our redeemer (and the redeemer in this tx is a default redeemer with nothing in it)
+       -- and then we add that redeemer to a new transaction built with the `build` command. The problem is
+       -- the fee and the change outputs created from the initial tx will be different because the size of
+       -- the total tx is now different. Therefore we expect the length to be 3 since only the "normal"
+       -- txouts are equivalent but the change outputs are different!
+       (PlutusPrelude.length (nub $ scOutValue PlutusPrelude.++ redeemerOutValue) PlutusPrelude.== 3)
+
+  certsAreEquivalent :: PV2CustomRedeemer -> V2.TxInfo -> Bool
+  certsAreEquivalent (PV2CustomRedeemer _ _ _ _ _ certs _ _ _ _ _) tInfo =
+    V2.txInfoDCert tInfo PlutusPrelude.== certs
+
+  --validtyIntervalsAreEquivalent :: PV2CustomRedeemer -> V2.TxInfo -> Bool
+  --validtyIntervalsAreEquivalent (PV2CustomRedeemer _ _ _ _ _ _ _ validInterval _ _ _) tInfo =
+  --   (V2.txInfoValidRange tInfo) PlutusPrelude./= validInterval
+    -- V2.ivFrom (V2.txInfoValidRange tInfo) PlutusPrelude.== V2.ivFrom validInterval Fails
+
+  reqSignersAreEquivalent :: PV2CustomRedeemer -> V2.TxInfo -> Bool
+  reqSignersAreEquivalent (PV2CustomRedeemer _ _ _ _ _ _ _ _ reqSigners _ _) tInfo =
+    V2.txInfoSignatories tInfo PlutusPrelude.== reqSigners
+
+  datumHashMapsAreEquivalent :: PV2CustomRedeemer -> V2.TxInfo -> Bool
+  datumHashMapsAreEquivalent (PV2CustomRedeemer _ _ _ _ _ _ _ _ _ _ datumHashMap) tInfo =
+    V2.txInfoData tInfo PlutusPrelude.== datumHashMap
+
+  correctNumberOfRedeemers :: PV2CustomRedeemer -> V2.TxInfo -> Bool
+  correctNumberOfRedeemers (PV2CustomRedeemer _ _ _ _ _ _ _ _ _ redeemers _) tInfo =
+    PlutusPrelude.length (V2.txInfoRedeemers tInfo) PlutusPrelude.== PlutusPrelude.length redeemers
+
+  -- TODO: not done yet
+  --withdrawalsAreEquivalent :: PV2CustomRedeemer -> V2.TxInfo -> Bool
+  --withdrawalsAreEquivalent (PV2CustomRedeemer _ _ _ _ _ _ wdrwls _ _ _ _) tInfo =
+  -- V2.txInfoWdrl tInfo PlutusPrelude.== wdrwls
+  -- TODO: Also need to do separate minting script
+
+validator :: V2.Validator
+validator = V2.mkValidatorScript
+    $$(PlutusTx.compile [|| wrap ||])
+  where
+    wrap = V2.mkUntypedValidator mkValidator
+
+v2ScriptContextEquivalencePlutusScript :: V2.Script
+v2ScriptContextEquivalencePlutusScript = V2.unValidatorScript validator
+
+v2ScriptContextEquivalenceSbs :: SBS.ShortByteString
+v2ScriptContextEquivalenceSbs =
+  SBS.toShort . LBS.toStrict $ serialise v2ScriptContextEquivalencePlutusScript
+
+v2ScriptContextEquivalenceScript :: PlutusScript PlutusScriptV2
+v2ScriptContextEquivalenceScript = PlutusScriptSerialised v2ScriptContextEquivalenceSbs
+

--- a/plutus-example/src/PlutusExample/ScriptContextChecker.hs
+++ b/plutus-example/src/PlutusExample/ScriptContextChecker.hs
@@ -4,7 +4,9 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
+
 
 module PlutusExample.ScriptContextChecker where
 
@@ -15,16 +17,17 @@ import Cardano.Api.Byron
 import Cardano.Api.Shelley
 import Cardano.Api.Shelley qualified as Api
 
+import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except.Extra
 import Data.Aeson qualified as Aeson
 import Data.Bifunctor (first)
 import Data.ByteString.Lazy qualified as LB
 import Data.Map.Strict qualified as Map
-import Data.Maybe qualified as M
 import Data.Sequence.Strict qualified as Seq
 import Data.Set qualified as Set
 import Data.Text qualified as T
+import GHC.Records (HasField (..))
 
 import Cardano.CLI.Environment
 import Cardano.CLI.Shelley.Run.Query
@@ -35,9 +38,13 @@ import Cardano.Ledger.Alonzo.PlutusScriptApi qualified as Alonzo
 import Cardano.Ledger.Alonzo.Tx qualified as Alonzo
 import Cardano.Ledger.Alonzo.TxInfo qualified as Alonzo
 import Cardano.Ledger.Alonzo.TxWitness qualified as Alonzo
+import Cardano.Ledger.Babbage.PParams
+import Cardano.Ledger.Coin qualified as Ledger
 import Cardano.Ledger.Shelley.API qualified as Shelley
+import Cardano.Ledger.Shelley.Tx ()
 import Cardano.Ledger.TxIn qualified as Ledger
 
+import Cardano.Ledger.Babbage.TxInfo qualified as Babbage
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Slotting.EpochInfo (EpochInfo, hoistEpochInfo)
 import Cardano.Slotting.Time (SystemStart)
@@ -45,23 +52,29 @@ import Control.Monad.Trans.Except
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras qualified as Consensus
 import Ouroboros.Consensus.HardFork.History qualified as Consensus
 import Ouroboros.Network.Protocol.LocalStateQuery.Type (AcquireFailure)
-import Plutus.V1.Ledger.Api qualified as Plutus
-import PlutusTx qualified
-import PlutusTx.IsData.Class
-import PlutusTx.Prelude hiding (Eq, Semigroup (..), unless, (.))
+import Plutus.V1.Ledger.Api qualified as V1
+import Plutus.V2.Ledger.Api qualified as V2
+import PlutusTx.AssocMap qualified as PMap
+import PlutusTx.Prelude as PPrelude hiding (Eq, Semigroup (..), unless, (.))
 
+import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import PlutusExample.PlutusVersion1.RedeemerContextScripts
+import PlutusExample.PlutusVersion2.RedeemerContextEquivalence
 
-newtype AnyCustomRedeemer
+data AnyCustomRedeemer
   = AnyPV1CustomRedeemer PV1CustomRedeemer
+  | AnyPV2CustomRedeemer PV2CustomRedeemer
   deriving (Show, Eq)
 
 -- We convert our custom redeemer to ScriptData so we can include it
 -- in our transaction.
 customRedeemerToScriptData :: AnyCustomRedeemer -> ScriptData
 customRedeemerToScriptData (AnyPV1CustomRedeemer cRedeem) =
-  fromPlutusData $ PlutusTx.builtinDataToData $ toBuiltinData cRedeem
+  fromPlutusData $ V1.toData cRedeem
+customRedeemerToScriptData (AnyPV2CustomRedeemer cRedeem) =
+  fromPlutusData $ V2.toData cRedeem
+
 
 data ScriptContextError = NoScriptsInByronEra
                         | NoScriptsInEra
@@ -75,18 +88,21 @@ data ScriptContextError = NoScriptsInByronEra
                         | QueryError ShelleyQueryCmdError
                         | ConsensusModeMismatch AnyConsensusMode AnyCardanoEra
                         | EraMismatch !Consensus.EraMismatch
+                        | PlutusV2TranslationError (Alonzo.TranslationError StandardCrypto)
+                        | MoreThanOneTxInput
                         deriving Show
 
 createAnyCustomRedeemer
-  :: ShelleyBasedEra era
+  :: forall era lang. PlutusScriptVersion lang
+  -> ShelleyBasedEra era
   -> ProtocolParameters
   -> UTxO era
   -> EpochInfo (Either Text)
   -> SystemStart
   -> Api.Tx era
   -> Either ScriptContextError AnyCustomRedeemer
-createAnyCustomRedeemer _ _ _ _ _ (ByronTx _) = Left NoScriptsInByronEra
-createAnyCustomRedeemer sbe pparams utxo eInfo sStart (ShelleyTx ShelleyBasedEraAlonzo ledgerTx) = do
+createAnyCustomRedeemer _ _ _ _ _ _ (ByronTx _) = Left NoScriptsInByronEra
+createAnyCustomRedeemer _ sbe pparams utxo eInfo sStart (ShelleyTx ShelleyBasedEraAlonzo ledgerTx) = do
   let txBody = Alonzo.body ledgerTx
       witness = Alonzo.wits ledgerTx
       Alonzo.TxWitness _ _ _ _ _rdmrs = witness
@@ -108,41 +124,79 @@ createAnyCustomRedeemer sbe pparams utxo eInfo sStart (ShelleyTx ShelleyBasedEra
     first IntervalConvError
       $ Alonzo.transVITime (toLedgerPParams sbe pparams) eInfo sStart $ Alonzo.txvldt txBody
 
-  tOuts <- if Prelude.all M.isJust eTouts
-           then return $ M.catMaybes eTouts
+  tOuts <- if Prelude.all isJust eTouts
+           then return $ catMaybes eTouts
            else Prelude.error "Tx Outs not all Just"
-  txins <- if Prelude.all M.isJust eTxIns
-           then return $ M.catMaybes eTxIns
+  txins <- if Prelude.all isJust eTxIns
+           then return $ catMaybes eTxIns
            else Prelude.error "Tx Ins not all Just"
-  Right . AnyPV1CustomRedeemer
-      $ PV1CustomRedeemer
-            tOuts
-            txins
-            minted
-            valRange
-            txfee
-            datumHashes
-            txcerts
-            txsignatories
-            (Just sPurpose)
- where
-  seqToList (x Seq.:<| rest) = x : seqToList rest
-  seqToList Seq.Empty        = []
+  Right . AnyPV1CustomRedeemer $ PV1CustomRedeemer tOuts txins minted valRange txfee datumHashes txcerts txsignatories (Just sPurpose)
 
-createAnyCustomRedeemer _ _ _ _ _ (ShelleyTx _ _) = Left NoScriptsInEra
+createAnyCustomRedeemer pScriptVer sbe pparams utxo eInfo sStart (ShelleyTx ShelleyBasedEraBabbage ledgerTx) = do
+  let txBody = getField @"body" ledgerTx
+      txins = Set.toList $ getField @"inputs" txBody
+      refTxins = Set.toList $ getField @"referenceInputs" txBody
+      outputs = seqToList $ getField @"outputs" txBody
+      fee = Ledger.unCoin $ getField @"txfee" txBody
+      certs = seqToList $ getField @"certs" txBody
+      vldt = getField @"vldt" txBody
+      reqSigners = Set.toList $ getField @"reqSignerHashes" txBody
+      Alonzo.TxDats datumHashMap = getField @"txdats" $ getField @"wits" ledgerTx
+      wdrwls = getField @"wdrls" txBody
+      txwit = getField @"wits" ledgerTx
+      Alonzo.Redeemers rdmrs = getField @"txrdmrs" txwit
+      rdmrList = Map.toList rdmrs
+
+      bUtxo = toLedgerUTxO ShelleyBasedEraBabbage utxo
+      -- Plutus script context types
+  case pScriptVer of
+    PlutusScriptV1 -> Prelude.error "createAnyCustomRedeemer: PlutusScriptV1 custom redeemer not wired up yet"
+    PlutusScriptV2 -> do
+      bV2Ins <- first PlutusV2TranslationError $ Prelude.mapM (Babbage.txInfoInV2 bUtxo) txins
+      bV2RefIns <- first PlutusV2TranslationError $ Prelude.mapM (Babbage.txInfoInV2 bUtxo) refTxins
+      bV2Outputs <- first PlutusV2TranslationError $ zipWithM Babbage.txInfoOutV2 (Prelude.map Alonzo.TxOutFromInput txins) outputs
+
+      let _bV2fee = V2.singleton V2.adaSymbol V2.adaToken fee -- Impossible to test
+          _withdrawals = PMap.fromList . Map.toList $ Alonzo.transWdrl wdrwls -- untested
+      valRange <-
+        first IntervalConvError
+          $ Alonzo.transVITime (toLedgerPParams sbe pparams) eInfo sStart vldt
+      redeemrs <- first PlutusV2TranslationError $ Prelude.mapM (Babbage.transRedeemerPtr txBody) rdmrList
+      Right . AnyPV2CustomRedeemer
+        $ PV2CustomRedeemer
+            { pv2Inputs = bV2Ins
+            , pv2RefInputs = bV2RefIns
+            , pv2Outputs = bV2Outputs
+            , pv2Fee = PPrelude.mempty -- Impossible to test
+            , pv2Mint = PPrelude.mempty -- TODO: Not tested
+            , pv2DCert = Prelude.map Alonzo.transDCert certs
+            , pv2Wdrl = PMap.empty -- TODO: Not tested
+            , pv2ValidRange = valRange -- TODO: Fails when using (/=)
+            , pv2Signatories = Prelude.map Alonzo.transKeyHash reqSigners
+            , pv2Redeemers = PMap.fromList redeemrs
+            , pv2Data = PMap.fromList . Prelude.map Alonzo.transDataPair $ Map.toList datumHashMap
+            }
+
+createAnyCustomRedeemer _ _ _ _ _ _ _ = Left NoScriptsInByronEra
+
+seqToList :: Seq.StrictSeq a -> [a]
+seqToList (x Seq.:<| rest) = x : seqToList rest
+seqToList Seq.Empty        = []
 
 createAnyCustomRedeemerFromTxFp
-  :: FilePath
+  :: PlutusScriptVersion lang
+  -> FilePath
   -> AnyConsensusModeParams
   -> NetworkId
   -> ExceptT ScriptContextError IO AnyCustomRedeemer
-createAnyCustomRedeemerFromTxFp fp (AnyConsensusModeParams cModeParams) network = do
+createAnyCustomRedeemerFromTxFp pScriptVer fp (AnyConsensusModeParams cModeParams) network = do
+  -- TODO: Expose readFileTx from cardano-cli
   InAnyCardanoEra cEra alonzoTx
     <- firstExceptT ReadTxBodyError
          . newExceptT
          $ readFileTextEnvelopeAnyOf
              [ FromSomeType (AsTx AsAlonzoEra) (InAnyCardanoEra AlonzoEra)
-             -- TODO: Babbage Era -- Update with Babbage
+             , FromSomeType (AsTx AsBabbageEra) (InAnyCardanoEra BabbageEra)
              ]
              fp
 
@@ -183,20 +237,22 @@ createAnyCustomRedeemerFromTxFp fp (AnyConsensusModeParams cModeParams) network 
                     cModeParams
                     localNodeConnInfo
                     utxoQinMode
-      hoistEither $ createAnyCustomRedeemer sbe pparams
+      hoistEither $ createAnyCustomRedeemer pScriptVer sbe pparams
                                        utxo eInfo sStart alonzoTx
     _ -> Prelude.error "Please specify --cardano-mode on cli."
 
+
 createAnyCustomRedeemerBsFromTxFp
-  :: FilePath
+  :: PlutusScriptVersion lang
+  -> FilePath
   -> AnyConsensusModeParams
   -> NetworkId
   -> ExceptT ScriptContextError IO LB.ByteString
-createAnyCustomRedeemerBsFromTxFp txFp anyCmodeParams nid = do
-  AnyPV1CustomRedeemer testScrContext <- createAnyCustomRedeemerFromTxFp txFp anyCmodeParams nid
-
+createAnyCustomRedeemerBsFromTxFp pScriptVer txFp anyCmodeParams nid = do
+  anyCustomRedeemer <- createAnyCustomRedeemerFromTxFp pScriptVer txFp anyCmodeParams nid
   return . Aeson.encode . scriptDataToJson ScriptDataJsonDetailedSchema
-                        $ testScriptContextToScriptData testScrContext
+         $ customRedeemerToScriptData anyCustomRedeemer
+
 
 getSbe :: CardanoEraStyle era -> ExceptT ScriptContextError IO (ShelleyBasedEra era)
 getSbe LegacyByronEra        = left ScriptContextErrorByronEra
@@ -205,8 +261,8 @@ getSbe (ShelleyBasedEra sbe) = return sbe
 
 -- Used in roundtrip testing
 
-fromPlutusTxId :: Plutus.TxId -> Ledger.TxId StandardCrypto
-fromPlutusTxId (Plutus.TxId builtInBs) =
+fromPlutusTxId :: V1.TxId -> Ledger.TxId StandardCrypto
+fromPlutusTxId (V1.TxId builtInBs) =
   case deserialiseFromRawBytes AsTxId $ fromBuiltin builtInBs of
     Just txidHash -> toShelleyTxId txidHash
     Nothing       -> Prelude.error "Could not derserialize txid"
@@ -230,35 +286,54 @@ sampleTestV1ScriptContextDataJSON =
         dummyScriptPurpose
 
 
-dummyCerts :: [Plutus.DCert]
+dummyCerts :: [V1.DCert]
 dummyCerts = []
 
-dummyTxIns :: [Plutus.TxInInfo]
+dummyTxIns :: [V1.TxInInfo]
 dummyTxIns = []
 
-dummySignatories :: [Plutus.PubKeyHash]
+dummySignatories :: [V1.PubKeyHash]
 dummySignatories = []
 
-dummyDatumHashes :: [(Plutus.DatumHash, Plutus.Datum)]
+dummyDatumHashes :: [(V1.DatumHash, V1.Datum)]
 dummyDatumHashes = []
 
-dummyLedgerVal :: Plutus.Value
+dummyLedgerVal :: V1.Value
 dummyLedgerVal = Alonzo.transValue $ toMaryValue Prelude.mempty
 
-dummyTxOuts :: [Plutus.TxOut]
+dummyTxOuts :: [V1.TxOut]
 dummyTxOuts = []
 
-dummyPOSIXTimeRange :: Plutus.POSIXTimeRange
-dummyPOSIXTimeRange = Plutus.from $ Plutus.POSIXTime 42
+dummyPOSIXTimeRange :: V1.POSIXTimeRange
+dummyPOSIXTimeRange = V1.from $ V1.POSIXTime 42
 
-dummyScriptPurpose :: Maybe Plutus.ScriptPurpose
+dummyScriptPurpose :: Maybe V1.ScriptPurpose
 dummyScriptPurpose = Nothing
 
 getTxInInfoFromTxIn
   :: Shelley.UTxO (Alonzo.AlonzoEra StandardCrypto)
   -> Ledger.TxIn StandardCrypto
-  -> Maybe Plutus.TxInInfo
+  -> Maybe V1.TxInInfo
 getTxInInfoFromTxIn (Shelley.UTxO utxoMap) txIn = do
   txOut <- Map.lookup txIn utxoMap
   Alonzo.txInfoIn txIn txOut
 
+sampleTestV2ScriptContextDataJSON :: LB.ByteString
+sampleTestV2ScriptContextDataJSON =
+  Aeson.encode
+    . scriptDataToJson ScriptDataJsonDetailedSchema
+    . customRedeemerToScriptData
+    . AnyPV2CustomRedeemer
+    $ PV2CustomRedeemer
+       { pv2Inputs = []
+       , pv2RefInputs = []
+       , pv2Outputs = []
+       , pv2Fee = PPrelude.mempty
+       , pv2Mint = PPrelude.mempty
+       , pv2DCert = []
+       , pv2Wdrl = PMap.empty
+       , pv2ValidRange = V2.always
+       , pv2Signatories = []
+       , pv2Redeemers = PMap.empty
+       , pv2Data = PMap.empty
+       }


### PR DESCRIPTION
Note:
- The mint field is still not tested
- Withdrawals are not tested
- When we feed a validity range via the redeemer we get failures when we try to compare for equality ((==) and (/=)) with the validity interval in the script context.
