### PR TITLE
Add note to `checkPredicateGenOptions`

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Test.hs
+++ b/plutus-contract/src/Plutus/Contract/Test.hs
@@ -284,7 +284,11 @@ checkPredicateInnerStream CheckOptions{_minLogLevel, _emulatorConfig} (TracePred
                 assert False
             Right r -> assert r
 
--- | A version of 'checkPredicateGen' with configurable 'CheckOptions'
+-- | A version of 'checkPredicateGen' with configurable 'CheckOptions'.
+--
+--   Note that the 'InitialChainState' in the 'EmulatorConfig' of the
+--   'CheckOptions' will be replaced with the 'mockchainInitialTxPool' generated
+--   by the model.
 checkPredicateGenOptions ::
     CheckOptions
     -> GeneratorModel


### PR DESCRIPTION
It is not obvious that the `initialChainState` of the `CheckOptions` will come from the generator model. I would have benefitted from seeing this note attached to the function.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
