### PR TITLE
Add minting context equivalence test plutus script

### DIFF
--- a/plutus-example/app/plutus-example.hs
+++ b/plutus-example/app/plutus-example.hs
@@ -16,7 +16,7 @@ import PlutusExample.PlutusVersion1.RedeemerContextScripts
 import PlutusExample.PlutusVersion1.Sum (sumScript)
 
 import PlutusExample.PlutusVersion2.MintingScript (v2mintingScript)
-import PlutusExample.PlutusVersion2.RedeemerContextEquivalence (v2ScriptContextEquivalenceScript)
+import PlutusExample.PlutusVersion2.RedeemerContextEquivalence (v2ScriptContextEquivalenceScript, v2mintEquivScript)
 import PlutusExample.PlutusVersion2.RequireRedeemer (requireRedeemerScript)
 import PlutusExample.PlutusVersion2.StakeScript (v2StakeScript)
 
@@ -43,5 +43,5 @@ main = do
   _ <- writeFileTextEnvelope (v2dir </> "minting-script.plutus") Nothing v2mintingScript
   _ <- writeFileTextEnvelope (v2dir </> "stake-script.plutus") Nothing v2StakeScript
   _ <- writeFileTextEnvelope (v2dir </> "context-equivalence-test.plutus") Nothing v2ScriptContextEquivalenceScript
-
+  _ <- writeFileTextEnvelope (v2dir </> "minting-context-equivalance-test.plutus") Nothing v2mintEquivScript
   return ()


### PR DESCRIPTION
Add a Plutus script that checks that the mint field of the ScriptContext is equal to the mint field of our redeemer

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
