### PR TITLE
PLT-172: Marconi index transactions that have been issued to a particular script

### DIFF
--- a/plutus-chain-index-core/plutus-chain-index-core.cabal
+++ b/plutus-chain-index-core/plutus-chain-index-core.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.2
+cabal-version: 3.0
 name:          plutus-chain-index-core
 version:       0.1.0.0
 license:       Apache-2.0
@@ -155,6 +155,7 @@ test-suite plutus-chain-index-test
   hs-source-dirs: test
   other-modules:
     Generators
+    MarconiSpec
     Plutus.ChainIndex.Emulator.DiskStateSpec
     Plutus.ChainIndex.Emulator.HandlersSpec
     Plutus.ChainIndex.HandlersSpec
@@ -164,6 +165,7 @@ test-suite plutus-chain-index-test
   -- Local components
   --------------------
   build-depends:
+    , cardano-api:gen
     , freer-extras
     , plutus-chain-index-core
     , plutus-ledger
@@ -172,6 +174,7 @@ test-suite plutus-chain-index-test
   -- Other IOG dependencies
   --------------------------
   build-depends:
+    , cardano-api
     , plutus-ledger-api
     , plutus-tx
 

--- a/plutus-chain-index-core/plutus-chain-index-core.cabal
+++ b/plutus-chain-index-core/plutus-chain-index-core.cabal
@@ -44,6 +44,7 @@ library
     Cardano.Protocol.Socket.Client
     Cardano.Protocol.Socket.Type
     Marconi.Index.Datum
+    Marconi.Index.ScriptTx
     Marconi.Index.TxConfirmationStatus
     Marconi.Index.Utxo
     Plutus.ChainIndex
@@ -85,7 +86,12 @@ library
   --------------------------
   build-depends:
     , cardano-api
+    , cardano-binary
+    , cardano-ledger-alonzo
     , cardano-ledger-byron
+    , cardano-ledger-core
+    , cardano-ledger-shelley
+    , cardano-ledger-shelley-ma
     , io-classes
     , iohk-monitoring
     , ouroboros-consensus

