### PR TITLE
Move plutus-ledger to use V2 types where available

### DIFF
--- a/plutus-ledger/src/Ledger.hs
+++ b/plutus-ledger/src/Ledger.hs
@@ -1,24 +1,32 @@
-module Ledger (
-    module Export,
-    AssetClass,
-    CurrencySymbol,
-    TokenName,
-    Value,
-    Ada
-    ) where
+module Ledger
+  ( module Ledger.Ada
+  , module Ledger.Address
+  , module Ledger.Blockchain
+  , module Ledger.Crypto
+  , module Ledger.Index
+  , module Ledger.Params
+  , module Ledger.Scripts
+  , module Ledger.Slot
+  , module Ledger.Tx
+  , module Ledger.Value
+  , module Plutus.V1.Ledger.Interval
+  , module Plutus.V1.Ledger.Time
+  , module Plutus.V1.Ledger.Value
+  , module Plutus.V2.Ledger.Contexts
+  ) where
 
 import Ledger.Ada (Ada)
-import Ledger.Address as Export
-import Ledger.Blockchain as Export
-import Ledger.Crypto as Export
-import Ledger.Index as Export
+import Ledger.Address
+import Ledger.Blockchain
+import Ledger.Crypto
+import Ledger.Index
 import Ledger.Orphans ()
-import Ledger.Params as Export
-import Ledger.Scripts as Export
-import Ledger.Slot as Export
-import Ledger.Tx as Export
-import Ledger.Value as Export (noAdaValue)
-import Plutus.V1.Ledger.Contexts as Export
-import Plutus.V1.Ledger.Interval as Export
-import Plutus.V1.Ledger.Time as Export
+import Ledger.Params
+import Ledger.Scripts
+import Ledger.Slot
+import Ledger.Tx
+import Ledger.Value (noAdaValue)
+import Plutus.V1.Ledger.Interval
+import Plutus.V1.Ledger.Time
 import Plutus.V1.Ledger.Value (AssetClass, CurrencySymbol, TokenName, Value)
+import Plutus.V2.Ledger.Contexts

