### PR TITLE
feat: replace `allowBigTransactions` function with `increaseTransactionLimits`

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Test.hs
+++ b/plutus-contract/src/Plutus/Contract/Test.hs
@@ -71,7 +71,7 @@ module Plutus.Contract.Test(
     , minLogLevel
     , emulatorConfig
     , changeInitialWalletValue
-    , allowBigTransactions
+    , increaseTransactionLimits
     -- * Etc
     , goldenPir
     ) where
@@ -188,8 +188,8 @@ changeInitialWalletValue wallet = over (emulatorConfig . initialChainState . _Le
 -- | Set higher limits on transaction size and execution units.
 -- This can be used to work around @MaxTxSizeUTxO@ and @ExUnitsTooBigUTxO@ errors.
 -- Note that if you need this your Plutus script will probably not validate on Mainnet.
-allowBigTransactions :: CheckOptions -> CheckOptions
-allowBigTransactions = over (emulatorConfig . params) Ledger.allowBigTransactions
+increaseTransactionLimits :: CheckOptions -> CheckOptions
+increaseTransactionLimits = over (emulatorConfig . params) Ledger.increaseTransactionLimits
 
 -- | Check if the emulator trace meets the condition
 checkPredicate ::

--- a/plutus-ledger/src/Ledger/Params.hs
+++ b/plutus-ledger/src/Ledger/Params.hs
@@ -8,7 +8,7 @@ module Ledger.Params(
   slotConfigL,
   protocolParamsL,
   networkIdL,
-  allowBigTransactions,
+  increaseTransactionLimits,
   -- * cardano-ledger specific types and conversion functions
   EmulatorEra,
   slotLength,
@@ -59,12 +59,12 @@ makeLensesFor
 -- | Set higher limits on transaction size and execution units.
 -- This can be used to work around @MaxTxSizeUTxO@ and @ExUnitsTooBigUTxO@ errors.
 -- Note that if you need this your Plutus script will probably not validate on Mainnet.
-allowBigTransactions :: Params -> Params
-allowBigTransactions = over protocolParamsL fixParams
+increaseTransactionLimits :: Params -> Params
+increaseTransactionLimits = over protocolParamsL fixParams
   where
     fixParams pp = pp
-      { protocolParamMaxTxSize = 256 * 1024
-      , protocolParamMaxTxExUnits = Just (ExecutionUnits {executionSteps = 100000000000, executionMemory = 100000000})
+      { protocolParamMaxTxSize = 2 * protocolParamMaxTxSize pp
+      , protocolParamMaxTxExUnits = protocolParamMaxTxExUnits pp >>= (\ExecutionUnits {executionSteps, executionMemory} -> pure $ ExecutionUnits {executionSteps = 10 * executionSteps, executionMemory = 10 * executionMemory})
       }
 
 instance Default Params where


### PR DESCRIPTION
The function `allowBigTransactions` was too limiting with the fixed setting that was provided by `allowBigTransactions`. This change adds the possibility to increase the limits even further.