--- a/plutus-chain-index-core/src/Marconi/Index/ScriptTx.hs
+++ b/plutus-chain-index-core/src/Marconi/Index/ScriptTx.hs
@@ -1,0 +1,197 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+
+module Marconi.Index.ScriptTx where
+
+import Codec.Serialise (deserialiseOrFail)
+import Control.Lens.Operators ((^.))
+import Data.ByteString qualified as BS
+import Data.Foldable (forM_, toList)
+import Data.Maybe (catMaybes, fromJust)
+import Database.SQLite.Simple qualified as SQL
+import Database.SQLite.Simple.FromField qualified as SQL
+import Database.SQLite.Simple.ToField qualified as SQL
+import GHC.Generics (Generic)
+
+import Cardano.Api (SlotNo)
+import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as Shelley
+import Cardano.Ledger.Alonzo.Language qualified as Alonzo
+import Cardano.Ledger.Alonzo.Scripts qualified as Alonzo
+import Cardano.Ledger.Core qualified
+import Cardano.Ledger.Crypto qualified as LedgerCrypto
+import Cardano.Ledger.Keys qualified as LedgerShelley
+import Cardano.Ledger.Shelley.Scripts qualified as LedgerShelley
+import Cardano.Ledger.ShelleyMA.Timelocks qualified as Timelock
+
+import RewindableIndex.Index.VSqlite (SqliteIndex)
+import RewindableIndex.Index.VSqlite qualified as Ix
+
+
+newtype Depth = Depth Int
+
+newtype ScriptAddress = ScriptAddress Shelley.ScriptHash
+  deriving (Show, Eq)
+newtype TxCbor = TxCbor BS.ByteString
+  deriving (Show)
+  deriving newtype (SQL.ToField, SQL.FromField)
+
+-- * SQLite
+
+data ScriptTxRow = ScriptTxRow
+  { scriptAddress :: !ScriptAddress
+  , txCbor        :: !TxCbor
+  } deriving (Generic)
+
+instance SQL.ToField ScriptAddress where
+  toField (ScriptAddress hash)  = SQL.SQLBlob . Shelley.serialiseToRawBytes $ hash
+instance SQL.FromField ScriptAddress where
+  fromField f = SQL.fromField f >>=
+    either
+      (const cantDeserialise)
+      (\b -> maybe cantDeserialise (return . ScriptAddress) $ Shelley.deserialiseFromRawBytes Shelley.AsScriptHash b) . deserialiseOrFail
+    where
+      cantDeserialise = SQL.returnError SQL.ConversionFailed f "Cannot deserialise address."
+
+instance SQL.ToRow ScriptTxRow where
+  toRow o = [SQL.toField $ scriptAddress o, SQL.toField $ txCbor o]
+
+-- * Indexer
+
+type Query = ScriptAddress
+type Result = [TxCbor]
+
+data ScriptTxUpdate = ScriptTxUpdate
+  { txScripts :: [(TxCbor, [ScriptAddress])]
+  , slotNo    :: !SlotNo
+  } deriving (Show)
+
+type ScriptTxIndex = SqliteIndex ScriptTxUpdate () Query Result
+
+
+toUpdate :: forall era . C.IsCardanoEra era => [C.Tx era] -> SlotNo -> ScriptTxUpdate
+toUpdate txs = ScriptTxUpdate txScripts'
+  where
+    txScripts' = map (\tx -> (TxCbor $ C.serialiseToCBOR tx, getTxScripts tx)) txs
+
+getTxBodyScripts :: forall era . C.TxBody era -> [ScriptAddress]
+getTxBodyScripts body = let
+    hashesMaybe :: [Maybe C.ScriptHash]
+    hashesMaybe = case body of
+      Shelley.ShelleyTxBody shelleyBasedEra _ scripts _ _ _ -> flip map scripts $ \script ->
+        case fromShelleyBasedScript shelleyBasedEra script of
+          Shelley.ScriptInEra _ script' -> Just $ C.hashScript script'
+      _ -> [] -- Byron transactions have no scripts
+    hashes = catMaybes hashesMaybe :: [Shelley.ScriptHash]
+  in map ScriptAddress hashes
+
+getTxScripts :: forall era . C.Tx era -> [ScriptAddress]
+getTxScripts (C.Tx txBody _ws) = getTxBodyScripts txBody
+
+open :: FilePath -> Depth -> IO ScriptTxIndex
+open dbPath (Depth k) = do
+  ix <- fromJust <$> Ix.newBoxed query store onInsert k ((k + 1) * 2) dbPath
+  let c = ix ^. Ix.handle
+  SQL.execute_ c "CREATE TABLE IF NOT EXISTS script_transactions (scriptAddress TEXT NOT NULL, txCbor BLOB NOT NULL)"
+  SQL.execute_ c "CREATE INDEX IF NOT EXISTS script_address ON script_transactions (scriptAddress)"
+  pure ix
+
+  where
+    onInsert :: ScriptTxIndex -> ScriptTxUpdate -> IO [()]
+    onInsert _ix _update = pure []
+
+    store :: ScriptTxIndex -> IO ()
+    store ix = do
+      persisted <- Ix.getEvents $ ix ^. Ix.storage
+      buffered <- Ix.getBuffer $ ix ^. Ix.storage
+      let updates = buffered ++ persisted :: [ScriptTxUpdate]
+          rows = do
+            ScriptTxUpdate txScriptAddrs _slotNo <- updates
+            (txCbor', scriptAddrs) <- txScriptAddrs
+            scriptAddr <- scriptAddrs
+            pure $ ScriptTxRow scriptAddr txCbor'
+      forM_ rows $
+        SQL.execute (ix ^. Ix.handle) "INSERT INTO script_transactions (scriptAddress, txCbor) VALUES (?, ?)"
+
+    query :: ScriptTxIndex -> Query -> [ScriptTxUpdate] -> IO Result
+    query ix scriptAddress' memory = let
+        filterByScriptAddress :: [ScriptTxUpdate] -> [TxCbor]
+        filterByScriptAddress updates' = do
+          ScriptTxUpdate update _slotNo <- updates'
+          map fst $ filter (\(_, addrs) -> scriptAddress' `elem` addrs) (update )
+      in do
+      persisted :: [SQL.Only TxCbor] <- SQL.query (ix ^. Ix.handle)
+        "SELECT txCbor FROM utxos WHERE scriptAddress = ?" (SQL.Only scriptAddress')
+
+      buffered <- Ix.getBuffer $ ix ^. Ix.storage
+      let
+        both :: [TxCbor]
+        both = filterByScriptAddress memory
+          <> filterByScriptAddress buffered
+          <> map (\(SQL.Only txCbor') -> txCbor') persisted
+
+      return both
+
+-- * Copy-paste
+--
+-- | TODO: Remove when the following function is exported from Cardano.Api.Script
+-- PR: https://github.com/input-output-hk/cardano-node/pull/4386
+fromShelleyBasedScript  :: Shelley.ShelleyBasedEra era
+                        -> Cardano.Ledger.Core.Script (Shelley.ShelleyLedgerEra era)
+                        -> Shelley.ScriptInEra era
+fromShelleyBasedScript era script =
+  case era of
+    Shelley.ShelleyBasedEraShelley ->
+      Shelley.ScriptInEra Shelley.SimpleScriptV1InShelley $
+      Shelley.SimpleScript Shelley.SimpleScriptV1 $
+      fromShelleyMultiSig script
+    Shelley.ShelleyBasedEraAllegra ->
+      Shelley.ScriptInEra Shelley.SimpleScriptV2InAllegra $
+      Shelley.SimpleScript Shelley.SimpleScriptV2 $
+      fromAllegraTimelock Shelley.TimeLocksInSimpleScriptV2 script
+    Shelley.ShelleyBasedEraMary ->
+      Shelley.ScriptInEra Shelley.SimpleScriptV2InMary $
+      Shelley.SimpleScript Shelley.SimpleScriptV2 $
+      fromAllegraTimelock Shelley.TimeLocksInSimpleScriptV2 script
+    Shelley.ShelleyBasedEraAlonzo ->
+      case script of
+        Alonzo.TimelockScript s ->
+          Shelley.ScriptInEra Shelley.SimpleScriptV2InAlonzo $
+          Shelley.SimpleScript Shelley.SimpleScriptV2 $
+          fromAllegraTimelock Shelley.TimeLocksInSimpleScriptV2 s
+        Alonzo.PlutusScript Alonzo.PlutusV1 s ->
+          Shelley.ScriptInEra Shelley.PlutusScriptV1InAlonzo $
+          Shelley.PlutusScript Shelley.PlutusScriptV1 $
+          Shelley.PlutusScriptSerialised s
+        Alonzo.PlutusScript Alonzo.PlutusV2 s ->
+          Shelley.ScriptInEra Shelley.PlutusScriptV2InAlonzo $
+          Shelley.PlutusScript Shelley.PlutusScriptV2 $
+          Shelley.PlutusScriptSerialised  s
+
+  where
+  fromAllegraTimelock :: Shelley.TimeLocksSupported lang
+                      -> Timelock.Timelock LedgerCrypto.StandardCrypto
+                      -> Shelley.SimpleScript lang
+  fromAllegraTimelock timelocks = go
+    where
+      go (Timelock.RequireSignature kh) = Shelley.RequireSignature
+                                            (Shelley.PaymentKeyHash (LedgerShelley.coerceKeyRole kh))
+      go (Timelock.RequireTimeExpire t) = Shelley.RequireTimeBefore timelocks t
+      go (Timelock.RequireTimeStart  t) = Shelley.RequireTimeAfter  timelocks t
+      go (Timelock.RequireAllOf      s) = Shelley.RequireAllOf (map go (toList s))
+      go (Timelock.RequireAnyOf      s) = Shelley.RequireAnyOf (map go (toList s))
+      go (Timelock.RequireMOf      i s) = Shelley.RequireMOf i (map go (toList s))
+
+  fromShelleyMultiSig :: LedgerShelley.MultiSig LedgerCrypto.StandardCrypto -> Shelley.SimpleScript lang
+  fromShelleyMultiSig = go
+    where
+      go (LedgerShelley.RequireSignature kh)
+                                  = Shelley.RequireSignature
+                                      (Shelley.PaymentKeyHash (LedgerShelley.coerceKeyRole kh))
+      go (LedgerShelley.RequireAllOf s) = Shelley.RequireAllOf (map go s)
+      go (LedgerShelley.RequireAnyOf s) = Shelley.RequireAnyOf (map go s)
+      go (LedgerShelley.RequireMOf m s) = Shelley.RequireMOf m (map go s)

--- a/plutus-chain-index-core/src/Marconi/Index/ScriptTx.hs
+++ b/plutus-chain-index-core/src/Marconi/Index/ScriptTx.hs
@@ -106,11 +106,9 @@ open dbPath (Depth k) = do
 
     store :: ScriptTxIndex -> IO ()
     store ix = do
-      persisted <- Ix.getEvents $ ix ^. Ix.storage
       buffered <- Ix.getBuffer $ ix ^. Ix.storage
-      let updates = buffered ++ persisted :: [ScriptTxUpdate]
-          rows = do
-            ScriptTxUpdate txScriptAddrs _slotNo <- updates
+      let rows = do
+            ScriptTxUpdate txScriptAddrs _slotNo <- buffered
             (txCbor', scriptAddrs) <- txScriptAddrs
             scriptAddr <- scriptAddrs
             pure $ ScriptTxRow scriptAddr txCbor'

--- a/plutus-chain-index-core/src/Marconi/Index/Utxo.hs
+++ b/plutus-chain-index-core/src/Marconi/Index/Utxo.hs
@@ -126,7 +126,9 @@ query ix addr updates = do
   storedUtxos <- SQL.query c "SELECT address, txId, inputIx FROM utxos LEFT JOIN spent ON utxos.txId = spent.txId AND utxos.inputIx = spent.inputIx WHERE utxos.txId IS NULL AND utxos.address = ?" (Only addr)
   let memoryUtxos  = concatMap (filter (onlyAt addr) . toRows) updates
       spentOutputs = foldl' Set.union Set.empty $ map _inputs updates
-  pure . Just $ storedUtxos ++ memoryUtxos
+  buffered <- Ix.getBuffer $ ix ^. Ix.storage
+  let bufferedUtxos = concatMap (filter (onlyAt addr) . toRows) buffered
+  pure . Just $ storedUtxos ++ bufferedUtxos ++ memoryUtxos
               -- Remove utxos that have been spent (from memory db).
               & filter (\u -> not (_reference u `Set.member` spentOutputs))
               & map _reference

--- a/plutus-chain-index-core/src/Marconi/Index/Utxo.hs
+++ b/plutus-chain-index-core/src/Marconi/Index/Utxo.hs
@@ -133,11 +133,9 @@ query ix addr updates = do
 
 store :: UtxoIndex -> IO ()
 store ix = do
-  events <- Ix.getEvents $ ix ^. Ix.storage
   buffer <- Ix.getBuffer $ ix ^. Ix.storage
-  let all'  = buffer ++ events
-      utxos = concatMap toRows all'
-      spent = concatMap (toList . _inputs) all'
+  let utxos = concatMap toRows buffer
+      spent = concatMap (toList . _inputs) buffer
       c     = ix ^. Ix.handle
 
   SQL.execute_ c "BEGIN"

--- a/plutus-chain-index-core/src/Plutus/Contract/CardanoAPI.hs
+++ b/plutus-chain-index-core/src/Plutus/Contract/CardanoAPI.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GADTs              #-}
-{-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RecordWildCards    #-}
 {-|

--- a/plutus-chain-index-core/test/MarconiSpec.hs
+++ b/plutus-chain-index-core/test/MarconiSpec.hs
@@ -1,0 +1,320 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TupleSections  #-}
+
+module MarconiSpec where
+
+import Control.Monad (replicateM)
+import Data.Coerce (coerce)
+import Data.Int (Int64)
+import Data.Map (Map)
+import Data.Ratio (Ratio, (%))
+import Data.Set qualified as S
+import Numeric.Natural (Natural)
+
+import Hedgehog
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Cardano.Api
+import Cardano.Api qualified as Api
+import Cardano.Api.Shelley
+import Gen.Cardano.Api.Metadata qualified as CGen
+import Gen.Cardano.Api.Typed qualified as CGen
+import Plutus.V1.Ledger.Api qualified as Plutus
+
+import Marconi.Index.ScriptTx qualified as ScriptTx
+
+tests :: TestTree
+tests = testGroup "Marconi"
+  [ testProperty "prop_script_hashes_in_tx_match" getTxBodyScriptsRoundtrip ]
+
+getTxBodyScriptsRoundtrip :: Property
+getTxBodyScriptsRoundtrip = property $ do
+  nScripts <- forAll $ Gen.integral (Range.linear 5 500)
+  AnyCardanoEra (era :: CardanoEra era) <- forAll $
+    Gen.enum (AnyCardanoEra ShelleyEra) maxBound
+
+  txIns <- replicateM nScripts $ forAll CGen.genTxIn
+  witnessesHashes <- replicateM nScripts $ forAll $ genWitnessAndHashInEra era
+
+  let (witnesses, scriptHashes) = unzip witnessesHashes
+      collateral = case collateralSupportedInEra era of
+        Just yes -> TxInsCollateral yes txIns
+        _        -> TxInsCollateralNone
+
+  txBody <- forAll $ genTxBodyWithTxIns era (zip txIns $ map BuildTxWith witnesses) collateral
+  let hashesFound = map coerce $ ScriptTx.getTxBodyScripts txBody :: [ScriptHash]
+  assert $ S.fromList scriptHashes == S.fromList hashesFound
+
+genTxBodyWithTxIns
+  :: IsCardanoEra era
+  => CardanoEra era
+  -> [(TxIn, BuildTxWith BuildTx (Witness WitCtxTxIn era))]
+  -> TxInsCollateral era
+  -> Gen (TxBody era)
+genTxBodyWithTxIns era txIns txInsCollateral = do
+  txBodyContent <- genTxBodyContentWithTxInsCollateral era txIns txInsCollateral
+  case makeTransactionBody txBodyContent of
+    Left err     -> fail $ displayError err
+    Right txBody -> pure txBody
+
+genTxBodyContentWithTxInsCollateral
+  :: CardanoEra era
+  -> [(TxIn, BuildTxWith BuildTx (Witness WitCtxTxIn era))]
+  -> TxInsCollateral era
+  -> Gen (TxBodyContent BuildTx era)
+genTxBodyContentWithTxInsCollateral era txIns txInsCollateral = do
+  txOuts <- Gen.list (Range.constant 1 10) (CGen.genTxOut era)
+  txFee <- genTxFee era
+  txValidityRange <- genTxValidityRange era
+  txMetadata <- genTxMetadataInEra era
+  txAuxScripts <- genTxAuxScripts era
+  let txExtraKeyWits = TxExtraKeyWitnessesNone --TODO: Alonzo era: Generate witness key hashes
+  txProtocolParams <- BuildTxWith . Just <$> genProtocolParameters
+  txWithdrawals <- genTxWithdrawals era
+  txCertificates <- genTxCertificates era
+  txUpdateProposal <- genTxUpdateProposal era
+  txMintValue <- genTxMintValue era
+  txScriptValidity <- genTxScriptValidity era
+
+  pure $ TxBodyContent
+    { Api.txIns
+    , Api.txInsCollateral
+    , Api.txOuts
+    , Api.txFee
+    , Api.txValidityRange
+    , Api.txMetadata
+    , Api.txAuxScripts
+    , Api.txExtraKeyWits
+    , Api.txProtocolParams
+    , Api.txWithdrawals
+    , Api.txCertificates
+    , Api.txUpdateProposal
+    , Api.txMintValue
+    , Api.txScriptValidity
+    }
+
+genWitnessAndHashInEra :: CardanoEra era -> Gen (Witness WitCtxTxIn era, ScriptHash)
+genWitnessAndHashInEra era = do
+  ScriptInEra scriptLanguageInEra script <- CGen.genScriptInEra era
+  witness :: Witness WitCtxTxIn era1 <- ScriptWitness ScriptWitnessForSpending <$> case script of
+    PlutusScript version plutusScript -> do
+      scriptData <- CGen.genScriptData
+      executionUnits <- genExecutionUnits
+      pure $ PlutusScriptWitness
+        scriptLanguageInEra
+        version
+        plutusScript
+        (ScriptDatumForTxIn scriptData)
+        scriptData
+        executionUnits
+    SimpleScript version simpleScript ->
+      pure $ SimpleScriptWitness scriptLanguageInEra version simpleScript
+  pure (witness, hashScript script)
+
+-- * Copy-paste
+
+-- | The following code is copied (including comments) from
+-- cardano-node commit 2b1d18c6c7b7142d9eebfec34da48840ed4409b6 (what
+-- plutus-apps main depends on)
+-- cardano-api/gen/Gen/Cardano/Api/Typed.hs
+
+type TxIns build era = [(TxIn, BuildTxWith build (Witness WitCtxTxIn era))]
+-- ^ From /cardano-node/cardano-api/src/Cardano/Api/TxBody.hs
+
+panic :: String -> a
+panic = error
+
+genTxScriptValidity :: CardanoEra era -> Gen (TxScriptValidity era)
+genTxScriptValidity era = case txScriptValiditySupportedInCardanoEra era of
+  Nothing      -> pure TxScriptValidityNone
+  Just witness -> TxScriptValidity witness <$> genScriptValidity
+
+genScriptValidity :: Gen ScriptValidity
+genScriptValidity = Gen.element [ScriptInvalid, ScriptValid]
+
+genTxMintValue :: CardanoEra era -> Gen (TxMintValue BuildTx era)
+genTxMintValue era =
+  case multiAssetSupportedInEra era of
+    Left _ -> pure TxMintNone
+    Right supported ->
+      Gen.choice
+        [ pure TxMintNone
+        , TxMintValue supported <$> CGen.genValueForMinting <*> return (BuildTxWith mempty)
+        ]
+
+genTxUpdateProposal :: CardanoEra era -> Gen (TxUpdateProposal era)
+genTxUpdateProposal era =
+  case updateProposalSupportedInEra era of
+    Nothing -> pure TxUpdateProposalNone
+    Just supported ->
+      Gen.choice
+        [ pure TxUpdateProposalNone
+        , TxUpdateProposal supported <$> CGen.genUpdateProposal
+        ]
+
+genTxCertificates :: CardanoEra era -> Gen (TxCertificates BuildTx era)
+genTxCertificates era =
+  case certificatesSupportedInEra era of
+    Nothing -> pure TxCertificatesNone
+    Just supported -> do
+      certs <- Gen.list (Range.constant 0 3) CGen.genCertificate
+      Gen.choice
+        [ pure TxCertificatesNone
+        , pure (TxCertificates supported certs $ BuildTxWith mempty)
+          -- TODO: Generate certificates
+        ]
+
+genTxWithdrawals :: CardanoEra era -> Gen (TxWithdrawals BuildTx era)
+genTxWithdrawals era =
+  case withdrawalsSupportedInEra era of
+    Nothing -> pure TxWithdrawalsNone
+    Just supported ->
+      Gen.choice
+        [ pure TxWithdrawalsNone
+        , pure (TxWithdrawals supported mempty)
+          -- TODO: Generate withdrawals
+        ]
+
+genTxAuxScripts :: CardanoEra era -> Gen (TxAuxScripts era)
+genTxAuxScripts era =
+  case auxScriptsSupportedInEra era of
+    Nothing -> pure TxAuxScriptsNone
+    Just supported ->
+      TxAuxScripts supported <$>
+        Gen.list (Range.linear 0 3)
+                 (CGen.genScriptInEra era)
+
+genTxMetadataInEra :: CardanoEra era -> Gen (TxMetadataInEra era)
+genTxMetadataInEra era =
+  case txMetadataSupportedInEra era of
+    Nothing -> pure TxMetadataNone
+    Just supported ->
+      Gen.choice
+        [ pure TxMetadataNone
+        , TxMetadataInEra supported <$> CGen.genTxMetadata
+        ]
+
+genTxValidityRange
+  :: CardanoEra era
+  -> Gen (TxValidityLowerBound era, TxValidityUpperBound era)
+genTxValidityRange era =
+  (,)
+    <$> genTxValidityLowerBound era
+    <*> genTxValidityUpperBound era
+
+-- TODO: Accept a range for generating ttl.
+genTxValidityUpperBound :: CardanoEra era -> Gen (TxValidityUpperBound era)
+genTxValidityUpperBound era =
+  case (validityUpperBoundSupportedInEra era,
+       validityNoUpperBoundSupportedInEra era) of
+    (Just supported, _) ->
+      TxValidityUpperBound supported <$> genTtl
+
+    (Nothing, Just supported) ->
+      pure (TxValidityNoUpperBound supported)
+
+    (Nothing, Nothing) ->
+      panic "genTxValidityUpperBound: unexpected era support combination"
+
+genTtl :: Gen SlotNo
+genTtl = genSlotNo
+
+genSlotNo :: Gen SlotNo
+genSlotNo = SlotNo <$> Gen.word64 Range.constantBounded
+
+-- TODO: Accept a range for generating ttl.
+genTxValidityLowerBound :: CardanoEra era -> Gen (TxValidityLowerBound era)
+genTxValidityLowerBound era =
+  case validityLowerBoundSupportedInEra era of
+    Nothing        -> pure TxValidityNoLowerBound
+    Just supported -> TxValidityLowerBound supported <$> genTtl
+
+genTxFee :: CardanoEra era -> Gen (TxFee era)
+genTxFee era =
+  case txFeesExplicitInEra era of
+    Left  supported -> pure (TxFeeImplicit supported)
+    Right supported -> TxFeeExplicit supported <$> CGen.genLovelace
+
+genTxInsCollateral :: CardanoEra era -> Gen (TxInsCollateral era)
+genTxInsCollateral era =
+    case collateralSupportedInEra era of
+      Nothing        -> pure TxInsCollateralNone
+      Just supported -> Gen.choice
+                          [ pure TxInsCollateralNone
+                          , TxInsCollateral supported <$> Gen.list (Range.linear 0 10) CGen.genTxIn
+                          ]
+
+genExecutionUnits :: Gen ExecutionUnits
+genExecutionUnits = ExecutionUnits <$> Gen.integral (Range.constant 0 1000)
+                                   <*> Gen.integral (Range.constant 0 1000)
+
+genNat :: Gen Natural
+genNat = Gen.integral (Range.linear 0 10)
+
+genProtocolParameters :: Gen ProtocolParameters
+genProtocolParameters =
+  ProtocolParameters
+    <$> ((,) <$> genNat <*> genNat)
+    <*> CGen.genRational
+    <*> CGen.genMaybePraosNonce
+    <*> genNat
+    <*> genNat
+    <*> genNat
+    <*> genNat
+    <*> genNat
+    <*> Gen.maybe CGen.genLovelace
+    <*> CGen.genLovelace
+    <*> CGen.genLovelace
+    <*> CGen.genLovelace
+    <*> genEpochNo
+    <*> genNat
+    <*> genRationalInt64
+    <*> CGen.genRational
+    <*> CGen.genRational
+    <*> (Just <$> CGen.genLovelace)
+    <*> genCostModels
+    <*> (Just <$> genExecutionUnitPrices)
+    <*> (Just <$> genExecutionUnits)
+    <*> (Just <$> genExecutionUnits)
+    <*> (Just <$> genNat)
+    <*> (Just <$> genNat)
+    <*> (Just <$> genNat)
+
+genExecutionUnitPrices :: Gen ExecutionUnitPrices
+genExecutionUnitPrices = ExecutionUnitPrices <$> CGen.genRational <*> CGen.genRational
+
+-- TODO: consolidate this back to just genRational once this is merged:
+-- https://github.com/input-output-hk/cardano-ledger-specs/pull/2330
+genRationalInt64 :: Gen Rational
+genRationalInt64 =
+    (\d -> ratioToRational (1 % d)) <$> genDenominator
+  where
+    genDenominator :: Gen Int64
+    genDenominator = Gen.integral (Range.linear 1 maxBound)
+
+    ratioToRational :: Ratio Int64 -> Rational
+    ratioToRational = toRational
+
+genEpochNo :: Gen EpochNo
+genEpochNo = EpochNo <$> Gen.word64 (Range.linear 0 10)
+
+genCostModels :: Gen (Map AnyPlutusScriptVersion CostModel)
+genCostModels =
+    Gen.map (Range.linear 0 (length plutusScriptVersions))
+            ((,) <$> Gen.element plutusScriptVersions
+                 <*> genCostModel)
+  where
+    plutusScriptVersions :: [AnyPlutusScriptVersion]
+    plutusScriptVersions = [minBound..maxBound]
+
+genCostModel :: Gen CostModel
+genCostModel = case Plutus.defaultCostModelParams of
+  Nothing -> panic "Plutus defaultCostModelParams is broken."
+  Just dcm ->
+      CostModel
+    -- TODO This needs to be the cost model struct for whichever
+    -- Plutus version we're using, once we support multiple Plutus versions.
+    <$> mapM (const $ Gen.integral (Range.linear 0 5000)) dcm

--- a/plutus-chain-index-core/test/Spec.hs
+++ b/plutus-chain-index-core/test/Spec.hs
@@ -22,6 +22,7 @@ import Hedgehog (Property, annotateShow, assert, failure, forAll, property, (/==
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 import Ledger (TxOutRef (TxOutRef, txOutRefId))
+import MarconiSpec qualified
 import Plutus.ChainIndex.Emulator.DiskStateSpec qualified as DiskStateSpec
 import Plutus.ChainIndex.Emulator.HandlersSpec qualified as EmulatorHandlersSpec
 import Plutus.ChainIndex.HandlersSpec qualified as HandlersSpec
@@ -52,6 +53,7 @@ tests =
     , DiskStateSpec.tests
     , EmulatorHandlersSpec.tests
     , HandlersSpec.tests
+    , MarconiSpec.tests
     ]
 
 utxoBalanceTests :: [TestTree]

--- a/plutus-chain-index/app/Marconi.hs
+++ b/plutus-chain-index/app/Marconi.hs
@@ -56,11 +56,12 @@ import Streaming.Prelude qualified as S
 --     39920450|679a55b523ff8d61942b2583b76e5d49498468164802ef1ebe513c685d6fb5c2|X(002f9787436835852ea78d3c45fc3d436b324184
 
 data Options = Options
-  { optionsSocketPath :: String,
-    optionsNetworkId  :: NetworkId,
-    optionsChainPoint :: ChainPoint,
-    optionsUtxoPath   :: Maybe FilePath,
-    optionsDatumPath  :: Maybe FilePath
+  { optionsSocketPath   :: String,
+    optionsNetworkId    :: NetworkId,
+    optionsChainPoint   :: ChainPoint,
+    optionsUtxoPath     :: Maybe FilePath,
+    optionsDatumPath    :: Maybe FilePath,
+    optionsScriptTxPath :: Maybe FilePath
   }
   deriving (Show)
 
@@ -75,6 +76,7 @@ optionsParser =
     <*> chainPointParser
     <*> optStrParser (long "utxo-db" <> help "Path to the utxo database.")
     <*> optStrParser (long "datum-db" <> help "Path to the datum database.")
+    <*> optStrParser (long "script-tx-db" <> help "Path to the script transactions' database.")
 
 optStrParser :: IsString a => Mod OptionFields a -> Parser (Maybe a)
 optStrParser fields = Just <$> strOption fields <|> pure Nothing
@@ -257,7 +259,8 @@ main = do
           , optionsNetworkId
           , optionsChainPoint
           , optionsUtxoPath
-          , optionsDatumPath } <- parseOptions
+          , optionsDatumPath
+          , optionsScriptTxPath } <- parseOptions
 
   c <- defaultConfigStdout
 

--- a/plutus-chain-index/app/Marconi.hs
+++ b/plutus-chain-index/app/Marconi.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE NamedFieldPuns    #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections     #-}
-
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 module Main where
 
 import Cardano.Api (Block (Block), BlockHeader (BlockHeader), BlockInMode (BlockInMode), CardanoMode,
@@ -20,6 +20,7 @@ import Control.Exception (catch)
 import Control.Lens.Operators ((&), (<&>), (^.))
 import Control.Monad (void, when)
 import Data.ByteString.Char8 qualified as C8
+
 import Data.Foldable (foldl')
 import Data.List (findIndex)
 import Data.Map (assocs)
@@ -29,10 +30,13 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.String (IsString)
 import Ledger (TxIn (..), TxOut (..), TxOutRef (..))
+import Ledger.Scripts as Ledger
 import Ledger.Tx.CardanoAPI (fromCardanoTxId, fromCardanoTxIn, fromCardanoTxOut, fromTxScriptValidity,
-                             scriptDataFromCardanoTxBody)
+                             scriptDataFromCardanoTxBody, withIsCardanoEra)
 import Marconi.Index.Datum (DatumIndex)
 import Marconi.Index.Datum qualified as Datum
+import Marconi.Index.ScriptTx ()
+import Marconi.Index.ScriptTx qualified as ScriptTx
 import Marconi.Index.Utxo (UtxoIndex, UtxoUpdate (..))
 import Marconi.Index.Utxo qualified as Utxo
 import Marconi.Logging (logging)
@@ -40,7 +44,6 @@ import Options.Applicative (Mod, OptionFields, Parser, auto, execParser, flag', 
                             metavar, option, readerError, strOption, (<**>), (<|>))
 import Plutus.Streaming (ChainSyncEvent (RollBackward, RollForward), ChainSyncEventException (NoIntersectionFound),
                          withChainSyncEventStream)
-import Plutus.V1.Ledger.Api (Datum, DatumHash)
 import Prettyprinter (defaultLayoutOptions, layoutPretty, pretty, (<+>))
 import Prettyprinter.Render.Text (renderStrict)
 import RewindableIndex.Index.VSplit qualified as Ix
@@ -225,16 +228,39 @@ utxoWorker Coordinator{_barrier} ch path = Utxo.open path (Utxo.Depth 2160) >>= 
               offset <- findIndex  (\u -> (u ^. Utxo.slotNo) < slot) events
               Ix.rewind offset index
 
+scriptTxWorker
+  :: Coordinator
+  -> TChan (ChainSyncEvent (BlockInMode CardanoMode))
+  -> FilePath
+  -> IO ()
+scriptTxWorker Coordinator{_barrier} ch path = ScriptTx.open path (ScriptTx.Depth 2160) >>= loop
+  where
+    loop :: ScriptTx.ScriptTxIndex -> IO ()
+    loop index = do
+      signalQSemN _barrier 1
+      event <- atomically $ readTChan ch
+      case event of
+        RollForward (BlockInMode (Block (BlockHeader slotNo _ _) txs :: Block era) era :: BlockInMode CardanoMode) _ct -> do
+          withIsCardanoEra era (Ix.insert (ScriptTx.toUpdate txs slotNo) index >>= loop)
+        RollBackward cp _ct -> do
+          events <- Ix.getEvents (index ^. Ix.storage)
+          loop $
+            fromMaybe index $ do
+              slot   <- chainPointToSlotNo cp
+              offset <- findIndex  (\u -> ScriptTx.slotNo u < slot) events
+              Ix.rewind offset index
+
 combinedIndexer
   :: Maybe FilePath
   -> Maybe FilePath
+  -> Maybe FilePath
   -> S.Stream (S.Of (ChainSyncEvent (BlockInMode CardanoMode))) IO r
   -> IO ()
-combinedIndexer utxoPath datumPath = S.foldM_ step initial finish
+combinedIndexer utxoPath datumPath scriptTxPath = S.foldM_ step initial finish
   where
     initial :: IO Coordinator
     initial = do
-      let indexerCount = length . catMaybes $ [utxoPath, datumPath]
+      let indexerCount = length . catMaybes $ [utxoPath, datumPath, scriptTxPath]
       coordinator <- initialCoordinator indexerCount
       when (isJust datumPath) $ do
         ch <- atomically . dupTChan $ _channel coordinator
@@ -242,6 +268,9 @@ combinedIndexer utxoPath datumPath = S.foldM_ step initial finish
       when (isJust utxoPath) $ do
         ch <- atomically . dupTChan $ _channel coordinator
         void . forkIO . utxoWorker coordinator ch $ fromJust utxoPath
+      when (isJust scriptTxPath) $ do
+        ch <- atomically . dupTChan $ _channel coordinator
+        void . forkIO . scriptTxWorker coordinator ch $ fromJust scriptTxPath
       pure coordinator
 
     step :: Coordinator -> ChainSyncEvent (BlockInMode CardanoMode) -> IO Coordinator
@@ -269,7 +298,7 @@ main = do
       optionsSocketPath
       optionsNetworkId
       optionsChainPoint
-      (combinedIndexer optionsUtxoPath optionsDatumPath . logging trace)
+      (combinedIndexer optionsUtxoPath optionsDatumPath optionsScriptTxPath . logging trace)
       `catch` \NoIntersectionFound ->
         logError trace $
           renderStrict $

--- a/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
+++ b/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
@@ -354,7 +354,7 @@ fromLedgerScript C.ShelleyBasedEraAlonzo script = fromAlonzoLedgerScript script
 fromAlonzoLedgerScript :: Alonzo.Script a -> Maybe (P.ScriptHash, P.Script)
 fromAlonzoLedgerScript Alonzo.TimelockScript {} = Nothing
 fromAlonzoLedgerScript (Alonzo.PlutusScript _ bs) =
-  let script = fmap (\s -> (P.scriptHash s, s))
+  let script = fmap (\s -> (P.scriptHash s, s :: P.Script))
              $ deserialiseOrFail
              $ BSL.fromStrict
              $ SBS.fromShort bs


### PR DESCRIPTION
This is a draft PR for the jira issue [marconi indexer: transactions that have been issued to a particular script](https://input-output.atlassian.net/browse/PLT-172). (This PR is also wrongly based off of `next-node` branch because it can understand the blocks since Vasil hard-fork -- will rebase once I manage to resolve the issues below.)

A concrete code thing I need help with is extracting script hashes from a transaction [here](https://github.com/input-output-hk/plutus-apps/blob/9a2e24eb1de814c33d42c7b2ecc11e8e62620361/plutus-chain-index/app/Marconi.hs#L261): how/where would I find the type(s)?

Another question is that the Jira issue says to set script address as the primary key, but if this is an index from transaction to script, then this is an 1:n relationship because (as far as I understand) a single script will be possibly targeted/ran by many transactions.

I've also read the indexer's code (the hysterical-screams) but can't say it's fully clear yet :), so would be good to see if the onInsert/store/query triple is correct.

Any other comments welcome as well!

(The main commits are 9a2e24eb1 and 79a9d7fad, the two previous ones already exist as separate PRs.)

---
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [X] Reviewer requested
