### PR TITLE
PLT-309: Rename 'currentSlot' to 'currentPABSlot' and add 'currentChainIndexSlot'.

### DIFF
--- a/plutus-contract/src/Plutus/Contract.hs
+++ b/plutus-contract/src/Plutus/Contract.hs
@@ -26,6 +26,8 @@ module Plutus.Contract(
     , Request.awaitSlot
     , Request.isSlot
     , Request.currentSlot
+    , Request.currentPABSlot
+    , Request.currentNodeSlot
     , Request.waitNSlots
     , Request.awaitTime
     , Request.isTime

--- a/plutus-contract/src/Plutus/Contract.hs
+++ b/plutus-contract/src/Plutus/Contract.hs
@@ -27,7 +27,7 @@ module Plutus.Contract(
     , Request.isSlot
     , Request.currentSlot
     , Request.currentPABSlot
-    , Request.currentNodeSlot
+    , Request.currentChainIndexSlot
     , Request.waitNSlots
     , Request.awaitTime
     , Request.isTime

--- a/plutus-contract/src/Plutus/Contract/Effects.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects.hs
@@ -144,7 +144,7 @@ instance Pretty PABReq where
     AwaitUtxoSpentReq utxo                  -> "Await utxo spent:" <+> pretty utxo
     AwaitUtxoProducedReq a                  -> "Await utxo produced:" <+> pretty a
     CurrentPABSlotReq                       -> "Current PAB slot"
-    CurrentChainIndexSlotReq                -> "Current node slot"
+    CurrentChainIndexSlotReq                -> "Current chain index slot"
     CurrentTimeReq                          -> "Current time"
     AwaitTxStatusChangeReq txid             -> "Await tx status change:" <+> pretty txid
     AwaitTxOutStatusChangeReq ref           -> "Await txout status change:" <+> pretty ref
@@ -188,7 +188,7 @@ instance Pretty PABResp where
     AwaitUtxoSpentResp utxo                  -> "Utxo spent:" <+> pretty utxo
     AwaitUtxoProducedResp addr               -> "Utxo produced:" <+> pretty addr
     CurrentPABSlotResp s                     -> "Current PAB slot:" <+> pretty s
-    CurrentChainIndexSlotResp s              -> "Current node slot:" <+> pretty s
+    CurrentChainIndexSlotResp s              -> "Current chain index slot:" <+> pretty s
     CurrentTimeResp s                        -> "Current time:" <+> pretty s
     AwaitTxStatusChangeResp txid status      -> "Status of" <+> pretty txid <+> "changed to" <+> pretty status
     AwaitTxOutStatusChangeResp ref status    -> "Status of" <+> pretty ref <+> "changed to" <+> pretty status

--- a/plutus-contract/src/Plutus/Contract/Effects.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects.hs
@@ -13,7 +13,8 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     _AwaitTimeReq,
     _AwaitUtxoSpentReq,
     _AwaitUtxoProducedReq,
-    _CurrentSlotReq,
+    _CurrentPABSlotReq,
+    _CurrentNodeSlotReq,
     _CurrentTimeReq,
     _AwaitTxStatusChangeReq,
     _AwaitTxOutStatusChangeReq,
@@ -46,7 +47,8 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     _AwaitTimeResp,
     _AwaitUtxoSpentResp,
     _AwaitUtxoProducedResp,
-    _CurrentSlotResp,
+    _CurrentPABSlotResp,
+    _CurrentNodeSlotResp,
     _CurrentTimeResp,
     _AwaitTxStatusChangeResp,
     _AwaitTxStatusChangeResp',
@@ -120,7 +122,8 @@ data PABReq =
     | AwaitUtxoProducedReq Address
     | AwaitTxStatusChangeReq TxId
     | AwaitTxOutStatusChangeReq TxOutRef
-    | CurrentSlotReq
+    | CurrentPABSlotReq
+    | CurrentNodeSlotReq
     | CurrentTimeReq
     | OwnContractInstanceIdReq
     | OwnAddressesReq
@@ -140,7 +143,8 @@ instance Pretty PABReq where
     AwaitTimeReq s                          -> "Await time:" <+> pretty s
     AwaitUtxoSpentReq utxo                  -> "Await utxo spent:" <+> pretty utxo
     AwaitUtxoProducedReq a                  -> "Await utxo produced:" <+> pretty a
-    CurrentSlotReq                          -> "Current slot"
+    CurrentPABSlotReq                       -> "Current PAB slot"
+    CurrentNodeSlotReq                      -> "Current node slot"
     CurrentTimeReq                          -> "Current time"
     AwaitTxStatusChangeReq txid             -> "Await tx status change:" <+> pretty txid
     AwaitTxOutStatusChangeReq ref           -> "Await txout status change:" <+> pretty ref
@@ -162,7 +166,8 @@ data PABResp =
     | AwaitUtxoProducedResp (NonEmpty ChainIndexTx)
     | AwaitTxStatusChangeResp TxId TxStatus
     | AwaitTxOutStatusChangeResp TxOutRef TxOutStatus
-    | CurrentSlotResp Slot
+    | CurrentPABSlotResp Slot
+    | CurrentNodeSlotResp Slot
     | CurrentTimeResp POSIXTime
     | OwnContractInstanceIdResp ContractInstanceId
     | OwnAddressesResp (NonEmpty Address)
@@ -182,7 +187,8 @@ instance Pretty PABResp where
     AwaitTimeResp s                          -> "Time:" <+> pretty s
     AwaitUtxoSpentResp utxo                  -> "Utxo spent:" <+> pretty utxo
     AwaitUtxoProducedResp addr               -> "Utxo produced:" <+> pretty addr
-    CurrentSlotResp s                        -> "Current slot:" <+> pretty s
+    CurrentPABSlotResp s                     -> "Current PAB slot:" <+> pretty s
+    CurrentNodeSlotResp s                    -> "Current node slot:" <+> pretty s
     CurrentTimeResp s                        -> "Current time:" <+> pretty s
     AwaitTxStatusChangeResp txid status      -> "Status of" <+> pretty txid <+> "changed to" <+> pretty status
     AwaitTxOutStatusChangeResp ref status    -> "Status of" <+> pretty ref <+> "changed to" <+> pretty status
@@ -202,7 +208,8 @@ matches a b = case (a, b) of
   (AwaitTimeReq{}, AwaitTimeResp{})                        -> True
   (AwaitUtxoSpentReq{}, AwaitUtxoSpentResp{})              -> True
   (AwaitUtxoProducedReq{}, AwaitUtxoProducedResp{})        -> True
-  (CurrentSlotReq, CurrentSlotResp{})                      -> True
+  (CurrentPABSlotReq, CurrentPABSlotResp{})                -> True
+  (CurrentNodeSlotReq, CurrentNodeSlotResp{})              -> True
   (CurrentTimeReq, CurrentTimeResp{})                      -> True
   (AwaitTxStatusChangeReq i, AwaitTxStatusChangeResp i' _) -> i == i'
   (AwaitTxOutStatusChangeReq i, AwaitTxOutStatusChangeResp i' _) -> i == i'

--- a/plutus-contract/src/Plutus/Contract/Effects.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects.hs
@@ -14,7 +14,7 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     _AwaitUtxoSpentReq,
     _AwaitUtxoProducedReq,
     _CurrentPABSlotReq,
-    _CurrentNodeSlotReq,
+    _CurrentChainIndexSlotReq,
     _CurrentTimeReq,
     _AwaitTxStatusChangeReq,
     _AwaitTxOutStatusChangeReq,
@@ -48,7 +48,7 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     _AwaitUtxoSpentResp,
     _AwaitUtxoProducedResp,
     _CurrentPABSlotResp,
-    _CurrentNodeSlotResp,
+    _CurrentChainIndexSlotResp,
     _CurrentTimeResp,
     _AwaitTxStatusChangeResp,
     _AwaitTxStatusChangeResp',
@@ -123,7 +123,7 @@ data PABReq =
     | AwaitTxStatusChangeReq TxId
     | AwaitTxOutStatusChangeReq TxOutRef
     | CurrentPABSlotReq
-    | CurrentNodeSlotReq
+    | CurrentChainIndexSlotReq
     | CurrentTimeReq
     | OwnContractInstanceIdReq
     | OwnAddressesReq
@@ -144,7 +144,7 @@ instance Pretty PABReq where
     AwaitUtxoSpentReq utxo                  -> "Await utxo spent:" <+> pretty utxo
     AwaitUtxoProducedReq a                  -> "Await utxo produced:" <+> pretty a
     CurrentPABSlotReq                       -> "Current PAB slot"
-    CurrentNodeSlotReq                      -> "Current node slot"
+    CurrentChainIndexSlotReq                -> "Current node slot"
     CurrentTimeReq                          -> "Current time"
     AwaitTxStatusChangeReq txid             -> "Await tx status change:" <+> pretty txid
     AwaitTxOutStatusChangeReq ref           -> "Await txout status change:" <+> pretty ref
@@ -167,7 +167,7 @@ data PABResp =
     | AwaitTxStatusChangeResp TxId TxStatus
     | AwaitTxOutStatusChangeResp TxOutRef TxOutStatus
     | CurrentPABSlotResp Slot
-    | CurrentNodeSlotResp Slot
+    | CurrentChainIndexSlotResp Slot
     | CurrentTimeResp POSIXTime
     | OwnContractInstanceIdResp ContractInstanceId
     | OwnAddressesResp (NonEmpty Address)
@@ -188,7 +188,7 @@ instance Pretty PABResp where
     AwaitUtxoSpentResp utxo                  -> "Utxo spent:" <+> pretty utxo
     AwaitUtxoProducedResp addr               -> "Utxo produced:" <+> pretty addr
     CurrentPABSlotResp s                     -> "Current PAB slot:" <+> pretty s
-    CurrentNodeSlotResp s                    -> "Current node slot:" <+> pretty s
+    CurrentChainIndexSlotResp s              -> "Current node slot:" <+> pretty s
     CurrentTimeResp s                        -> "Current time:" <+> pretty s
     AwaitTxStatusChangeResp txid status      -> "Status of" <+> pretty txid <+> "changed to" <+> pretty status
     AwaitTxOutStatusChangeResp ref status    -> "Status of" <+> pretty ref <+> "changed to" <+> pretty status
@@ -209,7 +209,7 @@ matches a b = case (a, b) of
   (AwaitUtxoSpentReq{}, AwaitUtxoSpentResp{})              -> True
   (AwaitUtxoProducedReq{}, AwaitUtxoProducedResp{})        -> True
   (CurrentPABSlotReq, CurrentPABSlotResp{})                -> True
-  (CurrentNodeSlotReq, CurrentNodeSlotResp{})              -> True
+  (CurrentChainIndexSlotReq, CurrentChainIndexSlotResp{})              -> True
   (CurrentTimeReq, CurrentTimeResp{})                      -> True
   (AwaitTxStatusChangeReq i, AwaitTxStatusChangeResp i' _) -> i == i'
   (AwaitTxOutStatusChangeReq i, AwaitTxOutStatusChangeResp i' _) -> i == i'

--- a/plutus-contract/src/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Plutus/Contract/Request.hs
@@ -23,7 +23,7 @@ module Plutus.Contract.Request(
     , isSlot
     , currentSlot
     , currentPABSlot
-    , currentNodeSlot
+    , currentChainIndexSlot
     , waitNSlots
     , awaitTime
     , isTime
@@ -138,7 +138,7 @@ import Plutus.V1.Ledger.Api (Address, Datum, DatumHash, MintingPolicy, MintingPo
 import PlutusTx qualified
 
 import Plutus.Contract.Effects (ActiveEndpoint (ActiveEndpoint, aeDescription, aeMetadata),
-                                PABReq (AdjustUnbalancedTxReq, AwaitSlotReq, AwaitTimeReq, AwaitTxOutStatusChangeReq, AwaitTxStatusChangeReq, AwaitUtxoProducedReq, AwaitUtxoSpentReq, BalanceTxReq, ChainIndexQueryReq, CurrentNodeSlotReq, CurrentPABSlotReq, CurrentTimeReq, ExposeEndpointReq, OwnAddressesReq, OwnContractInstanceIdReq, WriteBalancedTxReq, YieldUnbalancedTxReq),
+                                PABReq (AdjustUnbalancedTxReq, AwaitSlotReq, AwaitTimeReq, AwaitTxOutStatusChangeReq, AwaitTxStatusChangeReq, AwaitUtxoProducedReq, AwaitUtxoSpentReq, BalanceTxReq, ChainIndexQueryReq, CurrentChainIndexSlotReq, CurrentPABSlotReq, CurrentTimeReq, ExposeEndpointReq, OwnAddressesReq, OwnContractInstanceIdReq, WriteBalancedTxReq, YieldUnbalancedTxReq),
                                 PABResp (ExposeEndpointResp))
 import Plutus.Contract.Effects qualified as E
 import Plutus.Contract.Logging (logDebug)
@@ -231,12 +231,12 @@ currentPABSlot ::
 currentPABSlot = pabReq CurrentPABSlotReq E._CurrentPABSlotResp
 
 -- | Get the current node slot number querying slot number from plutus chain index to be aligned with slot at local running node
-currentNodeSlot ::
+currentChainIndexSlot ::
     forall w s e.
     ( AsContractError e
     )
     => Contract w s e Slot
-currentNodeSlot = pabReq CurrentNodeSlotReq E._CurrentNodeSlotResp
+currentChainIndexSlot = pabReq CurrentChainIndexSlotReq E._CurrentChainIndexSlotResp
 
 -- | Wait for a number of slots to pass
 waitNSlots ::

--- a/plutus-contract/src/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Plutus/Contract/Request.hs
@@ -22,6 +22,8 @@ module Plutus.Contract.Request(
     awaitSlot
     , isSlot
     , currentSlot
+    , currentPABSlot
+    , currentNodeSlot
     , waitNSlots
     , awaitTime
     , isTime
@@ -136,7 +138,7 @@ import Plutus.V1.Ledger.Api (Address, Datum, DatumHash, MintingPolicy, MintingPo
 import PlutusTx qualified
 
 import Plutus.Contract.Effects (ActiveEndpoint (ActiveEndpoint, aeDescription, aeMetadata),
-                                PABReq (AdjustUnbalancedTxReq, AwaitSlotReq, AwaitTimeReq, AwaitTxOutStatusChangeReq, AwaitTxStatusChangeReq, AwaitUtxoProducedReq, AwaitUtxoSpentReq, BalanceTxReq, ChainIndexQueryReq, CurrentSlotReq, CurrentTimeReq, ExposeEndpointReq, OwnAddressesReq, OwnContractInstanceIdReq, WriteBalancedTxReq, YieldUnbalancedTxReq),
+                                PABReq (AdjustUnbalancedTxReq, AwaitSlotReq, AwaitTimeReq, AwaitTxOutStatusChangeReq, AwaitTxStatusChangeReq, AwaitUtxoProducedReq, AwaitUtxoSpentReq, BalanceTxReq, ChainIndexQueryReq, CurrentNodeSlotReq, CurrentPABSlotReq, CurrentTimeReq, ExposeEndpointReq, OwnAddressesReq, OwnContractInstanceIdReq, WriteBalancedTxReq, YieldUnbalancedTxReq),
                                 PABResp (ExposeEndpointResp))
 import Plutus.Contract.Effects qualified as E
 import Plutus.Contract.Logging (logDebug)
@@ -212,12 +214,29 @@ isSlot ::
 isSlot = Promise . awaitSlot
 
 -- | Get the current slot number
+{-# DEPRECATED currentSlot "It was renamed to 'currentPABSlot', this function will be removed" #-}
 currentSlot ::
     forall w s e.
     ( AsContractError e
     )
     => Contract w s e Slot
-currentSlot = pabReq CurrentSlotReq E._CurrentSlotResp
+currentSlot = currentPABSlot
+
+-- | Get the current slot number of PAB
+currentPABSlot ::
+    forall w s e.
+    ( AsContractError e
+    )
+    => Contract w s e Slot
+currentPABSlot = pabReq CurrentPABSlotReq E._CurrentPABSlotResp
+
+-- | Get the current node slot number querying slot number from plutus chain index to be aligned with slot at local running node
+currentNodeSlot ::
+    forall w s e.
+    ( AsContractError e
+    )
+    => Contract w s e Slot
+currentNodeSlot = pabReq CurrentNodeSlotReq E._CurrentNodeSlotResp
 
 -- | Wait for a number of slots to pass
 waitNSlots ::

--- a/plutus-contract/src/Plutus/Contract/Trace.hs
+++ b/plutus-contract/src/Plutus/Contract/Trace.hs
@@ -127,7 +127,6 @@ handleCurrentPABSlotQueries =
 
 handleCurrentNodeSlotQueries ::
     ( Member (LogObserve (LogMessage Text)) effs
-    , Member NodeClientEffect effs
     , Member ChainIndexQueryEffect effs
     )
     => RequestHandler effs PABReq PABResp

--- a/plutus-contract/src/Plutus/Contract/Trace.hs
+++ b/plutus-contract/src/Plutus/Contract/Trace.hs
@@ -28,7 +28,8 @@ module Plutus.Contract.Trace
     , handleSlotNotifications
     , handleTimeNotifications
     , handleOwnAddressesQueries
-    , handleCurrentSlotQueries
+    , handleCurrentPABSlotQueries
+    , handleCurrentNodeSlotQueries
     , handleCurrentTimeQueries
     , handleTimeToSlotConversions
     , handleUnbalancedTransactions
@@ -116,13 +117,22 @@ handleTimeNotifications ::
 handleTimeNotifications =
     generalise (preview E._AwaitTimeReq) E.AwaitTimeResp RequestHandler.handleTimeNotifications
 
-handleCurrentSlotQueries ::
+handleCurrentPABSlotQueries ::
     ( Member (LogObserve (LogMessage Text)) effs
     , Member NodeClientEffect effs
     )
     => RequestHandler effs PABReq PABResp
-handleCurrentSlotQueries =
-    generalise (preview E._CurrentSlotReq) E.CurrentSlotResp RequestHandler.handleCurrentSlot
+handleCurrentPABSlotQueries =
+    generalise (preview E._CurrentPABSlotReq) E.CurrentPABSlotResp RequestHandler.handleCurrentPABSlot
+
+handleCurrentNodeSlotQueries ::
+    ( Member (LogObserve (LogMessage Text)) effs
+    , Member NodeClientEffect effs
+    , Member ChainIndexQueryEffect effs
+    )
+    => RequestHandler effs PABReq PABResp
+handleCurrentNodeSlotQueries =
+    generalise (preview E._CurrentNodeSlotReq) E.CurrentNodeSlotResp RequestHandler.handleCurrentNodeSlot
 
 handleCurrentTimeQueries ::
     ( Member (LogObserve (LogMessage Text)) effs

--- a/plutus-contract/src/Plutus/Contract/Trace.hs
+++ b/plutus-contract/src/Plutus/Contract/Trace.hs
@@ -29,7 +29,7 @@ module Plutus.Contract.Trace
     , handleTimeNotifications
     , handleOwnAddressesQueries
     , handleCurrentPABSlotQueries
-    , handleCurrentNodeSlotQueries
+    , handleCurrentChainIndexSlotQueries
     , handleCurrentTimeQueries
     , handleTimeToSlotConversions
     , handleUnbalancedTransactions
@@ -125,13 +125,13 @@ handleCurrentPABSlotQueries ::
 handleCurrentPABSlotQueries =
     generalise (preview E._CurrentPABSlotReq) E.CurrentPABSlotResp RequestHandler.handleCurrentPABSlot
 
-handleCurrentNodeSlotQueries ::
+handleCurrentChainIndexSlotQueries ::
     ( Member (LogObserve (LogMessage Text)) effs
     , Member ChainIndexQueryEffect effs
     )
     => RequestHandler effs PABReq PABResp
-handleCurrentNodeSlotQueries =
-    generalise (preview E._CurrentNodeSlotReq) E.CurrentNodeSlotResp RequestHandler.handleCurrentNodeSlot
+handleCurrentChainIndexSlotQueries =
+    generalise (preview E._CurrentChainIndexSlotReq) E.CurrentChainIndexSlotResp RequestHandler.handleCurrentChainIndexSlot
 
 handleCurrentTimeQueries ::
     ( Member (LogObserve (LogMessage Text)) effs

--- a/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
+++ b/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
@@ -171,8 +171,7 @@ handleCurrentPABSlot =
 
 handleCurrentNodeSlot ::
     forall effs a.
-    ( Member NodeClientEffect effs
-    , Member (LogObserve (LogMessage Text)) effs
+    ( Member (LogObserve (LogMessage Text)) effs
     , Member ChainIndexQueryEffect effs
     )
     => RequestHandler effs a Slot

--- a/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
+++ b/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
@@ -21,7 +21,7 @@ module Plutus.Contract.Trace.RequestHandler(
     , handleOwnAddresses
     , handleSlotNotifications
     , handleCurrentPABSlot
-    , handleCurrentNodeSlot
+    , handleCurrentChainIndexSlot
     , handleTimeNotifications
     , handleCurrentTime
     , handleTimeToSlotConversions
@@ -169,15 +169,15 @@ handleCurrentPABSlot =
         surroundDebug @Text "handleCurrentPABSlot" $ do
             Wallet.Effects.getClientSlot
 
-handleCurrentNodeSlot ::
+handleCurrentChainIndexSlot ::
     forall effs a.
     ( Member (LogObserve (LogMessage Text)) effs
     , Member ChainIndexQueryEffect effs
     )
     => RequestHandler effs a Slot
-handleCurrentNodeSlot =
+handleCurrentChainIndexSlot =
     RequestHandler $ \_ ->
-        surroundDebug @Text "handleCurrentNodeSlot" $ do
+        surroundDebug @Text "handleCurrentChainIndexSlot" $ do
             t <- ChainIndexEff.getTip
             case t of
                 TipAtGenesis   -> return $ Slot 0

--- a/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
+++ b/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
@@ -20,7 +20,8 @@ module Plutus.Contract.Trace.RequestHandler(
     , handleAdjustUnbalancedTx
     , handleOwnAddresses
     , handleSlotNotifications
-    , handleCurrentSlot
+    , handleCurrentPABSlot
+    , handleCurrentNodeSlot
     , handleTimeNotifications
     , handleCurrentTime
     , handleTimeToSlotConversions
@@ -49,12 +50,13 @@ import Plutus.Contract.Resumable (Request (Request, itID, rqID, rqRequest),
 
 import Control.Monad.Freer.Extras.Log (LogMessage, LogMsg, LogObserve, logDebug, logWarn, surroundDebug)
 import Data.List.NonEmpty (NonEmpty)
-import Ledger (POSIXTime, POSIXTimeRange, Params (..), Slot, SlotRange)
+import Ledger (POSIXTime, POSIXTimeRange, Params (..), Slot (..), SlotRange)
 import Ledger.Constraints.OffChain (UnbalancedTx, adjustUnbalancedTx)
 import Ledger.TimeSlot qualified as TimeSlot
 import Ledger.Tx (CardanoTx, ToCardanoError)
 import Plutus.ChainIndex (ChainIndexQueryEffect)
 import Plutus.ChainIndex.Effects qualified as ChainIndexEff
+import Plutus.ChainIndex.Types (Tip (..))
 import Plutus.Contract.Effects (ChainIndexQuery (..), ChainIndexResponse (..))
 import Plutus.Contract.Wallet qualified as Wallet
 import Plutus.V1.Ledger.Api (Address)
@@ -156,16 +158,31 @@ handleTimeNotifications =
             guard (currentSlot >= targetSlot_)
             pure $ TimeSlot.slotToEndPOSIXTime pSlotConfig currentSlot
 
-handleCurrentSlot ::
+handleCurrentPABSlot ::
     forall effs a.
     ( Member NodeClientEffect effs
     , Member (LogObserve (LogMessage Text)) effs
     )
     => RequestHandler effs a Slot
-handleCurrentSlot =
+handleCurrentPABSlot =
     RequestHandler $ \_ ->
-        surroundDebug @Text "handleCurrentSlot" $ do
+        surroundDebug @Text "handleCurrentPABSlot" $ do
             Wallet.Effects.getClientSlot
+
+handleCurrentNodeSlot ::
+    forall effs a.
+    ( Member NodeClientEffect effs
+    , Member (LogObserve (LogMessage Text)) effs
+    , Member ChainIndexQueryEffect effs
+    )
+    => RequestHandler effs a Slot
+handleCurrentNodeSlot =
+    RequestHandler $ \_ ->
+        surroundDebug @Text "handleCurrentNodeSlot" $ do
+            t <- ChainIndexEff.getTip
+            case t of
+                TipAtGenesis   -> return $ Slot 0
+                (Tip slot _ _) -> return slot
 
 handleCurrentTime ::
     forall effs a.

--- a/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
@@ -253,7 +253,8 @@ handleBlockchainQueries =
     <> RequestHandler.handleOwnAddressesQueries
     <> RequestHandler.handleOwnInstanceIdQueries
     <> RequestHandler.handleSlotNotifications
-    <> RequestHandler.handleCurrentSlotQueries
+    <> RequestHandler.handleCurrentPABSlotQueries
+    <> RequestHandler.handleCurrentNodeSlotQueries
     <> RequestHandler.handleTimeNotifications
     <> RequestHandler.handleCurrentTimeQueries
     <> RequestHandler.handleTimeToSlotConversions

--- a/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
@@ -254,7 +254,7 @@ handleBlockchainQueries =
     <> RequestHandler.handleOwnInstanceIdQueries
     <> RequestHandler.handleSlotNotifications
     <> RequestHandler.handleCurrentPABSlotQueries
-    <> RequestHandler.handleCurrentNodeSlotQueries
+    <> RequestHandler.handleCurrentChainIndexSlotQueries
     <> RequestHandler.handleTimeNotifications
     <> RequestHandler.handleCurrentTimeQueries
     <> RequestHandler.handleTimeToSlotConversions

--- a/plutus-pab/src/Plutus/PAB/Arbitrary.hs
+++ b/plutus-pab/src/Plutus/PAB/Arbitrary.hs
@@ -262,7 +262,7 @@ instance Arbitrary PABReq where
         oneof
             [ AwaitSlotReq <$> arbitrary
             , pure CurrentPABSlotReq
-            , pure CurrentNodeSlotReq
+            , pure CurrentChainIndexSlotReq
             , pure OwnContractInstanceIdReq
             , ExposeEndpointReq <$> arbitrary
             , pure OwnAddressesReq

--- a/plutus-pab/src/Plutus/PAB/Arbitrary.hs
+++ b/plutus-pab/src/Plutus/PAB/Arbitrary.hs
@@ -261,7 +261,8 @@ instance Arbitrary PABReq where
     arbitrary =
         oneof
             [ AwaitSlotReq <$> arbitrary
-            , pure CurrentSlotReq
+            , pure CurrentPABSlotReq
+            , pure CurrentNodeSlotReq
             , pure OwnContractInstanceIdReq
             , ExposeEndpointReq <$> arbitrary
             , pure OwnAddressesReq

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
@@ -268,7 +268,8 @@ stmRequestHandler = fmap sequence (wrapHandler (fmap pure nonBlockingRequests) <
         <> RequestHandler.handleUnbalancedTransactions @effs
         <> RequestHandler.handlePendingTransactions @effs
         <> RequestHandler.handleOwnInstanceIdQueries @effs
-        <> RequestHandler.handleCurrentSlotQueries @effs
+        <> RequestHandler.handleCurrentPABSlotQueries @effs
+        <> RequestHandler.handleCurrentNodeSlotQueries @effs
         <> RequestHandler.handleCurrentTimeQueries @effs
         <> RequestHandler.handleYieldedUnbalancedTx @effs
         <> RequestHandler.handleAdjustUnbalancedTx @effs

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
@@ -269,7 +269,7 @@ stmRequestHandler = fmap sequence (wrapHandler (fmap pure nonBlockingRequests) <
         <> RequestHandler.handlePendingTransactions @effs
         <> RequestHandler.handleOwnInstanceIdQueries @effs
         <> RequestHandler.handleCurrentPABSlotQueries @effs
-        <> RequestHandler.handleCurrentNodeSlotQueries @effs
+        <> RequestHandler.handleCurrentChainIndexSlotQueries @effs
         <> RequestHandler.handleCurrentTimeQueries @effs
         <> RequestHandler.handleYieldedUnbalancedTx @effs
         <> RequestHandler.handleAdjustUnbalancedTx @effs

--- a/plutus-use-cases/src/Plutus/Contracts/PubKey.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/PubKey.hs
@@ -105,7 +105,7 @@ pubKeyContract pk vl = mapError (review _PubKeyError   ) $ do
             -- The 'awaitChainIndexSlot' blocks the contract until the chain-index
             -- is synced until the current slot. This is not a good solution,
             -- as the chain-index is always some time behind the current slot.
-            slot <- currentSlot
+            slot <- currentPABSlot
             awaitChainIndexSlot slot
 
             ciTxOut <- unspentTxOutFromRef outRef


### PR DESCRIPTION
- Deprecates 'currentSlot' contract method.
- Introduces 'currentPABSlot' - a replacement for 'currentSlot'.
- Introduces 'currentChainIndexSlot' to query the chain index's node's slot.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
