### PR TITLE
Moved datum and redeemer hash computation functions in plutus-script-utils

### DIFF
--- a/doc/plutus/tutorials/EscrowImpl.hs
+++ b/doc/plutus/tutorials/EscrowImpl.hs
@@ -64,6 +64,7 @@ import Ledger.Tx qualified as Tx
 import Ledger.Typed.Scripts (TypedValidator)
 import Ledger.Typed.Scripts qualified as Scripts
 import Ledger.Value (Value, geq, lt)
+import Plutus.Script.Utils.Scripts qualified as Scripts
 import Plutus.Script.Utils.V1.Scripts qualified as Scripts
 import Plutus.V1.Ledger.Api (Datum (Datum), DatumHash, ValidatorHash)
 import Plutus.V1.Ledger.Contexts (ScriptContext (ScriptContext, scriptContextTxInfo), TxInfo (txInfoValidRange))

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Tx.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Tx.hs
@@ -1,11 +1,7 @@
-{-# LANGUAGE DeriveAnyClass    #-}
-{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TupleSections     #-}
 
 {-| The chain index' version of a transaction
@@ -41,7 +37,8 @@ import Ledger (Address, OnChainTx (..), SomeCardanoApiTx (SomeTx), Tx (..), TxIn
                TxOut (txOutAddress), TxOutRef (..), onCardanoTx, txId)
 import Plutus.ChainIndex.Types
 import Plutus.Contract.CardanoAPI (fromCardanoTx, setValidity)
-import Plutus.Script.Utils.V1.Scripts (datumHash, mintingPolicyHash, redeemerHash, validatorHash)
+import Plutus.Script.Utils.Scripts (datumHash, redeemerHash)
+import Plutus.Script.Utils.V1.Scripts (mintingPolicyHash, validatorHash)
 import Plutus.V1.Ledger.Scripts (Datum, DatumHash, MintingPolicy (getMintingPolicy),
                                  MintingPolicyHash (MintingPolicyHash), Redeemer, RedeemerHash, Script, ScriptHash (..),
                                  Validator (getValidator), ValidatorHash (ValidatorHash))

--- a/plutus-chain-index/app/Marconi.hs
+++ b/plutus-chain-index/app/Marconi.hs
@@ -39,9 +39,9 @@ import Marconi.Index.Utxo qualified as Utxo
 import Marconi.Logging (logging)
 import Options.Applicative (Mod, OptionFields, Parser, auto, execParser, flag', help, helper, info, long, maybeReader,
                             metavar, option, readerError, strOption, (<**>), (<|>))
-import Plutus.Script.Utils.V1.Scripts (Datum, DatumHash)
 import Plutus.Streaming (ChainSyncEvent (RollBackward, RollForward), ChainSyncEventException (NoIntersectionFound),
                          withChainSyncEventStream)
+import Plutus.V1.Ledger.Api (Datum, DatumHash)
 import Prettyprinter (defaultLayoutOptions, layoutPretty, pretty, (<+>))
 import Prettyprinter.Render.Text (renderStrict)
 import Streaming.Prelude qualified as S

--- a/plutus-chain-index/app/Marconi/Index/Datum.hs
+++ b/plutus-chain-index/app/Marconi/Index/Datum.hs
@@ -28,7 +28,7 @@ import Database.SQLite.Simple.ToField (ToField (toField))
 import Cardano.Api (SlotNo (SlotNo))
 import Index.VSqlite (SqliteIndex)
 import Index.VSqlite qualified as Ix
-import Plutus.Script.Utils.V1.Scripts (Datum, DatumHash)
+import Plutus.V1.Ledger.Api (Datum, DatumHash)
 
 type Event        = [(SlotNo, (DatumHash, Datum))]
 type Query        = DatumHash

--- a/plutus-chain-index/plutus-chain-index.cabal
+++ b/plutus-chain-index/plutus-chain-index.cabal
@@ -128,7 +128,6 @@ executable marconi
   build-depends:
     , hysterical-screams
     , plutus-ledger
-    , plutus-script-utils
     , plutus-streaming
 
   --------------------------
@@ -137,6 +136,7 @@ executable marconi
   build-depends:
     , cardano-api
     , iohk-monitoring
+    , plutus-ledger-api
 
   ------------------------
   -- Non-IOG dependencies

--- a/plutus-contract/src/Plutus/Contract/Oracle.hs
+++ b/plutus-contract/src/Plutus/Contract/Oracle.hs
@@ -45,7 +45,7 @@ import Ledger.Constraints qualified as Constraints
 import Ledger.Crypto (Passphrase, PrivateKey, PubKey (..), Signature (..))
 import Ledger.Crypto qualified as Crypto
 import Ledger.Scripts (Datum (Datum), DatumHash (DatumHash))
-import Plutus.Script.Utils.V1.Scripts qualified as Scripts
+import Plutus.Script.Utils.Scripts qualified as Scripts
 import Plutus.V1.Ledger.Bytes (LedgerBytes (LedgerBytes))
 import Plutus.V1.Ledger.Contexts (ScriptContext)
 import Plutus.V1.Ledger.Time (POSIXTime)

--- a/plutus-contract/src/Plutus/Contract/Test/ContractModel/DoubleSatisfaction.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/ContractModel/DoubleSatisfaction.hs
@@ -57,7 +57,8 @@ import Ledger.Validation qualified as Validation
 import Ledger.Value (adaOnlyValue)
 import Plutus.Contract.Test hiding (not)
 import Plutus.Contract.Test.ContractModel.Internal
-import Plutus.Script.Utils.V1.Scripts (datumHash, validatorHash)
+import Plutus.Script.Utils.Scripts (datumHash)
+import Plutus.Script.Utils.V1.Scripts (validatorHash)
 import Plutus.Trace.Emulator as Trace (EmulatorTrace, activateContract, callEndpoint, runEmulatorStream)
 import Plutus.V1.Ledger.Address
 import Plutus.V1.Ledger.TxId

--- a/plutus-contract/test/Spec/Contract.hs
+++ b/plutus-contract/test/Spec/Contract.hs
@@ -39,7 +39,7 @@ import Plutus.Contract.Test (Shrinking (DoShrink, DontShrink), TracePredicate, a
                              waitingForSlot, walletFundsChange, (.&&.))
 import Plutus.Contract.Types (ResumableResult (ResumableResult, _finalState), responses)
 import Plutus.Contract.Util (loopM)
-import Plutus.Script.Utils.V1.Scripts (datumHash)
+import Plutus.Script.Utils.Scripts (datumHash)
 import Plutus.Trace qualified as Trace
 import Plutus.Trace.Emulator (ContractInstanceTag, EmulatorTrace, activateContract, activeEndpoints, callEndpoint)
 import Plutus.Trace.Emulator.Types (ContractInstanceLog (_cilMessage),

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -104,7 +104,8 @@ import Ledger.Typed.Scripts (Any, ConnectionError (UnknownRef), TypedValidator,
                              ValidatorTypes (DatumType, RedeemerType))
 import Ledger.Typed.Scripts qualified as Scripts
 import Ledger.Validation (evaluateMinLovelaceOutput, fromPlutusTxOutUnsafe)
-import Plutus.Script.Utils.V1.Scripts (datumHash, mintingPolicyHash, validatorHash)
+import Plutus.Script.Utils.Scripts (datumHash)
+import Plutus.Script.Utils.V1.Scripts (mintingPolicyHash, validatorHash)
 import Plutus.Script.Utils.V1.Typed.Scripts qualified as Typed
 import Plutus.V1.Ledger.Ada qualified as Ada
 import Plutus.V1.Ledger.Scripts (Datum (Datum), DatumHash, MintingPolicy, MintingPolicyHash, Redeemer, Validator,

--- a/plutus-ledger/src/Ledger/Index.hs
+++ b/plutus-ledger/src/Ledger/Index.hs
@@ -75,7 +75,8 @@ import Ledger.Params (Params (pSlotConfig))
 import Ledger.TimeSlot qualified as TimeSlot
 import Ledger.Tx (CardanoTx (..), txId, updateUtxoCollateral)
 import Ledger.Validation (evaluateMinLovelaceOutput, fromPlutusTxOutUnsafe)
-import Plutus.Script.Utils.V1.Scripts
+import Plutus.Script.Utils.Scripts (datumHash)
+import Plutus.Script.Utils.V1.Scripts (mintingPolicyHash, validatorHash)
 import Plutus.V1.Ledger.Ada (Ada)
 import Plutus.V1.Ledger.Ada qualified as Ada
 import Plutus.V1.Ledger.Address (Address (Address, addressCredential))

--- a/plutus-ledger/src/Ledger/Tx.hs
+++ b/plutus-ledger/src/Ledger/Tx.hs
@@ -78,7 +78,7 @@ import Ledger.Crypto (Passphrase, PrivateKey, signTx, signTx', toPublicKey)
 import Ledger.Orphans ()
 import Ledger.Tx.CardanoAPI (SomeCardanoApiTx (SomeTx), ToCardanoError (..))
 import Ledger.Tx.CardanoAPI qualified as CardanoAPI
-import Plutus.Script.Utils.V1.Scripts (datumHash)
+import Plutus.Script.Utils.Scripts (datumHash)
 import Plutus.V1.Ledger.Api (Credential (PubKeyCredential, ScriptCredential), Datum (Datum), DatumHash, TxId (TxId),
                              Validator, ValidatorHash, Value, addressCredential, toBuiltin)
 import Plutus.V1.Ledger.Slot (SlotRange)

--- a/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
+++ b/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
@@ -105,6 +105,7 @@ import GHC.Generics (Generic)
 import Ledger.Address qualified as P
 import Ledger.Params qualified as P
 import Ledger.Tx.CardanoAPITemp (makeTransactionBody')
+import Plutus.Script.Utils.Scripts qualified as P
 import Plutus.Script.Utils.V1.Scripts qualified as P
 import Plutus.V1.Ledger.Ada qualified as Ada
 import Plutus.V1.Ledger.Api qualified as Api

--- a/plutus-script-utils/plutus-script-utils.cabal
+++ b/plutus-script-utils/plutus-script-utils.cabal
@@ -57,6 +57,7 @@ library
   hs-source-dirs:   src
   default-language: Haskell2010
   exposed-modules:
+    Plutus.Script.Utils.Scripts
     Plutus.Script.Utils.V1.Generators
     Plutus.Script.Utils.V1.Scripts
     Plutus.Script.Utils.V1.Typed.Scripts

--- a/plutus-script-utils/src/Plutus/Script/Utils/Scripts.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/Scripts.hs
@@ -1,0 +1,70 @@
+{-|
+This module contains functions related to BuiltinData, or more specifially,
+'Datum's and 'Redeemer's. These functions do not depend on a particular version
+of Plutus.
+-}
+module Plutus.Script.Utils.Scripts
+    ( -- * Script data hashes
+      PV1.Datum
+    , PV1.DatumHash
+    , PV1.Redeemer
+    , PV1.RedeemerHash
+    , datumHash
+    , redeemerHash
+    , dataHash
+    ) where
+
+import Cardano.Api qualified as Script
+import Cardano.Api.Shelley qualified as Script
+import Plutus.V1.Ledger.Api qualified as PV1
+import PlutusTx.Builtins qualified as Builtins
+
+-- | Hash a 'PV1.Datum builtin data.
+datumHash :: PV1.Datum -> PV1.DatumHash
+datumHash = PV1.DatumHash . dataHash . PV1.getDatum
+
+-- | Hash a 'PV1.Redeemer' builtin data.
+redeemerHash :: PV1.Redeemer -> PV1.RedeemerHash
+redeemerHash = PV1.RedeemerHash . dataHash . PV1.getRedeemer
+
+-- | Hash a 'Builtins.BuiltinData'
+dataHash :: Builtins.BuiltinData -> Builtins.BuiltinByteString
+dataHash =
+    Builtins.toBuiltin
+    . Script.serialiseToRawBytes
+    . Script.hashScriptData
+    . toCardanoAPIData
+
+-- | Convert a 'Builtins.BuiltinsData' value to a 'cardano-api' script
+--   data value.
+--
+-- For why we depend on `cardano-api`,
+-- see note [Hash computation of datums, redeemers and scripts]
+toCardanoAPIData :: Builtins.BuiltinData -> Script.ScriptData
+toCardanoAPIData = Script.fromPlutusData . Builtins.builtinDataToData
+
+{- Note [Hash computation of datums, redeemers and scripts]
+
+We have three options for computing the hash (each with advantages and drawbacks):
+
+1- Depend on `cardano-api` and use it's `Scripts.hashScriptData` and `Scripts.hashScript`
+functions.
+The good: most simplest way to compute the hashes.
+The bad: this package has an additional pretty large dependency.
+
+2- Depend on `cardano-ledger` instead and use their `hashScriptData` and `hashScript`.
+The good: smaller footprint than `cardano-api`.
+The bad: a lower-lever library than `cardano-api`.
+
+3- Depend on `cardano-crypto-class`, and reimplement ourselves the hashing functions
+from `cardano-ledger`.
+The good: the lowest dependency footprint.
+The bad: code duplication.
+
+However, we expect that most Plutus script devs depending on this package will
+also probably depend on `cardano-api`, so the dependency on `cardano-api` should
+(probably) be an non-issue.
+
+If this becomes an issue, we'll change the implementation.
+-}
+

--- a/plutus-script-utils/src/Plutus/Script/Utils/V1/Scripts.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V1/Scripts.hs
@@ -1,14 +1,10 @@
+{-|
+This module contains functions related to the computation of script hashes for
+PlutusV1.
+-}
 module Plutus.Script.Utils.V1.Scripts
-    ( -- * Script data hashes
-      PV1.Datum
-    , PV1.DatumHash
-    , PV1.Redeemer
-    , PV1.RedeemerHash
-    , datumHash
-    , redeemerHash
-    , dataHash
-    -- * Script hashes
-    , PV1.Validator
+    ( -- * Script hashes
+      PV1.Validator
     , PV1.ValidatorHash
     , PV1.MintingPolicy
     , PV1.MintingPolicyHash
@@ -30,14 +26,6 @@ import Data.ByteString.Short qualified as SBS
 import Plutus.V1.Ledger.Api qualified as PV1
 import Plutus.V1.Ledger.Scripts qualified as PV1
 import PlutusTx.Builtins qualified as Builtins
-
--- | Hash a 'PV1.Datum builtin data.
-datumHash :: PV1.Datum -> PV1.DatumHash
-datumHash = PV1.DatumHash . dataHash . PV1.getDatum
-
--- | Hash a 'PV1.Redeemer' builtin data.
-redeemerHash :: PV1.Redeemer -> PV1.RedeemerHash
-redeemerHash = PV1.RedeemerHash . dataHash . PV1.getRedeemer
 
 -- | Hash a 'PV1.Validator' script.
 validatorHash :: PV1.Validator -> PV1.ValidatorHash
@@ -62,22 +50,6 @@ stakeValidatorHash =
   . PV1.getScriptHash
   . scriptHash
   . PV1.getStakeValidator
-
--- | Hash a 'Builtins.BuiltinData'
-dataHash :: Builtins.BuiltinData -> Builtins.BuiltinByteString
-dataHash =
-    Builtins.toBuiltin
-    . Script.serialiseToRawBytes
-    . Script.hashScriptData
-    . toCardanoAPIData
-
--- | Convert a 'Builtins.BuiltinsData' value to a 'cardano-api' script
---   data value.
---
--- For why we depend on `cardano-api`,
--- see note [Hash computation of datums, redeemers and scripts]
-toCardanoAPIData :: Builtins.BuiltinData -> Script.ScriptData
-toCardanoAPIData = Script.fromPlutusData . Builtins.builtinDataToData
 
 -- | Hash a 'Script'
 scriptHash :: PV1.Script -> PV1.ScriptHash
@@ -105,28 +77,3 @@ toCardanoApiScript =
 scriptCurrencySymbol :: PV1.MintingPolicy -> PV1.CurrencySymbol
 scriptCurrencySymbol scrpt =
     let (PV1.MintingPolicyHash hsh) = mintingPolicyHash scrpt in PV1.CurrencySymbol hsh
-
-{- Note [Hash computation of datums, redeemers and scripts]
-
-We have three options for computing the hash (each with advantages and drawbacks):
-
-1- Depend on `cardano-api` and use it's `Scripts.hashScriptData` and `Scripts.hashScript`
-functions.
-The good: most simplest way to compute the hashes.
-The bad: this package has an additional pretty large dependency.
-
-2- Depend on `cardano-ledger` instead and use their `hashScriptData` and `hashScript`.
-The good: smaller footprint than `cardano-api`.
-The bad: a lower-lever library than `cardano-api`.
-
-3- Depend on `cardano-crypto-class`, and reimplement ourselves the hashing functions
-from `cardano-ledger`.
-The good: the lowest dependency footprint.
-The bad: code duplication.
-
-However, we expect that most Plutus script devs depending on this package will
-also probably depend on `cardano-api`, so the dependency on `cardano-api` should
-(probably) be an non-issue.
-
-If this becomes an issue, we'll change the implementation.
--}

--- a/plutus-script-utils/src/Plutus/Script/Utils/V1/Typed/Scripts.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V1/Typed/Scripts.hs
@@ -33,7 +33,7 @@ import Data.Aeson (FromJSON (parseJSON), KeyValue ((.=)), ToJSON (toJSON), objec
 import Data.Aeson qualified
 import Data.Aeson.Types (typeMismatch)
 import GHC.Generics (Generic)
-import Plutus.Script.Utils.V1.Scripts (datumHash)
+import Plutus.Script.Utils.Scripts (datumHash)
 import Plutus.Script.Utils.V1.Typed.Scripts.MonetaryPolicies hiding (forwardToValidator)
 import Plutus.Script.Utils.V1.Typed.Scripts.StakeValidators hiding (forwardToValidator)
 import Plutus.Script.Utils.V1.Typed.Scripts.Validators

--- a/plutus-script-utils/src/Plutus/Script/Utils/V1/Typed/Scripts/Validators.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V1/Typed/Scripts/Validators.hs
@@ -43,6 +43,7 @@ import Data.ByteString.Lazy qualified as BSL
 import Data.Kind (Type)
 import Data.Void (Void)
 import GHC.Generics (Generic)
+import Plutus.Script.Utils.Scripts qualified as Scripts
 import Plutus.Script.Utils.V1.Scripts qualified as Scripts
 import Plutus.Script.Utils.V1.Typed.Scripts.MonetaryPolicies qualified as MPS
 import Plutus.Script.Utils.V1.Typed.TypeUtils (Any)

--- a/plutus-use-cases/src/Plutus/Contracts/Escrow.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Escrow.hs
@@ -70,7 +70,7 @@ import Ledger.Typed.Scripts qualified as Scripts
 import Ledger.Value (Value, geq, lt)
 import Plutus.Contract
 import Plutus.Contract.Typed.Tx qualified as Typed
-import Plutus.Script.Utils.V1.Scripts (datumHash)
+import Plutus.Script.Utils.Scripts (datumHash)
 import Plutus.V1.Ledger.Scripts (Datum (Datum), DatumHash, ValidatorHash)
 
 import Prelude (Semigroup (..), foldMap)

--- a/plutus-use-cases/src/Plutus/Contracts/Tutorial/Escrow.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Tutorial/Escrow.hs
@@ -58,7 +58,7 @@ import Ledger.Tx qualified as Tx
 import Ledger.Typed.Scripts (TypedValidator)
 import Ledger.Typed.Scripts qualified as Scripts
 import Ledger.Value (Value, geq, lt)
-import Plutus.Script.Utils.V1.Scripts qualified as Ledger
+import Plutus.Script.Utils.Scripts qualified as Ledger
 import Plutus.V1.Ledger.Api (Datum (Datum), DatumHash)
 import Plutus.V1.Ledger.Contexts (ScriptContext (..), TxInfo (..))
 

--- a/plutus-use-cases/src/Plutus/Contracts/Tutorial/EscrowStrict.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Tutorial/EscrowStrict.hs
@@ -55,7 +55,7 @@ import Ledger.Tx qualified as Tx
 import Ledger.Typed.Scripts (TypedValidator)
 import Ledger.Typed.Scripts qualified as Scripts
 import Ledger.Value (Value, geq, lt)
-import Plutus.Script.Utils.V1.Scripts qualified as Ledger
+import Plutus.Script.Utils.Scripts qualified as Ledger
 import Plutus.V1.Ledger.Api (Datum (Datum), DatumHash, ValidatorHash)
 import Plutus.V1.Ledger.Contexts (ScriptContext (..), TxInfo (..))
 

--- a/plutus-use-cases/test/Spec/Escrow/Endpoints.hs
+++ b/plutus-use-cases/test/Spec/Escrow/Endpoints.hs
@@ -17,7 +17,7 @@ import Ledger.Interval (from)
 import Ledger.Tx qualified as Tx
 import Ledger.Typed.Scripts (TypedValidator)
 import Ledger.Typed.Scripts qualified as Scripts
-import Plutus.Script.Utils.V1.Scripts qualified as Ledger
+import Plutus.Script.Utils.Scripts qualified as Ledger
 import Plutus.V1.Ledger.Api (Datum (Datum))
 
 import Plutus.Contract


### PR DESCRIPTION
Moved datum and redeemer hash computation functions in plutus-script-utils in another module which does not depend on a specific version of Plutus.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
