### PR TITLE
Replace Ledger.Tx.ChainIndexTxOut

### DIFF
--- a/doc/plutus/tutorials/EscrowImpl.hs
+++ b/doc/plutus/tutorials/EscrowImpl.hs
@@ -308,7 +308,7 @@ redeem inst escrow = mapError (review _EscrowError) $ do
                 <> Constraints.mustValidateIn valRange
     if current >= escrowDeadline escrow
     then throwing _RedeemFailed DeadlinePassed
-    else if foldMap (view Tx.ciTxOutValue) unspentOutputs `lt` targetTotal escrow
+    else if foldMap Tx.ocTxOutValue unspentOutputs `lt` targetTotal escrow
          then throwing _RedeemFailed NotEnoughFundsAtAddress
          else do
            utx <- mkTxConstraints ( Constraints.typedValidatorLookups inst
@@ -338,7 +338,11 @@ refund ::
 refund inst escrow = do
     pk <- ownFirstPaymentPubKeyHash
     unspentOutputs <- utxosAt (Scripts.validatorAddress inst)
-    let flt _ ciTxOut = either id Scripts.datumHash (Tx._ciTxOutScriptDatum ciTxOut) == Scripts.datumHash (Datum (PlutusTx.toBuiltinData pk))
+    let flt _ ocTxOut = case ocTxOut of
+                          Tx.ScriptOffChainTxOut _vh _v dh _m_va _m_da _m_rs ->
+                            dh == Scripts.datumHash (Datum (PlutusTx.toBuiltinData pk))
+                          Tx.PublicKeyOffChainTxOut {} ->
+                            False
         tx' = Typed.collectFromScriptFilter flt unspentOutputs Refund
                 <> Constraints.mustValidateIn (from (Haskell.succ $ escrowDeadline escrow))
     if Constraints.modifiesUtxoSet tx'
@@ -361,7 +365,7 @@ payRedeemRefund params vl = do
     let inst = typedValidator params
         go = do
             cur <- utxosAt (Scripts.validatorAddress inst)
-            let presentVal = foldMap (view Tx.ciTxOutValue) cur
+            let presentVal = foldMap Tx.ocTxOutValue cur
             if presentVal `geq` targetTotal params
                 then Right <$> redeem inst params
                 else do

--- a/playground-common/src/PSGenerator/Common.hs
+++ b/playground-common/src/PSGenerator/Common.hs
@@ -21,7 +21,7 @@ import Language.PureScript.Bridge (BridgePart, DataConstructor (DataConstructor,
 import Language.PureScript.Bridge.Builder (BridgeData)
 import Language.PureScript.Bridge.PSTypes (psInt, psNumber, psString)
 import Language.PureScript.Bridge.TypeParameters (A)
-import Ledger (Address, BlockId, CardanoTx, ChainIndexTxOut, OnChainTx, PaymentPubKey, PaymentPubKeyHash, PubKey,
+import Ledger (Address, BlockId, CardanoTx, OffChainTxOut, OnChainTx, PaymentPubKey, PaymentPubKeyHash, PubKey,
                PubKeyHash, RedeemerPtr, ScriptTag, Signature, StakePubKey, StakePubKeyHash, Tx, TxId, TxIn, TxInType,
                TxOut, TxOutRef, TxOutTx, UtxoIndex, ValidationPhase)
 import Ledger.Ada (Ada)
@@ -423,7 +423,7 @@ ledgerTypes =
     , equal . genericShow . argonaut $ mkSumType @ChainIndexTx
     , equal . genericShow . argonaut $ mkSumType @ChainIndex.ChainIndexTxOut
     , equal . genericShow . argonaut $ mkSumType @ChainIndexTxOutputs
-    , equal . genericShow . argonaut $ mkSumType @ChainIndexTxOut
+    , equal . genericShow . argonaut $ mkSumType @OffChainTxOut
     , equal . genericShow . argonaut $ mkSumType @ChainIndexLog
     , equal . genericShow . argonaut $ mkSumType @ChainIndexError
     , equal . genericShow . argonaut $ mkSumType @BeamError

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Api.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Api.hs
@@ -30,7 +30,7 @@ import Data.Proxy (Proxy (..))
 import GHC.Generics (Generic)
 import Ledger (AssetClass, TxId)
 import Ledger.Credential (Credential)
-import Ledger.Tx (ChainIndexTxOut, TxOutRef)
+import Ledger.Tx (OffChainTxOut, TxOutRef)
 import Plutus.ChainIndex.Tx (ChainIndexTx)
 import Plutus.ChainIndex.Types (Diagnostics, Tip)
 import Plutus.V1.Ledger.Api (Datum, DatumHash, MintingPolicy, MintingPolicyHash, Redeemer, RedeemerHash, StakeValidator,
@@ -171,12 +171,12 @@ deriving instance (OpenApi.ToSchema a, Generic a) => OpenApi.ToSchema (QueryResp
 type API
     = "healthcheck" :> Description "Is the server alive?" :> Get '[JSON] NoContent
     :<|> "from-hash" :> FromHashAPI
-    :<|> "tx-out" :> Description "Get a transaction output from its reference." :> ReqBody '[JSON] TxOutRef :> Post '[JSON] ChainIndexTxOut
-    :<|> "unspent-tx-out" :> Description "Get a unspent transaction output from its reference." :> ReqBody '[JSON] TxOutRef :> Post '[JSON] ChainIndexTxOut
+    :<|> "tx-out" :> Description "Get a transaction output from its reference." :> ReqBody '[JSON] TxOutRef :> Post '[JSON] OffChainTxOut
+    :<|> "unspent-tx-out" :> Description "Get a unspent transaction output from its reference." :> ReqBody '[JSON] TxOutRef :> Post '[JSON] OffChainTxOut
     :<|> "tx" :> Description "Get a transaction from its id." :> ReqBody '[JSON] TxId :> Post '[JSON] ChainIndexTx
     :<|> "is-utxo" :> Description "Check if the reference is an UTxO." :> ReqBody '[JSON] TxOutRef :> Post '[JSON] IsUtxoResponse
     :<|> "utxo-at-address" :> Description "Get all UTxOs at an address." :> ReqBody '[JSON] UtxoAtAddressRequest :> Post '[JSON] UtxosResponse
-    :<|> "unspent-txouts-at-address" :> Description "Get all unspent transaction output at an address." :> ReqBody '[JSON] QueryAtAddressRequest :> Post '[JSON] (QueryResponse [(TxOutRef, ChainIndexTxOut)])
+    :<|> "unspent-txouts-at-address" :> Description "Get all unspent transaction output at an address." :> ReqBody '[JSON] QueryAtAddressRequest :> Post '[JSON] (QueryResponse [(TxOutRef, OffChainTxOut)])
     :<|> "utxo-with-currency" :> Description "Get all UTxOs with a currency." :> ReqBody '[JSON] UtxoWithCurrencyRequest :> Post '[JSON] UtxosResponse
     :<|> "txs" :> Description "Get transactions from a list of their ids." :> ReqBody '[JSON] [TxId] :> Post '[JSON] [ChainIndexTx]
     :<|> "txo-at-address" :> Description "Get TxOs at an address." :> ReqBody '[JSON] TxoAtAddressRequest :> Post '[JSON] TxosResponse

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Client.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Client.hs
@@ -32,7 +32,7 @@ import Control.Monad.Freer.Reader (Reader, ask)
 import Control.Monad.IO.Class (MonadIO (..))
 import Data.Proxy (Proxy (..))
 import Ledger (TxId)
-import Ledger.Tx (ChainIndexTxOut, TxOutRef)
+import Ledger.Tx (OffChainTxOut, TxOutRef)
 import Network.HTTP.Types.Status (Status (..))
 import Plutus.ChainIndex.Api (API, IsUtxoResponse, QueryAtAddressRequest (QueryAtAddressRequest), QueryResponse,
                               TxoAtAddressRequest (TxoAtAddressRequest), TxosResponse,
@@ -57,12 +57,12 @@ getMintingPolicy :: MintingPolicyHash -> ClientM MintingPolicy
 getStakeValidator :: StakeValidatorHash -> ClientM StakeValidator
 getRedeemer :: RedeemerHash -> ClientM Redeemer
 
-getTxOut :: TxOutRef -> ClientM ChainIndexTxOut
+getTxOut :: TxOutRef -> ClientM OffChainTxOut
 getTx :: TxId -> ClientM ChainIndexTx
-getUnspentTxOut :: TxOutRef -> ClientM ChainIndexTxOut
+getUnspentTxOut :: TxOutRef -> ClientM OffChainTxOut
 getIsUtxo :: TxOutRef -> ClientM IsUtxoResponse
 getUtxoSetAtAddress :: UtxoAtAddressRequest -> ClientM UtxosResponse
-getUnspentTxOutsAtAddress :: QueryAtAddressRequest -> ClientM (QueryResponse [(TxOutRef, ChainIndexTxOut)])
+getUnspentTxOutsAtAddress :: QueryAtAddressRequest -> ClientM (QueryResponse [(TxOutRef, OffChainTxOut)])
 getUtxoSetWithCurrency :: UtxoWithCurrencyRequest -> ClientM UtxosResponse
 getTxs :: [TxId] -> ClientM [ChainIndexTx]
 getTxoSetAtAddress :: TxoAtAddressRequest -> ClientM TxosResponse

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/DbSchema.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/DbSchema.hs
@@ -36,7 +36,7 @@ import Database.Beam (Beamable, Columnar, Database, DatabaseSettings, FromBacken
 import Database.Beam.Migrate (CheckedDatabaseSettings, defaultMigratableDbSettings, renameCheckedEntity,
                               unCheckDatabase)
 import Database.Beam.Sqlite (Sqlite)
-import Ledger (BlockId (..), ChainIndexTxOut (..), Slot)
+import Ledger (BlockId (..), OffChainTxOut (..), Slot)
 import Plutus.ChainIndex.Tx (ChainIndexTx)
 import Plutus.ChainIndex.Tx qualified as CI
 import Plutus.ChainIndex.Types (BlockNumber (..), Tip (..))
@@ -262,7 +262,7 @@ deriving via Serialisable Redeemer instance HasDbType Redeemer
 deriving via Serialisable StakeValidator instance HasDbType StakeValidator
 deriving via Serialisable Validator instance HasDbType Validator
 deriving via Serialisable ChainIndexTx instance HasDbType ChainIndexTx
-deriving via Serialisable ChainIndexTxOut instance HasDbType ChainIndexTxOut
+deriving via Serialisable OffChainTxOut instance HasDbType OffChainTxOut
 deriving via Serialisable TxOutRef instance HasDbType TxOutRef
 deriving via Serialisable CI.ChainIndexTxOut instance HasDbType CI.ChainIndexTxOut
 deriving via Serialisable Credential instance HasDbType Credential

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Effects.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Effects.hs
@@ -34,7 +34,7 @@ import Control.Monad.Freer.Extras.Pagination (PageQuery)
 import Control.Monad.Freer.TH (makeEffect)
 import Ledger (AssetClass, TxId)
 import Ledger.Credential (Credential)
-import Ledger.Tx (ChainIndexTxOut, TxOutRef)
+import Ledger.Tx (OffChainTxOut, TxOutRef)
 import Plutus.ChainIndex.Api (IsUtxoResponse, QueryResponse, TxosResponse, UtxosResponse)
 import Plutus.ChainIndex.Tx (ChainIndexTx)
 import Plutus.ChainIndex.Types (ChainSyncBlock, Diagnostics, Point, Tip)
@@ -59,10 +59,10 @@ data ChainIndexQueryEffect r where
     StakeValidatorFromHash :: StakeValidatorHash -> ChainIndexQueryEffect (Maybe StakeValidator)
 
     -- | Get the TxOut from a TxOutRef (if available)
-    UnspentTxOutFromRef :: TxOutRef -> ChainIndexQueryEffect (Maybe ChainIndexTxOut)
+    UnspentTxOutFromRef :: TxOutRef -> ChainIndexQueryEffect (Maybe OffChainTxOut)
 
     -- | Get the TxOut from a TxOutRef (if available)
-    TxOutFromRef :: TxOutRef -> ChainIndexQueryEffect (Maybe ChainIndexTxOut)
+    TxOutFromRef :: TxOutRef -> ChainIndexQueryEffect (Maybe OffChainTxOut)
 
     -- | Get the transaction for a tx ID
     TxFromTxId :: TxId -> ChainIndexQueryEffect (Maybe ChainIndexTx)
@@ -75,7 +75,7 @@ data ChainIndexQueryEffect r where
 
     -- | Get the unspent txouts located at an address
     -- This is to avoid multiple queries from chain-index when using utxosAt
-    UnspentTxOutSetAtAddress :: PageQuery TxOutRef -> Credential -> ChainIndexQueryEffect (QueryResponse [(TxOutRef, ChainIndexTxOut)])
+    UnspentTxOutSetAtAddress :: PageQuery TxOutRef -> Credential -> ChainIndexQueryEffect (QueryResponse [(TxOutRef, OffChainTxOut)])
 
     -- | Unspent outputs containing a specific currency ('AssetClass').
     --

--- a/plutus-chain-index-core/test/Plutus/ChainIndex/Emulator/DiskStateSpec.hs
+++ b/plutus-chain-index-core/test/Plutus/ChainIndex/Emulator/DiskStateSpec.hs
@@ -32,19 +32,19 @@ addressMapAndTxShouldShareTxOuts :: Property
 addressMapAndTxShouldShareTxOuts = property $ do
     chainIndexTx <- forAll $ Gen.evalTxGenState Gen.genTx
     let diskState = DiskState.fromTx chainIndexTx
-        ciTxOutRefs = Set.fromList $ fmap snd $ txOutsWithRef chainIndexTx
+        txOutRefs = Set.fromList $ fmap snd $ txOutsWithRef chainIndexTx
         addressMapTxOutRefs =
           mconcat $ diskState ^.. DiskState.addressMap . DiskState.unCredentialMap . folded
-    ciTxOutRefs === addressMapTxOutRefs
+    txOutRefs === addressMapTxOutRefs
 
 assetClassMapAndTxShouldShareTxOuts :: Property
 assetClassMapAndTxShouldShareTxOuts = property $ do
     chainIndexTx <- forAll $ Gen.evalTxGenState Gen.genTx
     let diskState = DiskState.fromTx chainIndexTx
-        ciTxOutRefs = Set.fromList
+        txOutRefs = Set.fromList
                     $ fmap snd
                     $ filter (\(ChainIndexTxOut{citoValue}, _) -> citoValue /= Ada.toValue (Ada.fromValue citoValue))
                     $ txOutsWithRef chainIndexTx
         assetClassMapTxOutRefs =
           mconcat $ diskState ^.. DiskState.assetClassMap . DiskState.unAssetClassMap . folded
-    ciTxOutRefs === assetClassMapTxOutRefs
+    txOutRefs === assetClassMapTxOutRefs

--- a/plutus-contract/src/Plutus/Contract/Effects.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects.hs
@@ -97,7 +97,7 @@ import Ledger.Scripts (Validator)
 import Ledger.Slot (Slot, SlotRange)
 import Ledger.Time (POSIXTime, POSIXTimeRange)
 import Ledger.TimeSlot (SlotConversionError)
-import Ledger.Tx (CardanoTx, ChainIndexTxOut, getCardanoTxId, onCardanoTx)
+import Ledger.Tx (CardanoTx, OffChainTxOut, getCardanoTxId, onCardanoTx)
 import Plutus.ChainIndex (Page (pageItems), PageQuery)
 import Plutus.ChainIndex.Api (IsUtxoResponse (IsUtxoResponse), QueryResponse (QueryResponse),
                               TxosResponse (TxosResponse), UtxosResponse (UtxosResponse))
@@ -284,13 +284,13 @@ data ChainIndexResponse =
   | ValidatorHashResponse (Maybe Validator)
   | MintingPolicyHashResponse (Maybe MintingPolicy)
   | StakeValidatorHashResponse (Maybe StakeValidator)
-  | TxOutRefResponse (Maybe ChainIndexTxOut)
-  | UnspentTxOutResponse (Maybe ChainIndexTxOut)
+  | TxOutRefResponse (Maybe OffChainTxOut)
+  | UnspentTxOutResponse (Maybe OffChainTxOut)
   | RedeemerHashResponse (Maybe Redeemer)
   | TxIdResponse (Maybe ChainIndexTx)
   | UtxoSetMembershipResponse IsUtxoResponse
   | UtxoSetAtResponse UtxosResponse
-  | UnspentTxOutsAtResponse (QueryResponse [(TxOutRef, ChainIndexTxOut)])
+  | UnspentTxOutsAtResponse (QueryResponse [(TxOutRef, OffChainTxOut)])
   | UtxoSetWithCurrencyResponse UtxosResponse
   | TxIdsResponse [ChainIndexTx]
   | TxoSetAtResponse TxosResponse

--- a/plutus-contract/src/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Plutus/Contract/Request.hs
@@ -12,7 +12,6 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
@@ -127,7 +126,7 @@ import Ledger (AssetClass, DiffMilliSeconds, POSIXTime, PaymentPubKeyHash (Payme
 import Ledger.Constraints (TxConstraints)
 import Ledger.Constraints.OffChain (ScriptLookups, UnbalancedTx)
 import Ledger.Constraints.OffChain qualified as Constraints
-import Ledger.Tx (CardanoTx, ChainIndexTxOut, ciTxOutValue, getCardanoTxId)
+import Ledger.Tx (CardanoTx, OffChainTxOut, getCardanoTxId, ocTxOutValue)
 import Ledger.Typed.Scripts (Any, TypedValidator, ValidatorTypes (DatumType, RedeemerType))
 import Ledger.Value qualified as V
 import Plutus.Contract.Util (loopM)
@@ -345,7 +344,7 @@ txOutFromRef ::
     ( AsContractError e
     )
     => TxOutRef
-    -> Contract w s e (Maybe ChainIndexTxOut)
+    -> Contract w s e (Maybe OffChainTxOut)
 txOutFromRef ref = do
   cir <- pabReq (ChainIndexQueryReq $ E.TxOutFromRef ref) E._ChainIndexQueryResp
   case cir of
@@ -357,7 +356,7 @@ unspentTxOutFromRef ::
     ( AsContractError e
     )
     => TxOutRef
-    -> Contract w s e (Maybe ChainIndexTxOut)
+    -> Contract w s e (Maybe OffChainTxOut)
 unspentTxOutFromRef ref = do
   cir <- pabReq (ChainIndexQueryReq $ E.UnspentTxOutFromRef ref) E._ChainIndexQueryResp
   case cir of
@@ -417,7 +416,7 @@ utxoRefsWithCurrency pq assetClass = do
     r                               -> throwError $ review _ChainIndexContractError ("UtxoSetWithCurrencyResponse", r)
 
 -- | Get all utxos belonging to the wallet that runs this contract.
-ownUtxos :: forall w s e. (AsContractError e) => Contract w s e (Map TxOutRef ChainIndexTxOut)
+ownUtxos :: forall w s e. (AsContractError e) => Contract w s e (Map TxOutRef OffChainTxOut)
 ownUtxos = do
     addrs <- ownAddresses
     fold <$> mapM utxosAt (NonEmpty.toList addrs)
@@ -429,7 +428,7 @@ queryUnspentTxOutsAt ::
     )
     => Address
     -> PageQuery TxOutRef
-    -> Contract w s e (QueryResponse [(TxOutRef, ChainIndexTxOut)])
+    -> Contract w s e (QueryResponse [(TxOutRef, OffChainTxOut)])
 queryUnspentTxOutsAt addr pq = do
   cir <- pabReq (ChainIndexQueryReq $ E.UnspentTxOutSetAtAddress pq $ addressCredential addr) E._ChainIndexQueryResp
   case cir of
@@ -442,7 +441,7 @@ utxosAt ::
     ( AsContractError e
     )
     => Address
-    -> Contract w s e (Map TxOutRef ChainIndexTxOut)
+    -> Contract w s e (Map TxOutRef OffChainTxOut)
 utxosAt addr =
   Map.fromList . concat <$> collectQueryResponse (queryUnspentTxOutsAt addr)
 
@@ -452,14 +451,14 @@ utxosTxOutTxAt ::
     ( AsContractError e
     )
     => Address
-    -> Contract w s e (Map TxOutRef (ChainIndexTxOut, ChainIndexTx))
+    -> Contract w s e (Map TxOutRef (OffChainTxOut, ChainIndexTx))
 utxosTxOutTxAt addr = do
   utxos <- utxosAt addr
   evalStateT (Map.traverseMaybeWithKey go utxos) mempty
   where
     go :: TxOutRef
-       -> ChainIndexTxOut
-       -> StateT (Map TxId ChainIndexTx) (Contract w s e) (Maybe (ChainIndexTxOut, ChainIndexTx))
+       -> OffChainTxOut
+       -> StateT (Map TxId ChainIndexTx) (Contract w s e) (Maybe (OffChainTxOut, ChainIndexTx))
     go ref out = StateT $ \lookupTx -> do
       let txid = txOutRefId ref
       -- Lookup the txid in the lookup table. If it's present, we don't need
@@ -483,13 +482,13 @@ utxosTxOutTxAt addr = do
 utxosTxOutTxFromTx ::
     AsContractError e
     => ChainIndexTx
-    -> Contract w s e [(TxOutRef, (ChainIndexTxOut, ChainIndexTx))]
+    -> Contract w s e [(TxOutRef, (OffChainTxOut, ChainIndexTx))]
 utxosTxOutTxFromTx tx =
   catMaybes <$> mapM mkOutRef (txOutRefs tx)
   where
     mkOutRef txOutRef = do
-      ciTxOutM <- unspentTxOutFromRef txOutRef
-      pure $ ciTxOutM >>= \ciTxOut -> pure (txOutRef, (ciTxOut, tx))
+      ocTxOutM <- unspentTxOutFromRef txOutRef
+      pure $ ocTxOutM >>= \ocTxOut -> pure (txOutRef, (ocTxOut, tx))
 
 foldTxoRefsAt ::
     forall w s e a.
@@ -569,7 +568,7 @@ watchAddressUntilSlot ::
     )
     => Address
     -> Slot
-    -> Contract w s e (Map TxOutRef ChainIndexTxOut)
+    -> Contract w s e (Map TxOutRef OffChainTxOut)
 watchAddressUntilSlot a slot = awaitSlot slot >> utxosAt a
 
 -- | Wait until the target time and get the unspent transaction outputs at an
@@ -580,7 +579,7 @@ watchAddressUntilTime ::
     )
     => Address
     -> POSIXTime
-    -> Contract w s e (Map TxOutRef ChainIndexTxOut)
+    -> Contract w s e (Map TxOutRef OffChainTxOut)
 watchAddressUntilTime a time = awaitTime time >> utxosAt a
 
 {-| Wait until the UTXO has been spent, returning the transaction that spends it.
@@ -633,7 +632,7 @@ fundsAtAddressGt
        )
     => Address
     -> Value
-    -> Contract w s e (Map TxOutRef ChainIndexTxOut)
+    -> Contract w s e (Map TxOutRef OffChainTxOut)
 fundsAtAddressGt addr vl =
     fundsAtAddressCondition (\presentVal -> presentVal `V.gt` vl) addr
 
@@ -643,11 +642,11 @@ fundsAtAddressCondition
        )
     => (Value -> Bool)
     -> Address
-    -> Contract w s e (Map TxOutRef ChainIndexTxOut)
+    -> Contract w s e (Map TxOutRef OffChainTxOut)
 fundsAtAddressCondition condition addr = loopM go () where
     go () = do
         cur <- utxosAt addr
-        let presentVal = foldMap (view ciTxOutValue) cur
+        let presentVal = foldMap ocTxOutValue cur
         if condition presentVal
             then pure (Right cur)
             else awaitUtxoProduced addr >> pure (Left ())
@@ -661,7 +660,7 @@ fundsAtAddressGeq
        )
     => Address
     -> Value
-    -> Contract w s e (Map TxOutRef ChainIndexTxOut)
+    -> Contract w s e (Map TxOutRef OffChainTxOut)
 fundsAtAddressGeq addr vl =
     fundsAtAddressCondition (\presentVal -> presentVal `V.geq` vl) addr
 
@@ -878,7 +877,7 @@ submitTxConstraintsSpending
   , AsContractError e
   )
   => TypedValidator a
-  -> Map TxOutRef ChainIndexTxOut
+  -> Map TxOutRef OffChainTxOut
   -> TxConstraints (RedeemerType a) (DatumType a)
   -> Contract w s e CardanoTx
 submitTxConstraintsSpending inst utxo =

--- a/plutus-contract/src/Plutus/Contract/StateMachine.hs
+++ b/plutus-contract/src/Plutus/Contract/StateMachine.hs
@@ -139,7 +139,6 @@ getStates
     -> [OnChainState s i]
 getStates (SM.StateMachineInstance _ si) refMap =
     flip mapMaybe (Map.toList refMap) $ \(txOutRef, ocTxOut) -> do
-      -- FIXME is it important to check txOut is a script?
       datum <- Tx.ocTxOutDatum ocTxOut
       ocsTxOutRef <- either (const Nothing) Just $ Typed.typeScriptTxOutRef si txOutRef (Tx.toTxOut ocTxOut) datum
       pure OnChainState{ocsTxOutRef}

--- a/plutus-contract/src/Plutus/Contract/Tx.hs
+++ b/plutus-contract/src/Plutus/Contract/Tx.hs
@@ -11,7 +11,7 @@ import Data.Maybe (fromMaybe)
 import Data.Map (Map)
 import Ledger.Address qualified as Address
 import Ledger.Constraints.TxConstraints (UntypedConstraints)
-import Ledger.Tx (ChainIndexTxOut)
+import Ledger.Tx (OffChainTxOut)
 import Plutus.Contract.Typed.Tx qualified as Typed
 import Plutus.Script.Utils.V1.Address qualified as Address
 import Plutus.V1.Ledger.Api (Redeemer (Redeemer), TxOutRef, Validator)
@@ -21,7 +21,7 @@ import PlutusTx qualified
 --   from the address of the given validator script, using the same redeemer
 --   script for all outputs.
 collectFromScript
-    :: Map Address.Address (Map TxOutRef ChainIndexTxOut)
+    :: Map Address.Address (Map TxOutRef OffChainTxOut)
     -> Validator
     -> Redeemer
     -> UntypedConstraints
@@ -29,8 +29,8 @@ collectFromScript = collectFromScriptFilter (\_ -> const True)
 
 -- | See
 collectFromScriptFilter
-    :: (TxOutRef -> ChainIndexTxOut -> Bool)
-    -> Map Address.Address (Map TxOutRef ChainIndexTxOut)
+    :: (TxOutRef -> OffChainTxOut -> Bool)
+    -> Map Address.Address (Map TxOutRef OffChainTxOut)
     -> Validator
     -> Redeemer
     -> UntypedConstraints

--- a/plutus-contract/src/Plutus/Contract/Typed/Tx.hs
+++ b/plutus-contract/src/Plutus/Contract/Typed/Tx.hs
@@ -9,7 +9,7 @@ module Plutus.Contract.Typed.Tx where
 
 import Ledger (TxOutRef)
 import Ledger.Constraints (TxConstraints, mustSpendOutputFromTheScript)
-import Ledger.Tx (ChainIndexTxOut)
+import Ledger.Tx (OffChainTxOut)
 
 import Data.Map qualified as Map
 
@@ -17,12 +17,12 @@ import Data.Map qualified as Map
 --   all the outputs that match a predicate, using the 'RedeemerValue'.
 collectFromScriptFilter ::
     forall i o
-    .  (TxOutRef -> ChainIndexTxOut -> Bool)
-    -> Map.Map TxOutRef ChainIndexTxOut
+    .  (TxOutRef -> OffChainTxOut -> Bool)
+    -> Map.Map TxOutRef OffChainTxOut
     -> i
     -> TxConstraints i o
 collectFromScriptFilter flt utxo red =
-    let ourUtxo :: Map.Map TxOutRef ChainIndexTxOut
+    let ourUtxo :: Map.Map TxOutRef OffChainTxOut
         ourUtxo = Map.filterWithKey flt utxo
     in collectFromScript ourUtxo red
 
@@ -30,7 +30,7 @@ collectFromScriptFilter flt utxo red =
 --   at the address
 collectFromScript ::
     forall i o
-    .  Map.Map TxOutRef ChainIndexTxOut
+    .  Map.Map TxOutRef OffChainTxOut
     -> i
     -> TxConstraints i o
 collectFromScript utxo redeemer =

--- a/plutus-contract/test/Spec/Contract.hs
+++ b/plutus-contract/test/Spec/Contract.hs
@@ -268,8 +268,8 @@ tests =
                 -- contract's caller. It's status should be changed eventually
                 -- to confirmed spent.
                 pubKeyHash <- ownFirstPaymentPubKeyHash
-                ciTxOutM <- unspentTxOutFromRef utxo
-                let lookups = Constraints.unspentOutputs (maybe mempty (Map.singleton utxo) ciTxOutM)
+                ocTxOutM <- unspentTxOutFromRef utxo
+                let lookups = Constraints.unspentOutputs (maybe mempty (Map.singleton utxo) ocTxOutM)
                 submitTxConstraintsWith @Void lookups $ Constraints.mustSpendPubKeyOutput utxo
                                                      <> Constraints.mustBeSignedBy pubKeyHash
                 s <- awaitTxOutStatusChange utxo
@@ -306,8 +306,8 @@ tests =
                 -- contract's caller. It's status should be changed eventually
                 -- to confirmed spent.
                 pubKeyHash <- ownFirstPaymentPubKeyHash
-                ciTxOutM <- unspentTxOutFromRef utxo
-                let lookups = Constraints.unspentOutputs (maybe mempty (Map.singleton utxo) ciTxOutM)
+                ocTxOutM <- unspentTxOutFromRef utxo
+                let lookups = Constraints.unspentOutputs (maybe mempty (Map.singleton utxo) ocTxOutM)
                 submitCardanoTxConstraintsWith lookups $ Constraints.mustSpendPubKeyOutput utxo
                                                       <> Constraints.mustBeSignedBy pubKeyHash
                 s <- awaitTxOutStatusChange utxo

--- a/plutus-ledger-constraints/test/Spec.hs
+++ b/plutus-ledger-constraints/test/Spec.hs
@@ -167,13 +167,13 @@ testScriptInputs lookups txc = property $ do
             Hedgehog.failure
 
 
-txOut0 :: Ledger.ChainIndexTxOut
-txOut0 = Ledger.ScriptChainIndexTxOut
-          (Ledger.Address (ScriptCredential alwaysSucceedValidatorHash) Nothing)
-          mempty
-          (Right Ledger.unitDatum)
-          Nothing
-          (Left alwaysSucceedValidatorHash)
+txOut0 :: Ledger.OffChainTxOut
+txOut0 =
+  Ledger.mkScriptOffChainTxOut
+    (Left alwaysSucceedValidatorHash)
+    mempty
+    (Right Ledger.unitDatum)
+    Nothing
 
 txOutRef0 :: Ledger.TxOutRef
 txOutRef0 = Ledger.TxOutRef (Ledger.TxId "") 0
@@ -202,18 +202,18 @@ validator1 = Scripts.mkTypedValidator
 validatorHash1 :: Ledger.ValidatorHash
 validatorHash1 = Scripts.validatorHash validator1
 
-txOut1 :: Ledger.ChainIndexTxOut
-txOut1 = Ledger.ScriptChainIndexTxOut
-  (Ledger.Address (ScriptCredential validatorHash1) Nothing)
-  mempty
-  (Right Ledger.unitDatum)
-  Nothing
-  (Left validatorHash1)
+txOut1 :: Ledger.OffChainTxOut
+txOut1 =
+  Ledger.mkScriptOffChainTxOut
+    (Left validatorHash1)
+    mempty
+    (Right Ledger.unitDatum)
+    Nothing
 
 txOutRef1 :: Ledger.TxOutRef
 txOutRef1 = Ledger.TxOutRef (Ledger.TxId "") 1
 
-utxo1 :: Map.Map Ledger.TxOutRef Ledger.ChainIndexTxOut
+utxo1 :: Map.Map Ledger.TxOutRef Ledger.OffChainTxOut
 utxo1 = Map.fromList [(txOutRef0, txOut0), (txOutRef1, txOut1)]
 
 {-# INLINABLE constraints1 #-}

--- a/plutus-ledger/src/Ledger/Tx.hs
+++ b/plutus-ledger/src/Ledger/Tx.hs
@@ -22,6 +22,7 @@ module Ledger.Tx
     , ocTxOutPublicKeyValue
     , ocTxOutPublicKeyDatumHash
     , ocTxOutPublicKeyReferenceScript
+    , ocTxOutPublicKeyStakingCredential
     -- * ScriptOffChainTxOut
     , ocTxOutValidatorHash
     , ocTxOutScriptValue
@@ -29,12 +30,14 @@ module Ledger.Tx
     , ocTxOutValidator
     , ocTxOutScriptDatum
     , ocTxOutScriptReferenceScript
+    , ocTxOutScriptStakingCredential
     -- * Common accessors
     , ocTxOutAddress
     , ocTxOutValue
     , ocTxOutDatum
     , ocTxOutDatumHash
     , ocTxOutReferenceScript
+    , ocTxOutStakingCredential
     -- * OffChainTxOut smart constructors
     , mkPublicKeyOffChainTxOut
     , mkScriptOffChainTxOut
@@ -109,40 +112,42 @@ type PrivateKey = Crypto.XPrv
 -- 'mkScriptOffChainTxOut' and the patterns below.
 data OffChainTxOut =
     PublicKeyOffChainTxOut'
-      V1.PubKeyHash        -- ^ Hash of the public key protecting the
-                           -- transaction output.
-      V1.Value             -- ^ Value of the transaction output.
-      (Maybe V1.DatumHash) -- ^ Optional datum hash attached to the
-                           -- transaction output.
-      (Maybe V1.Datum)     -- ^ Optional datum attached to the transaction
-                           -- output, either found inline or resolved from
-                           -- its hash offchain.
-      (Maybe V1.Script)    -- ^ Optional reference script attached to the
-                           -- transaction output.
+      V1.PubKeyHash                -- ^ Hash of the public key protecting the
+                                   -- transaction output.
+      V1.Value                     -- ^ Value of the transaction output.
+      (Maybe V1.DatumHash)         -- ^ Optional datum hash attached to the
+                                   -- transaction output.
+      (Maybe V1.Datum)             -- ^ Optional datum attached to the transaction
+                                   -- output, either found inline or resolved from
+                                   -- its hash offchain.
+      (Maybe V1.Script)            -- ^ Optional reference script attached to the
+                                   -- transaction output.
+      (Maybe V1.StakingCredential) -- staking credential of the address (if any)
   | ScriptOffChainTxOut'
-      V1.ValidatorHash     -- ^ Hash of the validator protecting the
-                           -- transaction output.
-      V1.Value             -- ^ Value of the transaction output.
-      V1.DatumHash         -- ^ FIXME Hash of the datum attached to the
-                           -- transaction output.
-      (Maybe V1.Validator) -- ^ Validator script protecting the transaction
-                           -- output, resolved from its hash off-chain
-      (Maybe V1.Datum)     -- ^ Datum attached to the transaction output,
-                           -- either found inline or resolved from its hash
-                           -- off-chain. A transaction output protected by
-                           -- a Plutus script is need to have an associated
-                           -- datum to be spendable.
-      (Maybe V1.Script)    -- ^ Optional reference script attached to the
-                           -- transaction output. The reference script is,
-                           -- in genereal, unrelated to the validator
-                           -- script althought it could also be the same.
+      V1.ValidatorHash             -- ^ Hash of the validator protecting the
+                                   -- transaction output.
+      V1.Value                     -- ^ Value of the transaction output.
+      V1.DatumHash                 -- ^ FIXME Hash of the datum attached to the
+                                   -- transaction output.
+      (Maybe V1.Validator)         -- ^ Validator script protecting the transaction
+                                   -- output, resolved from its hash off-chain
+      (Maybe V1.Datum)             -- ^ Datum attached to the transaction output,
+                                   -- either found inline or resolved from its hash
+                                   -- off-chain. A transaction output protected by
+                                   -- a Plutus script is need to have an associated
+                                   -- datum to be spendable.
+      (Maybe V1.Script)            -- ^ Optional reference script attached to the
+                                   -- transaction output. The reference script is,
+                                   -- in genereal, unrelated to the validator
+                                   -- script althought it could also be the same.
+      (Maybe V1.StakingCredential) -- staking credential of the address (if any)
   deriving (Show, Eq, Serialise, Generic, ToJSON, FromJSON, OpenApi.ToSchema)
 
-pattern PublicKeyOffChainTxOut :: V1.PubKeyHash -> V1.Value -> Maybe V1.DatumHash -> Maybe V1.Datum -> Maybe V1.Script -> OffChainTxOut
-pattern PublicKeyOffChainTxOut { ocTxOutPublicKeyHash, ocTxOutPublicKeyValue, ocTxOutPublicKeyDatumHash, ocTxOutDatum, ocTxOutPublicKeyReferenceScript } <- PublicKeyOffChainTxOut' ocTxOutPublicKeyHash ocTxOutPublicKeyValue ocTxOutPublicKeyDatumHash ocTxOutDatum ocTxOutPublicKeyReferenceScript
+pattern PublicKeyOffChainTxOut :: V1.PubKeyHash -> V1.Value -> Maybe V1.DatumHash -> Maybe V1.Datum -> Maybe V1.Script -> Maybe V1.StakingCredential -> OffChainTxOut
+pattern PublicKeyOffChainTxOut { ocTxOutPublicKeyHash, ocTxOutPublicKeyValue, ocTxOutPublicKeyDatumHash, ocTxOutDatum, ocTxOutPublicKeyReferenceScript, ocTxOutPublicKeyStakingCredential } <- PublicKeyOffChainTxOut' ocTxOutPublicKeyHash ocTxOutPublicKeyValue ocTxOutPublicKeyDatumHash ocTxOutDatum ocTxOutPublicKeyReferenceScript ocTxOutPublicKeyStakingCredential
 
-pattern ScriptOffChainTxOut :: V1.ValidatorHash -> V1.Value -> V1.DatumHash -> Maybe V1.Validator -> Maybe V1.Datum -> Maybe V1.Script -> OffChainTxOut
-pattern ScriptOffChainTxOut { ocTxOutValidatorHash, ocTxOutScriptValue, ocTxOutScriptDatumHash, ocTxOutValidator, ocTxOutScriptDatum, ocTxOutScriptReferenceScript } <- ScriptOffChainTxOut' ocTxOutValidatorHash ocTxOutScriptValue ocTxOutScriptDatumHash ocTxOutValidator ocTxOutScriptDatum ocTxOutScriptReferenceScript
+pattern ScriptOffChainTxOut :: V1.ValidatorHash -> V1.Value -> V1.DatumHash -> Maybe V1.Validator -> Maybe V1.Datum -> Maybe V1.Script -> Maybe V1.StakingCredential -> OffChainTxOut
+pattern ScriptOffChainTxOut { ocTxOutValidatorHash, ocTxOutScriptValue, ocTxOutScriptDatumHash, ocTxOutValidator, ocTxOutScriptDatum, ocTxOutScriptReferenceScript, ocTxOutScriptStakingCredential } <- ScriptOffChainTxOut' ocTxOutValidatorHash ocTxOutScriptValue ocTxOutScriptDatumHash ocTxOutValidator ocTxOutScriptDatum ocTxOutScriptReferenceScript ocTxOutScriptStakingCredential
 
 {-# COMPLETE PublicKeyOffChainTxOut, ScriptOffChainTxOut #-}
 
@@ -154,6 +159,7 @@ mkPublicKeyOffChainTxOut pkh va m_doe m_sc =
     (either id datumHash <$> m_doe)
     (either (const Nothing) Just =<< m_doe)
     m_sc
+    Nothing -- FIXME staking credential
 
 mkScriptOffChainTxOut :: Either V1.ValidatorHash V1.Validator -> V1.Value -> Either V1.DatumHash V1.Datum -> Maybe V1.Script -> OffChainTxOut
 mkScriptOffChainTxOut voh va doh m_sc =
@@ -164,6 +170,7 @@ mkScriptOffChainTxOut voh va doh m_sc =
     (either (const Nothing) Just voh)
     (either (const Nothing) Just doh)
     m_sc
+    Nothing -- FIXME staking credential
 
 ocTxOutAddress :: OffChainTxOut -> V1.Address
 ocTxOutAddress PublicKeyOffChainTxOut { ocTxOutPublicKeyHash } =
@@ -189,6 +196,12 @@ ocTxOutReferenceScript PublicKeyOffChainTxOut { ocTxOutPublicKeyReferenceScript 
 ocTxOutReferenceScript ScriptOffChainTxOut { ocTxOutScriptReferenceScript } =
   ocTxOutScriptReferenceScript
 
+ocTxOutStakingCredential :: OffChainTxOut -> Maybe V1.StakingCredential
+ocTxOutStakingCredential PublicKeyOffChainTxOut { ocTxOutPublicKeyStakingCredential } =
+  ocTxOutPublicKeyStakingCredential
+ocTxOutStakingCredential ScriptOffChainTxOut { ocTxOutScriptStakingCredential } =
+  ocTxOutScriptStakingCredential
+
 -- | Converts a transaction output from the chain index to the plutus-ledger-api
 -- transaction output.
 --
@@ -207,9 +220,10 @@ fromTxOut :: V1.Tx.TxOut -> Maybe OffChainTxOut
 fromTxOut (V1.Tx.TxOut address value mDatumHash) =
   case V1.addressCredential address of
     V1.PubKeyCredential pkh ->
-      pure $ PublicKeyOffChainTxOut' pkh value mDatumHash Nothing Nothing
-    V1.ScriptCredential vh ->
-      mDatumHash >>= \dh -> pure $ ScriptOffChainTxOut' vh value dh Nothing Nothing Nothing
+      pure $ PublicKeyOffChainTxOut' pkh value mDatumHash Nothing Nothing (V1.stakingCredential address)
+    V1.ScriptCredential vh -> do
+      dh <- mDatumHash
+      pure $ ScriptOffChainTxOut' vh value dh Nothing Nothing Nothing (V1.stakingCredential address)
 
 instance Pretty OffChainTxOut where
     pretty txOut@PublicKeyOffChainTxOut {} =

--- a/plutus-pab-executables/examples/ContractExample/IntegrationTest.hs
+++ b/plutus-pab-executables/examples/ContractExample/IntegrationTest.hs
@@ -41,11 +41,11 @@ run' :: Contract () EmptySchema IError ()
 run' = do
     logInfo @Haskell.String "Starting integration test"
     pkh <- ownFirstPaymentPubKeyHash
-    (txOutRef, ciTxOut, pkInst) <- mapError PKError (PubKey.pubKeyContract pkh (Ada.adaValueOf 10))
+    (txOutRef, ocTxOut, pkInst) <- mapError PKError (PubKey.pubKeyContract pkh (Ada.adaValueOf 10))
     logInfo @Haskell.String "pubKey contract complete:"
     let lookups =
             Constraints.otherData (Datum $ getRedeemer unitRedeemer)
-            <> Constraints.unspentOutputs (maybe mempty (Map.singleton txOutRef) ciTxOut)
+            <> Constraints.unspentOutputs (maybe mempty (Map.singleton txOutRef) ocTxOut)
             <> Constraints.otherScript  (Scripts.validatorScript pkInst)
         constraints =
             Constraints.mustSpendScriptOutput txOutRef unitRedeemer

--- a/plutus-pab/src/Plutus/PAB/Core.hs
+++ b/plutus-pab/src/Plutus/PAB/Core.hs
@@ -86,7 +86,6 @@ module Plutus.PAB.Core
 import Control.Applicative (Alternative ((<|>)))
 import Control.Concurrent.STM (STM)
 import Control.Concurrent.STM qualified as STM
-import Control.Lens (view)
 import Control.Monad (forM, guard, void)
 import Control.Monad.Freer (Eff, LastMember, Member, interpret, reinterpret, runM, send, subsume, type (~>))
 import Control.Monad.Freer.Error (Error, runError, throwError)
@@ -103,7 +102,7 @@ import Data.Set (Set)
 import Data.Text (Text)
 import Ledger (Address (addressCredential), Params, TxOutRef)
 import Ledger.Address (PaymentPubKeyHash)
-import Ledger.Tx (CardanoTx, TxId, ciTxOutValue)
+import Ledger.Tx (CardanoTx, TxId, ocTxOutValue)
 import Ledger.Value (Value)
 import Plutus.ChainIndex (ChainIndexQueryEffect, RollbackState (Unknown), TxOutStatus, TxStatus)
 import Plutus.ChainIndex qualified as ChainIndex
@@ -582,7 +581,7 @@ valueAt :: Wallet -> PABAction t env Value
 valueAt wallet = do
   handleAgentThread wallet Nothing $ do
     txOutsM <- ChainIndex.collectQueryResponse (\pq -> ChainIndex.unspentTxOutSetAtAddress pq cred)
-    pure $ foldMap (view ciTxOutValue . snd) $ concat txOutsM
+    pure $ foldMap (ocTxOutValue . snd) $ concat txOutsM
   where
     cred = addressCredential $ mockWalletAddress wallet
 

--- a/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground-server/usecases/Game.hs
@@ -31,7 +31,7 @@ import Data.Map qualified as Map
 import Data.Maybe (catMaybes)
 import Ledger.Ada qualified as Ada
 import Ledger.Constraints qualified as Constraints
-import Ledger.Tx (ChainIndexTxOut (..))
+import Ledger.Tx (OffChainTxOut (..))
 import Ledger.Typed.Scripts qualified as Scripts
 import Playground.Contract
 import Plutus.Contract
@@ -137,14 +137,15 @@ guess = endpoint @"guess" @GuessParams $ \(GuessParams theGuess) -> do
     void (submitTxConstraintsSpending gameInstance utxos tx)
 
 -- | Find the secret word in the Datum of the UTxOs
-findSecretWordValue :: Map TxOutRef ChainIndexTxOut -> Maybe HashedString
+findSecretWordValue :: Map TxOutRef OffChainTxOut -> Maybe HashedString
 findSecretWordValue =
   listToMaybe . catMaybes . Map.elems . Map.map secretWordValue
 
 -- | Extract the secret word in the Datum of a given transaction output is possible
-secretWordValue :: ChainIndexTxOut -> Maybe HashedString
+secretWordValue :: OffChainTxOut -> Maybe HashedString
 secretWordValue o = do
-  Datum d <- either (const Nothing) Just (_ciTxOutScriptDatum o)
+  -- FIXME is it important to check txOut is a script?
+  Datum d <- ocTxOutDatum o
   PlutusTx.fromBuiltinData d
 
 game :: AsContractError e => Contract () GameSchema e ()

--- a/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground-server/usecases/Game.hs
@@ -31,7 +31,7 @@ import Data.Map qualified as Map
 import Data.Maybe (catMaybes)
 import Ledger.Ada qualified as Ada
 import Ledger.Constraints qualified as Constraints
-import Ledger.Tx (OffChainTxOut (..))
+import Ledger.Tx (OffChainTxOut (..), ocTxOutDatum)
 import Ledger.Typed.Scripts qualified as Scripts
 import Playground.Contract
 import Plutus.Contract
@@ -144,7 +144,6 @@ findSecretWordValue =
 -- | Extract the secret word in the Datum of a given transaction output is possible
 secretWordValue :: OffChainTxOut -> Maybe HashedString
 secretWordValue o = do
-  -- FIXME is it important to check txOut is a script?
   Datum d <- ocTxOutDatum o
   PlutusTx.fromBuiltinData d
 

--- a/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground-server/usecases/Vesting.hs
@@ -14,7 +14,6 @@
 module Vesting where
 -- TRIM TO HERE
 -- Vesting scheme as a PLC contract
-import Control.Lens (view)
 import Control.Monad (void, when)
 import Data.Default (Default (def))
 import Data.Map qualified as Map
@@ -180,7 +179,7 @@ retrieveFundsC vesting payment = do
     nextTime <- awaitTime 0
     unspentOutputs <- utxosAt addr
     let
-        currentlyLocked = foldMap (view Tx.ciTxOutValue) (Map.elems unspentOutputs)
+        currentlyLocked = foldMap Tx.ocTxOutValue (Map.elems unspentOutputs)
         remainingValue = currentlyLocked - payment
         mustRemainLocked = totalAmount vesting - availableAt vesting nextTime
         maxPayment = currentlyLocked - mustRemainLocked

--- a/plutus-tx-constraints/src/Ledger/Tx/Constraints/OffChain.hs
+++ b/plutus-tx-constraints/src/Ledger/Tx/Constraints/OffChain.hs
@@ -199,11 +199,11 @@ processConstraint = \case
     P.MustSpendPubKeyOutput txo -> do
         txout <- mapReaderT (mapStateT (mapExcept (first LedgerMkTxError))) $ P.lookupTxOutRef txo
         case txout of
-          Tx.PublicKeyChainIndexTxOut {} -> do
+          Tx.PublicKeyOffChainTxOut {} -> do
               txIn <- throwLeft ToCardanoError $ C.toCardanoTxIn txo
               unbalancedTx . tx . txIns <>= [(txIn, C.BuildTxWith (C.KeyWitness C.KeyWitnessForSpending))]
-            --   valueSpentInputs <>= provided _ciTxOutValue
-          _ -> throwError (LedgerMkTxError $ P.TxOutRefWrongType txo)
+          Tx.ScriptOffChainTxOut {} ->
+            throwError (LedgerMkTxError $ P.TxOutRefWrongType txo)
 
     P.MustPayToPubKeyAddress pk mskh md vl -> do
 

--- a/plutus-use-cases/src/Plutus/Contracts/Escrow.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Escrow.hs
@@ -332,11 +332,7 @@ refund ::
 refund inst escrow = do
     pk <- ownFirstPaymentPubKeyHash
     unspentOutputs <- utxosAt (Scripts.validatorAddress inst)
-    let flt _ ocTxOut = case ocTxOut of
-                          Tx.ScriptOffChainTxOut _vh _v dh _m_va _m_da _m_rs ->
-                            dh == datumHash (Datum (PlutusTx.toBuiltinData pk))
-                          Tx.PublicKeyOffChainTxOut {} ->
-                            False
+    let flt _ ocTxOut = Tx.ocTxOutDatumHash ocTxOut == Just (Ledger.datumHash (Datum (PlutusTx.toBuiltinData pk)))
         tx' = Typed.collectFromScriptFilter flt unspentOutputs Refund
                 <> Constraints.mustValidateIn (from (Haskell.succ $ escrowDeadline escrow))
     if Constraints.modifiesUtxoSet tx'

--- a/plutus-use-cases/src/Plutus/Contracts/Game.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Game.hs
@@ -48,7 +48,7 @@ import GHC.Generics (Generic)
 import Ledger (Address, POSIXTime, PaymentPubKeyHash, ScriptContext, TxOutRef, Value)
 import Ledger.Ada qualified as Ada
 import Ledger.Constraints qualified as Constraints
-import Ledger.Tx (ChainIndexTxOut (..))
+import Ledger.Tx (OffChainTxOut (..))
 import Ledger.Typed.Scripts qualified as Scripts
 import Playground.Contract (ToSchema)
 import Plutus.Contract (AsContractError, Contract, Endpoint, Promise, adjustUnbalancedTx, collectFromScript, endpoint,
@@ -179,14 +179,14 @@ guess = endpoint @"guess" $ \GuessArgs { guessArgsGameParam, guessArgsSecret } -
     yieldUnbalancedTx unbalancedTx
 
 -- | Find the secret word in the Datum of the UTxOs
-findSecretWordValue :: Map TxOutRef ChainIndexTxOut -> Maybe HashedString
+findSecretWordValue :: Map TxOutRef OffChainTxOut -> Maybe HashedString
 findSecretWordValue =
   listToMaybe . catMaybes . Map.elems . Map.map secretWordValue
 
 -- | Extract the secret word in the Datum of a given transaction output is possible
-secretWordValue :: ChainIndexTxOut -> Maybe HashedString
+secretWordValue :: OffChainTxOut -> Maybe HashedString
 secretWordValue o = do
-  Datum d <- either (const Nothing) Just (_ciTxOutScriptDatum o)
+  Datum d <- ocTxOutDatum o
   PlutusTx.fromBuiltinData d
 
 contract :: AsContractError e => Contract () GameSchema e ()

--- a/plutus-use-cases/src/Plutus/Contracts/PubKey.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/PubKey.hs
@@ -69,7 +69,7 @@ pubKeyContract
     )
     => PaymentPubKeyHash
     -> Value
-    -> Contract w s e (TxOutRef, Maybe ChainIndexTxOut, TypedValidator PubKeyContract)
+    -> Contract w s e (TxOutRef, Maybe OffChainTxOut, TypedValidator PubKeyContract)
 pubKeyContract pk vl = mapError (review _PubKeyError   ) $ do
     let inst = typedValidator pk
         address = Scripts.validatorAddress inst
@@ -108,8 +108,8 @@ pubKeyContract pk vl = mapError (review _PubKeyError   ) $ do
             slot <- currentSlot
             awaitChainIndexSlot slot
 
-            ciTxOut <- unspentTxOutFromRef outRef
-            pure (outRef, ciTxOut, inst)
+            ocTxOut <- unspentTxOutFromRef outRef
+            pure (outRef, ocTxOut, inst)
         _                    -> throwing _MultipleScriptOutputs pk
 
 -- | Temporary. Read TODO in 'pubKeyContract'.

--- a/plutus-use-cases/src/Plutus/Contracts/SimpleEscrow.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/SimpleEscrow.hs
@@ -18,7 +18,7 @@
 module Plutus.Contracts.SimpleEscrow
   where
 
-import Control.Lens (makeClassyPrisms, view)
+import Control.Lens (makeClassyPrisms)
 import Control.Monad (void)
 import Control.Monad.Error.Lens (throwing)
 import Data.Aeson (FromJSON, ToJSON)
@@ -142,7 +142,7 @@ redeemEp = endpoint @"redeem" redeem
       pk <- ownFirstPaymentPubKeyHash
       unspentOutputs <- utxosAt escrowAddress
 
-      let value = foldMap (view Tx.ciTxOutValue) unspentOutputs
+      let value = foldMap Tx.ocTxOutValue unspentOutputs
           tx = Typed.collectFromScript unspentOutputs Redeem
                       <> Constraints.mustValidateIn (Interval.to (Haskell.pred $ deadline params))
                       -- Pay me the output of this script

--- a/plutus-use-cases/src/Plutus/Contracts/TokenAccount.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/TokenAccount.hs
@@ -37,7 +37,7 @@ module Plutus.Contracts.TokenAccount(
   , typedValidator
   ) where
 
-import Control.Lens (makeClassyPrisms, review, view)
+import Control.Lens (makeClassyPrisms, review)
 import Control.Monad (void)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Map qualified as Map
@@ -176,7 +176,7 @@ redeemTx :: forall w s e.
 redeemTx account pk = mapError (review _TAContractError) $ do
     let inst = typedValidator account
     utxos <- utxosAt (address account)
-    let totalVal = foldMap (view Ledger.ciTxOutValue) utxos
+    let totalVal = foldMap Ledger.ocTxOutValue utxos
         numInputs = Map.size utxos
     logInfo @String
         $ "TokenAccount.redeemTx: Redeeming "
@@ -214,7 +214,7 @@ balance
     -> Contract w s e Value
 balance account = mapError (review _TAContractError) $ do
     utxos <- utxosAt (address account)
-    let inner = foldMap (view Ledger.ciTxOutValue) utxos
+    let inner = foldMap Ledger.ocTxOutValue utxos
     pure inner
 
 -- | Create a new token and return its 'Account' information.

--- a/plutus-use-cases/src/Plutus/Contracts/Tutorial/Escrow.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Tutorial/Escrow.hs
@@ -44,7 +44,7 @@ module Plutus.Contracts.Tutorial.Escrow(
     , covIdx
     ) where
 
-import Control.Lens (makeClassyPrisms, review, view)
+import Control.Lens (makeClassyPrisms, review)
 import Control.Monad (void)
 import Control.Monad.Error.Lens (throwing)
 import Data.Aeson (FromJSON, ToJSON)
@@ -272,7 +272,7 @@ redeem inst escrow = mapError (review _EscrowError) $ do
     let
         tx = Typed.collectFromScript unspentOutputs Redeem
                 <> foldMap mkTx (escrowTargets escrow)
-    if foldMap (view Tx.ciTxOutValue) unspentOutputs `lt` targetTotal escrow
+    if foldMap Tx.ocTxOutValue unspentOutputs `lt` targetTotal escrow
        then throwing _RedeemFailed NotEnoughFundsAtAddress
        else do
          utx <- mkTxConstraints ( Constraints.typedValidatorLookups inst
@@ -302,7 +302,11 @@ refund ::
 refund inst _escrow = do
     pk <- ownFirstPaymentPubKeyHash
     unspentOutputs <- utxosAt (Scripts.validatorAddress inst)
-    let flt _ ciTxOut = either id Ledger.datumHash (Tx._ciTxOutScriptDatum ciTxOut) == Ledger.datumHash (Datum (PlutusTx.toBuiltinData pk))
+    let flt _ ocTxOut = case ocTxOut of
+                          Tx.ScriptOffChainTxOut _vh _v dh _m_va _m_da _m_rs ->
+                            dh == Ledger.datumHash (Datum (PlutusTx.toBuiltinData pk))
+                          Tx.PublicKeyOffChainTxOut {} ->
+                            False
         tx' = Typed.collectFromScriptFilter flt unspentOutputs Refund
     if Constraints.modifiesUtxoSet tx'
     then do

--- a/plutus-use-cases/src/Plutus/Contracts/Tutorial/Escrow.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Tutorial/Escrow.hs
@@ -302,11 +302,7 @@ refund ::
 refund inst _escrow = do
     pk <- ownFirstPaymentPubKeyHash
     unspentOutputs <- utxosAt (Scripts.validatorAddress inst)
-    let flt _ ocTxOut = case ocTxOut of
-                          Tx.ScriptOffChainTxOut _vh _v dh _m_va _m_da _m_rs ->
-                            dh == Ledger.datumHash (Datum (PlutusTx.toBuiltinData pk))
-                          Tx.PublicKeyOffChainTxOut {} ->
-                            False
+    let flt _ ocTxOut = Tx.ocTxOutDatumHash ocTxOut == Just (Ledger.datumHash (Datum (PlutusTx.toBuiltinData pk)))
         tx' = Typed.collectFromScriptFilter flt unspentOutputs Refund
     if Constraints.modifiesUtxoSet tx'
     then do

--- a/plutus-use-cases/src/Plutus/Contracts/Tutorial/EscrowStrict.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Tutorial/EscrowStrict.hs
@@ -276,8 +276,7 @@ redeem ::
 redeem inst escrow = mapError (review _EscrowError) $ do
     let addr = Scripts.validatorAddress inst
     unspentOutputs <- utxosAt addr
-    let
-        tx = Typed.collectFromScript unspentOutputs Redeem
+    let tx = Typed.collectFromScript unspentOutputs Redeem
                 <> foldMap mkTx (escrowTargets escrow)
     if foldMap Tx.ocTxOutValue unspentOutputs `lt` targetTotal escrow
        then throwing _RedeemFailed NotEnoughFundsAtAddress
@@ -309,11 +308,7 @@ refund ::
 refund inst _escrow = do
     pk <- ownFirstPaymentPubKeyHash
     unspentOutputs <- utxosAt (Scripts.validatorAddress inst)
-    let flt _ ocTxOut = case ocTxOut of
-                          Tx.ScriptOffChainTxOut _vh _v dh _m_va _m_da _m_rs ->
-                            dh == Ledger.datumHash (Datum (PlutusTx.toBuiltinData pk))
-                          Tx.PublicKeyOffChainTxOut {} ->
-                            False
+    let flt _ ocTxOut = Tx.ocTxOutDatumHash ocTxOut == Just (Ledger.datumHash (Datum (PlutusTx.toBuiltinData pk)))
         tx' = Typed.collectFromScriptFilter flt unspentOutputs Refund
     if Constraints.modifiesUtxoSet tx'
     then do

--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
@@ -35,16 +35,15 @@ module Plutus.Contracts.Uniswap.OffChain
     , calculateRemoval, funds
     ) where
 
-import Control.Lens (view)
 import Control.Monad hiding (fmap)
 import Data.Map qualified as Map
 import Data.Monoid (Last (..))
 import Data.Proxy (Proxy (..))
 import Data.Text (Text, pack)
 import Data.Void (Void, absurd)
-import Ledger (ChainIndexTxOut (PublicKeyChainIndexTxOut, ScriptChainIndexTxOut, _ciTxOutScriptDatum), ciTxOutValue,
-               pubKeyHashAddress)
+import Ledger (pubKeyHashAddress)
 import Ledger.Constraints as Constraints hiding (adjustUnbalancedTx)
+import Ledger.Tx
 import Ledger.Typed.Scripts qualified as Scripts
 import Playground.Contract
 import Plutus.Contract as Contract
@@ -291,7 +290,7 @@ remove us RemoveParams{..} = do
         lC           = mkCoin (liquidityCurrency us) $ lpTicker lp
         psVal        = unitValue psC
         lVal         = valueOf lC rpDiff
-        inVal        = view ciTxOutValue o
+        inVal        = ocTxOutValue o
         inA          = amountOf inVal rpCoinA
         inB          = amountOf inVal rpCoinB
         (outA, outB) = calculateRemoval inA inB liquidity rpDiff
@@ -318,7 +317,7 @@ add us AddParams{..} = do
     pkh                           <- Contract.ownFirstPaymentPubKeyHash
     (_, (oref, o, lp, liquidity)) <- findUniswapFactoryAndPool us apCoinA apCoinB
     when (apAmountA < 0 || apAmountB < 0) $ throwError "amounts must not be negative"
-    let outVal = view ciTxOutValue o
+    let outVal = ocTxOutValue o
         oldA   = amountOf outVal apCoinA
         oldB   = amountOf outVal apCoinB
         newA   = oldA + apAmountA
@@ -361,7 +360,7 @@ swap :: forall w s. Uniswap -> SwapParams -> Contract w s Text ()
 swap us SwapParams{..} = do
     unless (spAmountA > 0 && spAmountB == 0 || spAmountA == 0 && spAmountB > 0) $ throwError "exactly one amount must be positive"
     (_, (oref, o, lp, liquidity)) <- findUniswapFactoryAndPool us spCoinA spCoinB
-    let outVal = view ciTxOutValue o
+    let outVal = ocTxOutValue o
     let oldA = amountOf outVal spCoinA
         oldB = amountOf outVal spCoinB
     (newA, newB) <- if spAmountA > 0 then do
@@ -398,10 +397,10 @@ pools us = do
     utxos <- utxosAt (uniswapAddress us)
     go $ snd <$> Map.toList utxos
   where
-    go :: [ChainIndexTxOut] -> Contract w s Text [((Coin A, Amount A), (Coin B, Amount B))]
+    go :: [OffChainTxOut] -> Contract w s Text [((Coin A, Amount A), (Coin B, Amount B))]
     go []       = return []
     go (o : os) = do
-        let v = view ciTxOutValue o
+        let v = ocTxOutValue o
         if isUnity v c
             then do
                 d <- getUniswapDatum o
@@ -426,15 +425,15 @@ funds :: forall w s. Contract w s Text Value
 funds = do
     pkh <- Contract.ownFirstPaymentPubKeyHash
     os  <- map snd . Map.toList <$> utxosAt (pubKeyHashAddress pkh Nothing)
-    return $ mconcat [view ciTxOutValue o | o <- os]
+    return $ foldMap ocTxOutValue os
 
-getUniswapDatum :: ChainIndexTxOut -> Contract w s Text UniswapDatum
+getUniswapDatum :: OffChainTxOut -> Contract w s Text UniswapDatum
 getUniswapDatum o =
   case o of
-      PublicKeyChainIndexTxOut {} ->
+      PublicKeyOffChainTxOut {} ->
         throwError "no datum for a txout of a public key address"
-      ScriptChainIndexTxOut { _ciTxOutScriptDatum } -> do
-        (Datum e) <- either getDatum pure _ciTxOutScriptDatum
+      (ScriptOffChainTxOut _vh _v dh _m_va m_da _m_sc) -> do
+        (Datum e) <- maybe (getDatum dh) pure m_da
         maybe (throwError "datum hash wrong type")
               pure
               (PlutusTx.fromBuiltinData e)
@@ -449,12 +448,12 @@ findUniswapInstance ::
     Uniswap
     -> Coin b
     -> (UniswapDatum -> Maybe a)
-    -> Contract w s Text (TxOutRef, ChainIndexTxOut, a)
+    -> Contract w s Text (TxOutRef, OffChainTxOut, a)
 findUniswapInstance us c f = do
     let addr = uniswapAddress us
     logInfo @String $ printf "looking for Uniswap instance at address %s containing coin %s " (show addr) (show c)
     utxos <- utxosAt addr
-    go  [x | x@(_, o) <- Map.toList utxos, isUnity (view ciTxOutValue o) c]
+    go  [x | x@(_, o) <- Map.toList utxos, isUnity (ocTxOutValue o) c]
   where
     go [] = throwError "Uniswap instance not found"
     go ((oref, o) : xs) = do
@@ -465,12 +464,12 @@ findUniswapInstance us c f = do
                 logInfo @String $ printf "found Uniswap instance with datum: %s" (show d)
                 return (oref, o, a)
 
-findUniswapFactory :: forall w s. Uniswap -> Contract w s Text (TxOutRef, ChainIndexTxOut, [LiquidityPool])
+findUniswapFactory :: forall w s. Uniswap -> Contract w s Text (TxOutRef, OffChainTxOut, [LiquidityPool])
 findUniswapFactory us@Uniswap{..} = findUniswapInstance us usCoin $ \case
     Factory lps -> Just lps
     Pool _ _    -> Nothing
 
-findUniswapPool :: forall w s. Uniswap -> LiquidityPool -> Contract w s Text (TxOutRef, ChainIndexTxOut, Amount Liquidity)
+findUniswapPool :: forall w s. Uniswap -> LiquidityPool -> Contract w s Text (TxOutRef, OffChainTxOut, Amount Liquidity)
 findUniswapPool us lp = findUniswapInstance us (poolStateCoin us) $ \case
         Pool lp' l
             | lp == lp' -> Just l
@@ -480,8 +479,8 @@ findUniswapFactoryAndPool :: forall w s.
                           Uniswap
                           -> Coin A
                           -> Coin B
-                          -> Contract w s Text ( (TxOutRef, ChainIndexTxOut, [LiquidityPool])
-                                               , (TxOutRef, ChainIndexTxOut, LiquidityPool, Amount Liquidity)
+                          -> Contract w s Text ( (TxOutRef, OffChainTxOut, [LiquidityPool])
+                                               , (TxOutRef, OffChainTxOut, LiquidityPool, Amount Liquidity)
                                                )
 findUniswapFactoryAndPool us coinA coinB = do
     (oref1, o1, lps) <- findUniswapFactory us

--- a/plutus-use-cases/src/Plutus/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Vesting.hs
@@ -205,7 +205,7 @@ retrieveFundsC vesting payment = mapError (review _VestingError) $ do
     nextTime <- awaitTime 0
     unspentOutputs <- utxosAt addr
     let
-        currentlyLocked = foldMap (view Tx.ciTxOutValue) (Map.elems unspentOutputs)
+        currentlyLocked = foldMap Tx.ocTxOutValue (Map.elems unspentOutputs)
         remainingValue = currentlyLocked - payment
         mustRemainLocked = totalAmount vesting - availableAt vesting nextTime
         maxPayment = currentlyLocked - mustRemainLocked

--- a/plutus-use-cases/test/Spec/Escrow/Endpoints.hs
+++ b/plutus-use-cases/test/Spec/Escrow/Endpoints.hs
@@ -49,11 +49,7 @@ badRefund ::
 badRefund inst pk = do
     unspentOutputs <- utxosAt (Scripts.validatorAddress inst)
     current <- currentTime
-    let flt _ ocTxOut = case ocTxOut of
-                          Tx.ScriptOffChainTxOut _vh _v dh _m_va _m_da _m_rs ->
-                            dh == Ledger.datumHash (Datum (PlutusTx.toBuiltinData pk))
-                          Tx.PublicKeyOffChainTxOut {} ->
-                            False
+    let flt _ ocTxOut = Tx.ocTxOutDatumHash ocTxOut == Just (Ledger.datumHash (Datum (PlutusTx.toBuiltinData pk)))
         tx' = Typed.collectFromScriptFilter flt unspentOutputs Refund
            <> Constraints.mustValidateIn (from (current - 1))
     utx <- mkTxConstraints ( Constraints.typedValidatorLookups inst

--- a/plutus-use-cases/test/Spec/PubKey.hs
+++ b/plutus-use-cases/test/Spec/PubKey.hs
@@ -18,8 +18,8 @@ import Test.Tasty
 
 theContract :: Contract () EmptySchema PubKeyError ()
 theContract = do
-  (txOutRef, ciTxOut, pkInst) <- pubKeyContract (mockWalletPaymentPubKeyHash w1) (Ada.adaValueOf 10)
-  let lookups = maybe mempty (Constraints.unspentOutputs . Map.singleton txOutRef) ciTxOut
+  (txOutRef, ocTxOut, pkInst) <- pubKeyContract (mockWalletPaymentPubKeyHash w1) (Ada.adaValueOf 10)
+  let lookups = maybe mempty (Constraints.unspentOutputs . Map.singleton txOutRef) ocTxOut
               <> Constraints.otherScript (Scripts.validatorScript pkInst)
   void $ submitTxConstraintsWith @Scripts.Any lookups (Constraints.mustSpendScriptOutput txOutRef unitRedeemer)
 


### PR DESCRIPTION
tl;dr. 

```
data DecoratedTxOut = DecoratedTxOut
  { decoratedTxOutAddress         :: Address
  , decoratedTxOutValue           :: Value
  , decoratedTxOutValidator       :: Maybe (Either ValidatorHash Validator)
  , decoratedTxOutDatum           :: Maybe (Either DatumHash Datum)
  , decoratedTxOutReferenceScript :: Maybe Script
  }
```

The idea is that at the contract level, we need a `TxOut` with additional information like the resolved validator & datum. I stole the word "decorated" from @michaelpj but I am happy to consider alternatives. In principle one could stick with `TxOut` and rely on qualified names.

Taking a  KISS approach I have defined a type that has all the information. The type is not "tight" sinceit has invariants:

If the address corresponds to a script then
1. the validator field must match
2. the datum must be present

(Note that `decoratedTxOutDatum` still returns a `Maybe`, perhaps we can improve on this).

Therefore the `DecoratedTxOut` constructor is private. I considered other internal representations but I am tempted to stick with this

There are few smart constructors exported:

```
mkDecoratedTxOut :: Address -> Value -> Maybe (Either DatumHash Datum) -> Maybe Script -> DecoratedTxOut
mkDecoratedTxOutFromValidator :: Validator -> Value -> Either DatumHash Datum -> Maybe Script -> DecoratedTxOut
mkDecoratedTxOutFromValidatorHash :: ValidatorHash -> Value -> Either DatumHash Datum -> Maybe Script -> DecoratedTxOut
```

Also there's a function to turn a `DecoratedTxOut` into a `TxOut`. I don't like this function because the type offers no guarantee to be equivalent to a `TxOut` but for the moment we need it because `plutus-script-utils` is lower level than `plutus-ledger` and takes `TxOut`s.

```
decoratedTxOutToV1 :: DecoratedTxOut -> TxOut
```

`Plutus.ChainIndex.Types.ChainIndexTxOut` is left alone as a internal type for plutus-chain-index. The chain-index API talks to the exernal parties thorugh `DecoratedTxOut` as defined in `plutus-ledger`.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
