### PR TITLE
Replace `Set TxIn` with `[TxIn]` to fix `StateMachine.getInput`

### DIFF
--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Emulator/DiskState.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Emulator/DiskState.hs
@@ -35,7 +35,7 @@ import GHC.Generics (Generic)
 import Ledger (Address (..), TxOut (..), TxOutRef)
 import Ledger.Credential (Credential)
 import Ledger.TxId (TxId)
-import Plutus.ChainIndex.Tx (ChainIndexTx (..), citxData, citxRedeemers, citxScripts, citxTxId, txOutsWithRef)
+import Plutus.ChainIndex.Tx (ChainIndexTx (..), citxData, citxScripts, citxTxId, txOutsWithRef, txRedeemersWithHash)
 import Plutus.ChainIndex.Types (Diagnostics (..))
 import Plutus.V1.Ledger.Ada qualified as Ada
 import Plutus.V1.Ledger.Api (Datum, DatumHash, Redeemer, RedeemerHash)
@@ -139,7 +139,7 @@ fromTx tx =
         { _DataMap = view citxData tx
         , _ScriptMap = view citxScripts tx
         , _TxMap = Map.singleton (view citxTxId tx) tx
-        , _RedeemerMap = view citxRedeemers tx
+        , _RedeemerMap = txRedeemersWithHash tx
         , _AddressMap = txCredentialMap tx
         , _AssetClassMap = txAssetClassMap tx
         }

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
@@ -537,7 +537,7 @@ fromTx :: ChainIndexTx -> Db InsertRows
 fromTx tx = mempty
     { datumRows = fromMap citxData
     , scriptRows = fromMap citxScripts
-    , redeemerRows = fromMap citxRedeemers
+    , redeemerRows = fromPairs (Map.toList . txRedeemersWithHash)
     , txRows = InsertRows [toDbValue (_citxTxId tx, tx)]
     , addressRows = fromPairs (fmap credential . txOutsWithRef)
     , assetClassRows = fromPairs (concatMap assetClasses . txOutsWithRef)

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/TxOutBalance.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/TxOutBalance.hs
@@ -58,7 +58,7 @@ fromTx tx =
         { _tobUnspentOutputs = Set.fromList $ fmap snd $ txOutsWithRef tx
         , _tobSpentOutputs =
           Map.fromSet (const $ view citxTxId tx)
-                      $ Set.mapMonotonic txInRef (view citxInputs tx)
+                     $ Set.fromList $ map txInRef (view citxInputs tx)
         }
 
 -- | Whether a 'TxOutRef' is a member of the UTXO set (ie. unspent)

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/TxUtxoBalance.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/TxUtxoBalance.hs
@@ -18,7 +18,7 @@ fromTx :: ChainIndexTx -> TxUtxoBalance
 fromTx tx =
     TxUtxoBalance
         { _tubUnspentOutputs = Set.fromList $ fmap snd $ txOutsWithRef tx
-        , _tubUnmatchedSpentInputs = Set.mapMonotonic txInRef (view citxInputs tx)
+        , _tubUnmatchedSpentInputs = Set.fromList $ map txInRef (view citxInputs tx)
         }
 
 -- | Whether a 'TxOutRef' is a member of the UTXO set (ie. unspent)

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Types.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Types.hs
@@ -76,6 +76,7 @@ import Ledger.Blockchain qualified as Ledger
 import Ledger.Slot (Slot)
 import Ledger.TxId (TxId)
 import Plutus.V1.Ledger.Scripts (Datum, DatumHash, Redeemer, RedeemerHash, Script, ScriptHash)
+import Plutus.V1.Ledger.Tx (Redeemers)
 import PlutusTx.Lattice (MeetSemiLattice (..))
 import Prettyprinter
 import Prettyprinter.Extras (PrettyShow (..))
@@ -89,10 +90,12 @@ data ChainIndexTxOutputs =
 
 makePrisms ''ChainIndexTxOutputs
 
+newtype RedeemerIx = RedeemerIx { getRedeemerIx :: Integer }
+
 data ChainIndexTx = ChainIndexTx {
     _citxTxId       :: TxId,
     -- ^ The id of this transaction.
-    _citxInputs     :: Set TxIn,
+    _citxInputs     :: [TxIn],
     -- ^ The inputs to this transaction.
     _citxOutputs    :: ChainIndexTxOutputs,
     -- ^ The outputs of this transaction, ordered so they can be referenced by index.
@@ -100,7 +103,7 @@ data ChainIndexTx = ChainIndexTx {
     -- ^ The 'SlotRange' during which this transaction may be validated.
     _citxData       :: Map DatumHash Datum,
     -- ^ Datum objects recorded on this transaction.
-    _citxRedeemers  :: Map RedeemerHash Redeemer,
+    _citxRedeemers  :: Redeemers,
     -- ^ Redeemers of the minting scripts.
     _citxScripts    :: Map ScriptHash Script,
     -- ^ The scripts (validator, stake validator or minting) part of cardano tx.
@@ -116,7 +119,7 @@ makeLenses ''ChainIndexTx
 instance Pretty ChainIndexTx where
     pretty ChainIndexTx{_citxTxId, _citxInputs, _citxOutputs = ValidTx outputs, _citxValidRange, _citxData, _citxRedeemers, _citxScripts} =
         let lines' =
-                [ hang 2 (vsep ("inputs:" : fmap pretty (Set.toList _citxInputs)))
+                [ hang 2 (vsep ("inputs:" : fmap pretty _citxInputs))
                 , hang 2 (vsep ("outputs:" : fmap pretty outputs))
                 , hang 2 (vsep ("scripts hashes:": fmap (pretty . fst) (Map.toList _citxScripts)))
                 , "validity range:" <+> viaShow _citxValidRange
@@ -126,7 +129,7 @@ instance Pretty ChainIndexTx where
         in nest 2 $ vsep ["Valid tx" <+> pretty _citxTxId <> colon, braces (vsep lines')]
     pretty ChainIndexTx{_citxTxId, _citxInputs, _citxOutputs = InvalidTx, _citxValidRange, _citxData, _citxRedeemers, _citxScripts} =
         let lines' =
-                [ hang 2 (vsep ("inputs:" : fmap pretty (Set.toList _citxInputs)))
+                [ hang 2 (vsep ("inputs:" : fmap pretty _citxInputs))
                 , hang 2 (vsep ["no outputs:"])
                 , hang 2 (vsep ("scripts hashes:": fmap (pretty . fst) (Map.toList _citxScripts)))
                 , "validity range:" <+> viaShow _citxValidRange

--- a/plutus-chain-index-core/src/Plutus/Contract/CardanoAPI.hs
+++ b/plutus-chain-index-core/src/Plutus/Contract/CardanoAPI.hs
@@ -17,6 +17,7 @@ module Plutus.Contract.CardanoAPI(
 
 import Cardano.Api qualified as C
 import Cardano.Api.Shelley qualified as C
+import Data.List (sort)
 import Data.Set qualified as Set
 import Ledger qualified as P
 import Ledger.Tx.CardanoAPI as Export
@@ -37,7 +38,9 @@ fromCardanoTx eraInMode tx@(C.Tx txBody@(C.TxBody C.TxBodyContent{..}) _) = do
     let scriptMap = plutusScriptsFromTxBody txBody
         isTxScriptValid = fromTxScriptValidity txScriptValidity
         (datums, redeemers) = scriptDataFromCardanoTxBody txBody
-        inputs =
+        -- We need to sort the inputs as the order is important
+        -- to find the corresponding redeemers
+        inputs = sort $
           if isTxScriptValid
             then fst <$> txIns
             else case txInsCollateral of
@@ -48,7 +51,7 @@ fromCardanoTx eraInMode tx@(C.Tx txBody@(C.TxBody C.TxBodyContent{..}) _) = do
             { _citxTxId = fromCardanoTxId (C.getTxId txBody)
             , _citxValidRange = fromCardanoValidityRange txValidityRange
             -- If the transaction is invalid, we use collateral inputs
-            , _citxInputs = Set.fromList $ fmap ((`P.TxIn` Nothing) . fromCardanoTxIn) inputs
+            , _citxInputs = fmap ((`P.TxIn` Nothing) . fromCardanoTxIn) inputs
             -- No outputs if the one of scripts failed
             , _citxOutputs = if isTxScriptValid then ValidTx txOutputs
                                                 else InvalidTx

--- a/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
@@ -341,7 +341,7 @@ updateTxOutStatus txns = do
     -- Check whether the contract instance is waiting for a status change of a
     -- transaction output of any of the new transactions. If that is the case,
     -- call 'addResponse' to sent the response.
-    let getSpentOutputs = Set.toList . Set.map txInRef . view citxInputs
+    let getSpentOutputs = map txInRef . view citxInputs
         -- If the tx is invalid, there is not outputs
         txWithTxOutStatus tx@ChainIndexTx {_citxTxId, _citxOutputs = InvalidTx} =
           fmap (, Committed TxInvalid (Spent _citxTxId)) $ getSpentOutputs tx
@@ -531,6 +531,6 @@ indexBlock :: [ChainIndexTx] -> IndexedBlock
 indexBlock = foldMap indexTx where
   indexTx otx =
     IndexedBlock
-      { ibUtxoSpent = Map.fromSet (const otx) $ Set.map txInRef $ view citxInputs otx
+      { ibUtxoSpent = Map.fromSet (const otx) $ Set.fromList $ map txInRef $ view citxInputs otx
       , ibUtxoProduced = Map.fromListWith (<>) $ view (citxOutputs . _ValidTx) otx >>= (\TxOut{txOutAddress} -> [(txOutAddress, otx :| [])])
       }

--- a/plutus-contract/src/Wallet/Emulator/Wallet.hs
+++ b/plutus-contract/src/Wallet/Emulator/Wallet.hs
@@ -338,6 +338,7 @@ handleBalance utx' = do
             theFee <- calcFee 5 $ Ada.lovelaceValueOf 300000
             tx <- handleBalanceTx utxo (utx & U.tx . Ledger.fee .~ theFee)
             cTx <- handleError (Right tx) $ fromPlutusTx params cUtxoIndex requiredSigners tx
+            -- pure $ Tx.CardanoApiTx (Tx.CardanoApiEmulatorEraTx cTx)
             pure $ Tx.Both tx (Tx.CardanoApiEmulatorEraTx cTx)
         Left txBodyContent -> do
             ownPaymentPubKey <- gets ownPaymentPublicKey

--- a/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
+++ b/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
@@ -293,7 +293,7 @@ toTxScriptValidity False = C.TxScriptValidity C.TxScriptValiditySupportedInAlonz
 -- with their hashes.
 scriptDataFromCardanoTxBody
   :: C.TxBody era
-  -> (Map P.DatumHash P.Datum, Map P.RedeemerHash P.Redeemer)
+  -> (Map P.DatumHash P.Datum, P.Redeemers)
 scriptDataFromCardanoTxBody C.ByronTxBody {} = (mempty, mempty)
 scriptDataFromCardanoTxBody (C.ShelleyTxBody _ _ _ C.TxBodyNoScriptData _ _) =
   (mempty, mempty)
@@ -308,14 +308,25 @@ scriptDataFromCardanoTxBody
                     )
              $ Map.elems dats
       redeemers = Map.fromList
-                $ fmap ( (\r -> (P.redeemerHash r, r))
-                       . P.Redeemer
-                       . fromCardanoScriptData
-                       . C.fromAlonzoData
-                       . fst
-                       )
-                $ Map.elems reds
+                $ map (\(ptr, rdmr) ->
+                        ( redeemerPtrFromCardanoRdmrPtr ptr
+                        , P.Redeemer
+                         $ fromCardanoScriptData
+                         $ C.fromAlonzoData
+                         $ fst rdmr
+                        )
+                      )
+                $ Map.toList reds
    in (datums, redeemers)
+
+redeemerPtrFromCardanoRdmrPtr :: Alonzo.RdmrPtr -> P.RedeemerPtr
+redeemerPtrFromCardanoRdmrPtr (Alonzo.RdmrPtr rdmrTag ptr) = P.RedeemerPtr t (toInteger ptr)
+  where
+    t = case rdmrTag of
+      Alonzo.Spend -> P.Spend
+      Alonzo.Mint  -> P.Mint
+      Alonzo.Cert  -> P.Cert
+      Alonzo.Rewrd -> P.Reward
 
 -- | Extract plutus scripts from a Cardano API tx body.
 --


### PR DESCRIPTION
This PR tries to fix the problem with `StateMachine.getInput` by properly querying the redeemer of the input by its index.

---

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