--- a/plutus-ledger/src/Ledger/Address.hs
+++ b/plutus-ledger/src/Ledger/Address.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Ledger.Address
-    ( module Export
+    ( module Plutus.V1.Ledger.Address
     , PaymentPrivateKey(..)
     , PaymentPubKey(..)
     , PaymentPubKeyHash(..)
@@ -24,7 +24,7 @@ import GHC.Generics (Generic)
 import Ledger.Crypto (PubKey (PubKey), PubKeyHash (PubKeyHash), pubKeyHash)
 import Ledger.Orphans ()
 import Ledger.Scripts (StakeValidatorHash (..), ValidatorHash (..))
-import Plutus.V1.Ledger.Address as Export hiding (pubKeyHashAddress)
+import Plutus.V1.Ledger.Address hiding (pubKeyHashAddress)
 import Plutus.V1.Ledger.Credential (Credential (PubKeyCredential, ScriptCredential), StakingCredential (StakingHash))
 import PlutusTx qualified
 import PlutusTx.Lift (makeLift)

--- a/plutus-ledger/src/Ledger/Blockchain.hs
+++ b/plutus-ledger/src/Ledger/Blockchain.hs
@@ -47,8 +47,8 @@ import Data.Text qualified as Text
 import Data.Text.Encoding (decodeUtf8')
 import GHC.Generics (Generic)
 import Ledger.Tx (CardanoTx, TxId, TxIn, TxOut, TxOutRef (..), getCardanoTxCollateralInputs, getCardanoTxId,
-                  getCardanoTxInputs, getCardanoTxOutputs, spentOutputs, txOutDatum, txOutPubKey, txOutValue,
-                  unspentOutputsTx, updateUtxo, updateUtxoCollateral, validValuesTx)
+                  getCardanoTxInputs, getCardanoTxOutputs, getOutputDatumHash, spentOutputs, txOutDatum, txOutPubKey,
+                  txOutValue, unspentOutputsTx, updateUtxo, updateUtxoCollateral, validValuesTx)
 import Prettyprinter (Pretty (..), (<+>))
 
 import Data.Either (fromRight)
@@ -126,7 +126,7 @@ value bc o = txOutValue <$> out bc o
 
 -- | Determine the data script that a transaction output refers to.
 datumTxo :: Blockchain -> TxOutRef -> Maybe DatumHash
-datumTxo bc o = txOutDatum =<< out bc o
+datumTxo bc o = out bc o >>= \txOut -> getOutputDatumHash $ txOutDatum txOut
 
 -- | Determine the public key that locks a transaction output, if there is one.
 pubKeyTxo :: Blockchain -> TxOutRef -> Maybe PubKeyHash

--- a/plutus-ledger/src/Ledger/Index/Internal.hs
+++ b/plutus-ledger/src/Ledger/Index/Internal.hs
@@ -25,12 +25,11 @@ import Plutus.V1.Ledger.Value qualified as V
 import Prettyprinter (Pretty)
 import Prettyprinter.Extras (PrettyShow (..))
 
--- | The UTxOs of a blockchain indexed by their references.
+
 newtype UtxoIndex = UtxoIndex { getIndex :: Map.Map TxOutRef TxOut }
     deriving stock (Show, Generic)
     deriving newtype (Eq, Semigroup, OpenApi.ToSchema, Monoid, Serialise)
     deriving anyclass (FromJSON, ToJSON, NFData)
-
 
 -- | A reason why a transaction is invalid.
 data ValidationError =

--- a/plutus-ledger/src/Ledger/Orphans.hs
+++ b/plutus-ledger/src/Ledger/Orphans.hs
@@ -31,18 +31,12 @@ import Ledger.Ada (Ada (Lovelace))
 import Ledger.Crypto (PrivateKey (PrivateKey, getPrivateKey), PubKey (PubKey), Signature (Signature))
 import Ledger.Slot (Slot (Slot))
 import Ledger.Tx.Internal (Tx)
-import Plutus.V1.Ledger.Api (Address, Credential, CurrencySymbol (CurrencySymbol), Extended, Interval,
-                             LedgerBytes (LedgerBytes), LowerBound, MintingPolicy (MintingPolicy),
-                             MintingPolicyHash (MintingPolicyHash), POSIXTime (POSIXTime), PubKeyHash (PubKeyHash),
-                             Redeemer (Redeemer), RedeemerHash (RedeemerHash), Script, StakeValidator (StakeValidator),
-                             StakeValidatorHash (StakeValidatorHash), StakingCredential, TokenName (TokenName),
-                             TxId (TxId), TxOut, TxOutRef, UpperBound, Validator (Validator),
-                             ValidatorHash (ValidatorHash), Value (Value), fromBytes)
-import Plutus.V1.Ledger.Bytes (bytes)
-import Plutus.V1.Ledger.Scripts (ScriptError, ScriptHash (..))
-import Plutus.V1.Ledger.Time (DiffMilliSeconds (DiffMilliSeconds))
-import Plutus.V1.Ledger.Tx (RedeemerPtr, ScriptTag, TxIn, TxInType)
-import Plutus.V1.Ledger.Value (AssetClass (AssetClass))
+import Plutus.V1.Ledger.Bytes
+import Plutus.V1.Ledger.Scripts
+import Plutus.V1.Ledger.Time
+import Plutus.V1.Ledger.Value
+import Plutus.V2.Ledger.Api
+import Plutus.V2.Ledger.Tx
 import PlutusCore (Kind, Some, Term, Type, ValueOf, Version)
 import PlutusTx.AssocMap qualified as AssocMap
 import Web.HttpApiData (FromHttpApiData (parseUrlPiece), ToHttpApiData (toUrlPiece))

--- a/plutus-ledger/src/Ledger/Scripts.hs
+++ b/plutus-ledger/src/Ledger/Scripts.hs
@@ -1,7 +1,8 @@
-module Ledger.Scripts (
-    module Export
-    ) where
+module Ledger.Scripts
+  ( module Plutus.Script.Utils.V2.Scripts
+  , module Plutus.V1.Ledger.Scripts
+  ) where
 
 import Ledger.Scripts.Orphans ()
-import Plutus.Script.Utils.V1.Scripts as Export
-import Plutus.V1.Ledger.Scripts as Export
+import Plutus.Script.Utils.V2.Scripts
+import Plutus.V1.Ledger.Scripts

--- a/plutus-ledger/src/Ledger/Test.hs
+++ b/plutus-ledger/src/Ledger/Test.hs
@@ -5,23 +5,21 @@
 {-# LANGUAGE TypeApplications    #-}
 module Ledger.Test where
 
-import Ledger qualified
-import Plutus.Script.Utils.V1.Scripts qualified as PV1
-import Plutus.Script.Utils.V1.Typed.Scripts.MonetaryPolicies qualified as MPS
-import Plutus.V1.Ledger.Api (Address, Validator)
+import Ledger
+import Plutus.Script.Utils.V2.Typed.Scripts.MonetaryPolicies qualified as MPS
 import PlutusTx qualified
 import Prelude hiding (not)
 
 someAddress :: Address
-someAddress = Ledger.scriptValidatorHashAddress (PV1.validatorHash someValidator) Nothing
+someAddress = scriptValidatorHashAddress (validatorHash someValidator) Nothing
 
 someValidator :: Validator
-someValidator = Ledger.mkValidatorScript $$(PlutusTx.compile [|| \(_ :: PlutusTx.BuiltinData) (_ :: PlutusTx.BuiltinData) (_ :: PlutusTx.BuiltinData) -> () ||])
+someValidator = mkValidatorScript $$(PlutusTx.compile [|| \(_ :: PlutusTx.BuiltinData) (_ :: PlutusTx.BuiltinData) (_ :: PlutusTx.BuiltinData) -> () ||])
 
 {-# INLINABLE mkPolicy #-}
-mkPolicy :: () -> Ledger.ScriptContext -> Bool
+mkPolicy :: () -> ScriptContext -> Bool
 mkPolicy _ _ = True
 
-coinMintingPolicy :: Ledger.MintingPolicy
-coinMintingPolicy = Ledger.mkMintingPolicyScript
+coinMintingPolicy :: MintingPolicy
+coinMintingPolicy = mkMintingPolicyScript
     $$(PlutusTx.compile [|| MPS.mkUntypedMintingPolicy mkPolicy ||])

--- a/plutus-ledger/src/Ledger/Tx.hs
+++ b/plutus-ledger/src/Ledger/Tx.hs
@@ -15,11 +15,12 @@
 
 module Ledger.Tx
     ( module Ledger.Tx.Internal
-    , module Plutus.V1.Ledger.Tx
+    , module Plutus.V2.Ledger.Tx
+    , module Plutus.Script.Utils.V2.Scripts
     -- * ChainIndexTxOut
     , ChainIndexTxOut(..)
     , toTxOut
-    , fromTxOut
+    -- , fromTxOut FIXME we need to figure this out
     -- ** Lenses and Prisms
     , ciTxOutAddress
     , ciTxOutValue
@@ -46,8 +47,8 @@ module Ledger.Tx
     , getCardanoTxMint
     , getCardanoTxValidityRange
     , getCardanoTxData
-    , SomeCardanoApiTx(.., CardanoApiEmulatorEraTx)
-    , ToCardanoError(..)
+    , CardanoAPI.SomeCardanoApiTx(.., CardanoApiEmulatorEraTx)
+    , CardanoAPI.ToCardanoError(..)
     -- * Transactions
     , addSignature
     , addSignature'
@@ -56,6 +57,8 @@ module Ledger.Tx
     , updateUtxoCollateral
     , txOutRefs
     , unspentOutputsTx
+    , getOutputDatumHash
+    , getOutputDatumOrHash
     -- * Hashing transactions
     , txId
     ) where
@@ -67,7 +70,6 @@ import Codec.CBOR.Write qualified as Write
 import Codec.Serialise (Serialise (encode))
 import Control.Lens (At (at), makeLenses, makePrisms, (&), (?~))
 import Data.Aeson (FromJSON, ToJSON)
-import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.OpenApi qualified as OpenApi
@@ -75,19 +77,15 @@ import Data.Proxy (Proxy (Proxy))
 import Data.Set (Set)
 import Data.Set qualified as Set
 import GHC.Generics (Generic)
-import Ledger.Address (Address, PaymentPubKey, StakePubKey, pubKeyAddress)
+import Ledger.Address (PaymentPubKey, StakePubKey, pubKeyAddress)
 import Ledger.Crypto (Passphrase, signTx, signTx', toPublicKey)
 import Ledger.Orphans ()
 import Ledger.Slot (SlotRange)
-import Ledger.Tx.CardanoAPI (SomeCardanoApiTx (SomeTx), ToCardanoError (..))
 import Ledger.Tx.CardanoAPI qualified as CardanoAPI
 import Ledger.Tx.Internal hiding (updateUtxoCollateral)
-import Plutus.Script.Utils.V1.Scripts (datumHash)
-import Plutus.V1.Ledger.Api qualified as V1
-import Plutus.V2.Ledger.Api qualified as V2
--- for re-export
-import Plutus.V1.Ledger.Tx
-import Plutus.V1.Ledger.Tx qualified as V1.Tx
+import Plutus.Script.Utils.V2.Scripts
+import Plutus.V2.Ledger.Api
+import Plutus.V2.Ledger.Tx
 import Prettyprinter (Pretty (pretty), braces, colon, hang, nest, viaShow, vsep, (<+>))
 
 type PrivateKey = Crypto.XPrv
@@ -107,60 +105,53 @@ data ChainIndexTxOut =
       -- public key hash.
       _ciTxOutAddress         :: Address,
       -- | Value of the transaction output.
-      _ciTxOutValue           :: V1.Value,
+      _ciTxOutValue           :: Value,
       -- | Optional datum attached to the transaction output.
-      _ciTxOutPublicKeyDatum  :: V2.OutputDatum,
+      _ciTxOutPublicKeyDatum  :: OutputDatum,
       -- | Optional reference script attached to the transaction output.
-      _ciTxOutReferenceScript :: Maybe V1.Script
+      _ciTxOutReferenceScript :: Maybe Script
     }
   | ScriptChainIndexTxOut {
       -- | Address of the transaction output. The address is protected by a
       -- script.
       _ciTxOutAddress         :: Address,
       -- | Value of the transaction output.
-      _ciTxOutValue           :: V1.Value,
+      _ciTxOutValue           :: Value,
       -- | Datum attached to the transaction output, either in full or as a
       -- hash reference. A transaction output protected by a Plutus script
       -- is guardateed to have an associated datum.
-      _ciTxOutScriptDatum     :: Either V1.DatumHash V1.Datum,
+      _ciTxOutScriptDatum     :: Either DatumHash Datum,
       -- | Optional reference script attached to the transaction output.
       -- The reference script is, in genereal, unrelated to the validator
       -- script althought it could also be the same.
-      _ciTxOutReferenceScript :: Maybe V1.Script,
+      _ciTxOutReferenceScript :: Maybe Script,
       -- | Validator protecting the transaction output, either in full or
       -- as a hash reference.
-      _ciTxOutValidator       :: Either V1.ValidatorHash V1.Validator
+      _ciTxOutValidator       :: Either ValidatorHash Validator
     }
   deriving (Show, Eq, Serialise, Generic, ToJSON, FromJSON, OpenApi.ToSchema)
 
 makeLenses ''ChainIndexTxOut
 makePrisms ''ChainIndexTxOut
 
--- | Converts a transaction output from the chain index to the plutus-ledger-api
--- transaction output.
---
--- Note that 'ChainIndexTxOut' supports features such inline datums and
--- reference scripts which are not supported by V1 TxOut. Converting from
--- 'ChainIndexTxOut' to 'TxOut' and back is therefore lossy.
-toTxOut :: ChainIndexTxOut -> V1.Tx.TxOut
-toTxOut (PublicKeyChainIndexTxOut addr v _outputDatum _referenceScript) =
-  V1.Tx.TxOut addr v Nothing
-toTxOut (ScriptChainIndexTxOut addr v (Left dh) _referenceScript _validator)     =
-  V1.Tx.TxOut addr v (Just dh)
-toTxOut (ScriptChainIndexTxOut addr v (Right d) _referenceScript _validator)     =
-  V1.Tx.TxOut addr v (Just $ datumHash d)
+toTxOut :: ChainIndexTxOut -> TxOut
+toTxOut (PublicKeyChainIndexTxOut addr v outputDatum referenceScript) =
+  TxOut addr v outputDatum (fmap scriptHash referenceScript)
+toTxOut (ScriptChainIndexTxOut addr v (Left dh) referenceScript _validator) =
+  TxOut addr v (OutputDatumHash dh) (fmap scriptHash referenceScript)
+toTxOut (ScriptChainIndexTxOut addr v (Right d) referenceScript _validator) =
+  TxOut addr v (OutputDatum d) (fmap scriptHash referenceScript)
 
--- | Converts a plutus-ledger-api transaction output to the chain index
--- transaction output.
-fromTxOut :: V1.Tx.TxOut -> Maybe ChainIndexTxOut
-fromTxOut V1.Tx.TxOut { txOutAddress, txOutValue, txOutDatumHash } =
-  case V1.addressCredential txOutAddress of
-    V1.PubKeyCredential _ ->
-      -- V1 transactions don't support inline datums
-      pure $ PublicKeyChainIndexTxOut txOutAddress txOutValue V2.NoOutputDatum Nothing
-    V1.ScriptCredential vh ->
-      txOutDatumHash >>= \dh ->
-        pure $ ScriptChainIndexTxOut txOutAddress txOutValue (Left dh) Nothing (Left vh)
+-- fromTxOut :: TxOut -> Maybe ChainIndexTxOut
+-- fromTxOut TxOut { txOutAddress, txOutValue, txOutDatum, txOutReferenceScript } =
+--   case addressCredential txOutAddress of
+--     PubKeyCredential _ ->
+--       pure $ PublicKeyChainIndexTxOut txOutAddress txOutValue txOutDatum refScript
+--     ScriptCredential vh -> do
+--       doh <- getOutputDatumHash txOutDatum
+--       pure $ ScriptChainIndexTxOut txOutAddress txOutValue doh refScript (Left vh)
+--   where
+--     refScript = _ txOutReferenceScript
 
 instance Pretty ChainIndexTxOut where
     pretty PublicKeyChainIndexTxOut {_ciTxOutAddress, _ciTxOutValue} =
@@ -168,33 +159,32 @@ instance Pretty ChainIndexTxOut where
     pretty ScriptChainIndexTxOut {_ciTxOutAddress, _ciTxOutValue} =
                 hang 2 $ vsep ["-" <+> pretty _ciTxOutValue <+> "addressed to", pretty _ciTxOutAddress]
 
-
 {- Note [Why we have the Both constructor in CardanoTx]
 
 We want to do validation with both the emulator and with the cardano-ledger library, at least as long
 as we don't have Phase2 validation errors via the cardano-ledger library.
 
 To do that we need the required signers which are only available in UnbalancedTx during balancing.
-So during balancing we can create the SomeCardanoApiTx, while proper validation can only happen in
+So during balancing we can create the CardanoAPI.SomeCardanoApiTx, while proper validation can only happen in
 Wallet.Emulator.Chain.validateBlock, since that's when we know the right Slot number. This means that
 we need both transaction types in the path from balancing to validateBlock. -}
 
 data CardanoTx
     = EmulatorTx { _emulatorTx :: Tx }
-    | CardanoApiTx { _cardanoApiTx :: SomeCardanoApiTx }
-    | Both { _emulatorTx :: Tx, _cardanoApiTx :: SomeCardanoApiTx }
+    | CardanoApiTx { _cardanoApiTx :: CardanoAPI.SomeCardanoApiTx }
+    | Both { _emulatorTx :: Tx, _cardanoApiTx :: CardanoAPI.SomeCardanoApiTx }
     deriving (Eq, Show, Generic)
     deriving anyclass (FromJSON, ToJSON, OpenApi.ToSchema, Serialise)
 
 makeLenses ''CardanoTx
 
-getEmulatorEraTx :: SomeCardanoApiTx -> C.Tx C.BabbageEra
-getEmulatorEraTx (SomeTx tx C.BabbageEraInCardanoMode) = tx
-getEmulatorEraTx _                                     = error "getEmulatorEraTx: Expected a Babbage tx"
+getEmulatorEraTx :: CardanoAPI.SomeCardanoApiTx -> C.Tx C.BabbageEra
+getEmulatorEraTx (CardanoAPI.SomeTx tx C.BabbageEraInCardanoMode) = tx
+getEmulatorEraTx _                                                = error "getEmulatorEraTx: Expected a Babbage tx"
 
-pattern CardanoApiEmulatorEraTx :: C.Tx C.BabbageEra -> SomeCardanoApiTx
+pattern CardanoApiEmulatorEraTx :: C.Tx C.BabbageEra -> CardanoAPI.SomeCardanoApiTx
 pattern CardanoApiEmulatorEraTx tx <- (getEmulatorEraTx -> tx) where
-    CardanoApiEmulatorEraTx tx = SomeTx tx C.BabbageEraInCardanoMode
+    CardanoApiEmulatorEraTx tx = CardanoAPI.SomeTx tx C.BabbageEraInCardanoMode
 
 {-# COMPLETE CardanoApiEmulatorEraTx #-}
 
@@ -217,83 +207,84 @@ instance Pretty CardanoTx where
                 ]
         in nest 2 $ vsep ["Tx" <+> pretty (getCardanoTxId tx) <> colon, braces (vsep lines')]
 
-onCardanoTx :: (Tx -> r) -> (SomeCardanoApiTx -> r) -> CardanoTx -> r
+onCardanoTx :: (Tx -> r) -> (CardanoAPI.SomeCardanoApiTx -> r) -> CardanoTx -> r
 onCardanoTx l r = mergeCardanoTxWith l r const
 
-mergeCardanoTxWith :: (Tx -> a) -> (SomeCardanoApiTx -> a) -> (a -> a -> a) -> CardanoTx -> a
+mergeCardanoTxWith :: (Tx -> a) -> (CardanoAPI.SomeCardanoApiTx -> a) -> (a -> a -> a) -> CardanoTx -> a
 mergeCardanoTxWith l _ _ (EmulatorTx tx)    = l tx
 mergeCardanoTxWith l r m (Both tx ctx)      = m (l tx) (r ctx)
 mergeCardanoTxWith _ r _ (CardanoApiTx ctx) = r ctx
 
-cardanoTxMap :: (Tx -> Tx) -> (SomeCardanoApiTx -> SomeCardanoApiTx) -> CardanoTx -> CardanoTx
+cardanoTxMap :: (Tx -> Tx) -> (CardanoAPI.SomeCardanoApiTx -> CardanoAPI.SomeCardanoApiTx) -> CardanoTx -> CardanoTx
 cardanoTxMap l _ (EmulatorTx tx)    = EmulatorTx (l tx)
 cardanoTxMap l r (Both tx ctx)      = Both (l tx) (r ctx)
 cardanoTxMap _ r (CardanoApiTx ctx) = CardanoApiTx (r ctx)
 
-getCardanoTxId :: CardanoTx -> V1.Tx.TxId
+getCardanoTxId :: CardanoTx -> TxId
 getCardanoTxId = onCardanoTx txId getCardanoApiTxId
 
-getCardanoApiTxId :: SomeCardanoApiTx -> V1.Tx.TxId
-getCardanoApiTxId (SomeTx (C.Tx body _) _) = CardanoAPI.fromCardanoTxId $ C.getTxId body
+getCardanoApiTxId :: CardanoAPI.SomeCardanoApiTx -> TxId
+getCardanoApiTxId (CardanoAPI.SomeTx (C.Tx body _) _) = CardanoAPI.fromCardanoTxId $ C.getTxId body
 
-getCardanoTxInputs :: CardanoTx -> Set V1.Tx.TxIn
+getCardanoTxInputs :: CardanoTx -> Set CardanoAPI.TxIn
 getCardanoTxInputs = onCardanoTx txInputs
-    (\(SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) ->
-        Set.fromList $ fmap ((`V1.Tx.TxIn` Nothing) . CardanoAPI.fromCardanoTxIn . fst) txIns)
+    (\(CardanoAPI.SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) ->
+        Set.fromList $ fmap ((`CardanoAPI.TxIn` Nothing) . CardanoAPI.fromCardanoTxIn . fst) txIns)
 
-getCardanoTxCollateralInputs :: CardanoTx -> Set V1.Tx.TxIn
+getCardanoTxCollateralInputs :: CardanoTx -> Set CardanoAPI.TxIn
 getCardanoTxCollateralInputs = onCardanoTx txCollateral
-    (\(SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) ->
+    (\(CardanoAPI.SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) ->
         CardanoAPI.fromCardanoTxInsCollateral txInsCollateral)
 
-getCardanoTxReferenceInputs :: CardanoTx -> Set TxIn
+getCardanoTxReferenceInputs :: CardanoTx -> Set CardanoAPI.TxIn
 getCardanoTxReferenceInputs = onCardanoTx txReferenceInputs
-    (\(SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) ->
+    (\(CardanoAPI.SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) ->
         txInsReferenceToPlutusTxIns txInsReference)
  where
      txInsReferenceToPlutusTxIns C.TxInsReferenceNone = Set.empty
      txInsReferenceToPlutusTxIns (C.TxInsReference _ txIns) =
-         Set.fromList $ fmap ((`TxIn` Nothing) . CardanoAPI.fromCardanoTxIn) txIns
+         Set.fromList $ fmap ((`CardanoAPI.TxIn` Nothing) . CardanoAPI.fromCardanoTxIn) txIns
 
-getCardanoTxOutRefs :: CardanoTx -> [(V1.Tx.TxOut, V1.Tx.TxOutRef)]
+getCardanoTxOutRefs :: CardanoTx -> [(TxOut, TxOutRef)]
 getCardanoTxOutRefs = onCardanoTx txOutRefs CardanoAPI.txOutRefs
 
-getCardanoTxOutputs :: CardanoTx -> [V1.Tx.TxOut]
+getCardanoTxOutputs :: CardanoTx -> [TxOut]
 getCardanoTxOutputs = fmap fst . getCardanoTxOutRefs
 
-getCardanoTxUnspentOutputsTx :: CardanoTx -> Map V1.Tx.TxOutRef V1.Tx.TxOut
+getCardanoTxUnspentOutputsTx :: CardanoTx -> Map.Map TxOutRef TxOut
 getCardanoTxUnspentOutputsTx = onCardanoTx unspentOutputsTx CardanoAPI.unspentOutputsTx
 
-getCardanoTxSpentOutputs :: CardanoTx -> Set V1.Tx.TxOutRef
-getCardanoTxSpentOutputs = Set.map V1.Tx.txInRef . getCardanoTxInputs
+getCardanoTxSpentOutputs :: CardanoTx -> Set TxOutRef
+getCardanoTxSpentOutputs = Set.map CardanoAPI.txInRef . getCardanoTxInputs
 
-getCardanoTxFee :: CardanoTx -> V1.Value
-getCardanoTxFee = onCardanoTx txFee (\(SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) -> CardanoAPI.fromCardanoFee txFee)
+getCardanoTxFee :: CardanoTx -> Value
+getCardanoTxFee = onCardanoTx txFee (\(CardanoAPI.SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) -> CardanoAPI.fromCardanoFee txFee)
 
-getCardanoTxMint :: CardanoTx -> V1.Value
-getCardanoTxMint = onCardanoTx txMint (\(SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) -> CardanoAPI.fromCardanoMintValue txMintValue)
+getCardanoTxMint :: CardanoTx -> Value
+getCardanoTxMint = onCardanoTx txMint (\(CardanoAPI.SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) -> CardanoAPI.fromCardanoMintValue txMintValue)
 
 getCardanoTxValidityRange :: CardanoTx -> SlotRange
 getCardanoTxValidityRange = onCardanoTx txValidRange
-    (\(SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) -> CardanoAPI.fromCardanoValidityRange txValidityRange)
+    (\(CardanoAPI.SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) -> CardanoAPI.fromCardanoValidityRange txValidityRange)
 
-getCardanoTxData :: CardanoTx -> Map V1.DatumHash V1.Datum
+getCardanoTxData :: CardanoTx -> Map.Map DatumHash Datum
 getCardanoTxData = onCardanoTx txData
-    (\(SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) ->
+    (\(CardanoAPI.SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) ->
         Map.fromList $ mapMaybe (\(C.TxOut _ _ d _) -> fromCardanoTxOutDatum d) txOuts)
     where
-        fromCardanoTxOutDatum :: C.TxOutDatum C.CtxTx era -> Maybe (V1.DatumHash, V1.Datum)
+      -- FIXME duplicated code
+        fromCardanoTxOutDatum :: C.TxOutDatum C.CtxTx era -> Maybe (DatumHash, Datum)
         fromCardanoTxOutDatum C.TxOutDatumNone = Nothing
         fromCardanoTxOutDatum (C.TxOutDatumHash _ _) = Nothing
         fromCardanoTxOutDatum (C.TxOutDatumInTx _ d) =
-            let d' = V1.Datum $ CardanoAPI.fromCardanoScriptData d in Just (datumHash d', d')
+            let d' = Datum $ CardanoAPI.fromCardanoScriptData d in Just (datumHash d', d')
         fromCardanoTxOutDatum (C.TxOutDatumInline _ d) =
-            let d' = V1.Datum $ CardanoAPI.fromCardanoScriptData d in Just (datumHash d', d')
+            let d' = Datum $ CardanoAPI.fromCardanoScriptData d in Just (datumHash d', d')
     -- TODO: add txMetaData
 
 getCardanoTxRedeemers :: CardanoTx -> Redeemers
 getCardanoTxRedeemers = onCardanoTx txRedeemers (const Map.empty) -- TODO: To implement
-    -- (\(SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) ->
+    -- (\(CardanoAPI.SomeTx (C.Tx (C.TxBody C.TxBodyContent {..}) _) _) ->
     --     Map.fromList $ mapMaybe (\(C.TxOut _ _ d _) -> fromCardanoTxOutDatum d) txOuts)
     -- where
     --     fromCardanoTxOutDatum :: C.TxOutDatum C.CtxTx era -> Maybe (DatumHash, Datum)
@@ -323,36 +314,36 @@ instance Pretty Tx where
         in nest 2 $ vsep ["Tx" <+> pretty txid <> colon, braces (vsep lines')]
 
 -- | Compute the id of a transaction.
-txId :: Tx -> V1.Tx.TxId
+txId :: Tx -> TxId
 -- Double hash of a transaction, excluding its witnesses.
-txId tx = V1.Tx.TxId $ V1.toBuiltin
+txId tx = TxId $ toBuiltin
                $ digest (Proxy @SHA256)
                $ digest (Proxy @SHA256)
                (Write.toStrictByteString $ encode $ strip tx)
 
 -- | Update a map of unspent transaction outputs and signatures based on the inputs
 --   and outputs of a transaction.
-updateUtxo :: CardanoTx -> Map V1.Tx.TxOutRef V1.Tx.TxOut -> Map V1.Tx.TxOutRef V1.Tx.TxOut
+updateUtxo :: CardanoTx -> Map.Map TxOutRef TxOut -> Map.Map TxOutRef TxOut
 updateUtxo tx unspent = (unspent `Map.withoutKeys` getCardanoTxSpentOutputs tx) `Map.union` getCardanoTxUnspentOutputsTx tx
 
 -- | Update a map of unspent transaction outputs and signatures based
 --   on the collateral inputs of a transaction (for when it is invalid).
-updateUtxoCollateral :: CardanoTx -> Map V1.Tx.TxOutRef V1.Tx.TxOut -> Map V1.Tx.TxOutRef V1.Tx.TxOut
-updateUtxoCollateral tx unspent = unspent `Map.withoutKeys` (Set.map V1.Tx.txInRef $ getCardanoTxCollateralInputs tx)
+updateUtxoCollateral :: CardanoTx -> Map.Map TxOutRef TxOut -> Map.Map TxOutRef TxOut
+updateUtxoCollateral tx unspent = unspent `Map.withoutKeys` (Set.map CardanoAPI.txInRef $ getCardanoTxCollateralInputs tx)
 
 -- | A list of a transaction's outputs paired with a 'TxOutRef's referring to them.
-txOutRefs :: Tx -> [(V1.Tx.TxOut, V1.Tx.TxOutRef)]
+txOutRefs :: Tx -> [(TxOut, TxOutRef)]
 txOutRefs t = mkOut <$> zip [0..] (txOutputs t) where
-    mkOut (i, o) = (o, V1.Tx.TxOutRef (txId t) i)
+    mkOut (i, o) = (o, TxOutRef (txId t) i)
 
 -- | The unspent outputs of a transaction.
-unspentOutputsTx :: Tx -> Map V1.Tx.TxOutRef V1.Tx.TxOut
+unspentOutputsTx :: Tx -> Map.Map TxOutRef TxOut
 unspentOutputsTx t = Map.fromList $ fmap f $ zip [0..] $ txOutputs t where
-    f (idx, o) = (V1.Tx.TxOutRef (txId t) idx, o)
+    f (idx, o) = (TxOutRef (txId t) idx, o)
 
 -- | Create a transaction output locked by a public payment key and optionnaly a public stake key.
-pubKeyTxOut :: V1.Value -> PaymentPubKey -> Maybe StakePubKey -> V1.Tx.TxOut
-pubKeyTxOut v pk sk = V1.Tx.TxOut (pubKeyAddress pk sk) v Nothing
+pubKeyTxOut :: Value -> PaymentPubKey -> Maybe StakePubKey -> TxOut
+pubKeyTxOut v pk sk = TxOut (pubKeyAddress pk sk) v NoOutputDatum Nothing
 
 -- | Sign the transaction with a 'PrivateKey' and passphrase (ByteString) and add the signature to the
 --   transaction's list of signatures.
@@ -367,3 +358,12 @@ addSignature' :: PrivateKey -> Tx -> Tx
 addSignature' privK tx = tx & signatures . at pubK ?~ sig where
     sig = signTx' (txId tx) privK
     pubK = toPublicKey privK
+
+getOutputDatumHash :: OutputDatum -> Maybe DatumHash
+getOutputDatumHash (getOutputDatumOrHash -> mdoe) =
+  mdoe >>= either Just (Just . datumHash)
+
+getOutputDatumOrHash :: OutputDatum -> Maybe (Either DatumHash Datum)
+getOutputDatumOrHash NoOutputDatum        = Nothing
+getOutputDatumOrHash (OutputDatumHash dh) = Just (Left dh)
+getOutputDatumOrHash (OutputDatum da)     = Just (Right da)

--- a/plutus-ledger/src/Ledger/Validation.hs
+++ b/plutus-ledger/src/Ledger/Validation.hs
@@ -89,7 +89,6 @@ import Ledger.Params (EmulatorEra, emulatorGlobals, emulatorPParams)
 import Ledger.Params qualified as P
 import Ledger.Tx qualified as P
 import Ledger.Tx.CardanoAPI qualified as P
-import Plutus.V1.Ledger.Api qualified as P
 import Plutus.V1.Ledger.Scripts qualified as P
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.ErrorCodes (checkHasFailedError)
@@ -338,12 +337,11 @@ fromPlutusTxId :: P.TxId -> Either P.ToCardanoError (TxId StandardCrypto)
 fromPlutusTxId = fmap toShelleyTxId . P.toCardanoTxId
 
 fromPlutusTxOut :: P.Params -> P.TxOut -> Either P.ToCardanoError (TxOut EmulatorEra)
-fromPlutusTxOut params = fmap (toShelleyTxOut ShelleyBasedEraBabbage) . P.toCardanoTxOut (P.pNetworkId params) P.toCardanoTxOutDatumHash
-
+fromPlutusTxOut params = fmap (toShelleyTxOut ShelleyBasedEraBabbage) . P.toCardanoTxOut (P.pNetworkId params) P.toCardanoTxOutDatum (const $ throwError P.ReferenceScriptNotSupported)
 
 -- | Like 'fromPlutusTxOut', but ignores the check for zeros in txOuts.
 fromPlutusTxOutUnsafe :: P.Params -> P.TxOut -> Either P.ToCardanoError (TxOut EmulatorEra)
-fromPlutusTxOutUnsafe params = fmap (toShelleyTxOut ShelleyBasedEraBabbage) . P.toCardanoTxOutUnsafe (P.pNetworkId params) P.toCardanoTxOutDatumHash
+fromPlutusTxOutUnsafe params = fmap (toShelleyTxOut ShelleyBasedEraBabbage) . P.toCardanoTxOutUnsafe (P.pNetworkId params) P.toCardanoTxOutDatum (const $ throwError P.ReferenceScriptNotSupported)
 
 fromPaymentPrivateKey :: Crypto.XPrv -> TxBody EmulatorEra -> C.Api.KeyWitness C.Api.BabbageEra
 fromPaymentPrivateKey xprv txBody

--- a/plutus-ledger/src/Ledger/Value.hs
+++ b/plutus-ledger/src/Ledger/Value.hs
@@ -1,14 +1,14 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Ledger.Value
-  ( module Export
+  ( module Plutus.V1.Ledger.Value
   , noAdaValue
   , adaOnlyValue
   , isAdaOnlyValue
   ) where
 
 import Ledger.Ada qualified as Ada
-import Plutus.V1.Ledger.Value as Export
+import Plutus.V1.Ledger.Value
 import PlutusTx.Prelude (Bool, Eq (..), (-))
 
 {-# INLINABLE noAdaValue #-}

--- a/plutus-ledger/test/Ledger/Tx/CardanoAPISpec.hs
+++ b/plutus-ledger/test/Ledger/Tx/CardanoAPISpec.hs
@@ -21,7 +21,6 @@ import Plutus.V1.Ledger.Scripts (unitRedeemer)
 
 import Data.Default (def)
 import Data.Map qualified as Map
-import Data.Set qualified as Set
 import Hedgehog (Gen, Property, forAll, property, (===))
 import Hedgehog qualified
 import Hedgehog.Gen qualified as Gen
@@ -89,7 +88,7 @@ convertMintingTx = property $ do
       vL n = Value.singleton (Value.mpsSymbol $ mintingPolicyHash mps) "L" n
       tx   = mempty
         { txMint = vL 1
-        , txMintScripts = Set.singleton mps
+        , txMintScripts = Map.singleton (mintingPolicyHash mps) mps
         , txRedeemers = Map.singleton (RedeemerPtr Mint 0) unitRedeemer
         }
       ectx = toCardanoTxBodyContent def [] tx >>= makeTransactionBody mempty

--- a/plutus-ledger/test/Spec.hs
+++ b/plutus-ledger/test/Spec.hs
@@ -229,7 +229,8 @@ ciTxOutRoundTrip :: Property
 ciTxOutRoundTrip = property $ do
   txOuts <- Map.elems . Gen.mockchainUtxo <$> forAll Gen.genMockchain
   forM_ txOuts $ \txOut -> do
-    Hedgehog.assert $ Tx.toTxOut (fromJust $ Tx.fromTxOut txOut) == txOut
+    -- Hedgehog.assert $ Tx.toTxOut (fromJust $ Tx.fromTxOut txOut) == txOut
+    fail "FIXME" -- FIXME
 
 -- | Asserting that time range of 'scSlotZeroTime' to 'scSlotZeroTime + scSlotLength'
 -- is 'Slot 0' and the time after that is 'Slot 1'.

--- a/plutus-script-utils/src/Plutus/Script/Utils/V2/Generators.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V2/Generators.hs
@@ -6,6 +6,7 @@ module Plutus.Script.Utils.V2.Generators
     ( alwaysSucceedValidator
     , alwaysSucceedValidatorHash
     , alwaysSucceedPolicy
+    , alwaysSucceedPolicyHash
     , PV1.someTokenValue
     ) where
 
@@ -25,3 +26,6 @@ alwaysSucceedValidatorHash = Scripts.validatorHash alwaysSucceedValidator
 alwaysSucceedPolicy :: PV2.MintingPolicy
 alwaysSucceedPolicy =
     PV2.mkMintingPolicyScript $$(PlutusTx.compile [|| \_ _ -> () ||])
+
+alwaysSucceedPolicyHash :: PV2.MintingPolicyHash
+alwaysSucceedPolicyHash = Scripts.mintingPolicyHash alwaysSucceedPolicy


### PR DESCRIPTION
This moves plutus-ledger to use plutus-ledger-api V2 types where available. Also adjusts a bit the dependecy between modules (making every plutus ledger reexport the plutus-ledger-api types it refers to, saving the consumer from having to explicitly depend on plutus-ledger-api).

Still in draft because there are some parts I am not sure how to solve. I'll leave comments inline.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
