### PR TITLE
Fix Ledger.Constraints.TxConstraints.collectFromPlutusV1ScriptFilter implementation

### DIFF
--- a/plutus-ledger-constraints/src/Ledger/Constraints/TxConstraints.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/TxConstraints.hs
@@ -9,11 +9,12 @@
 {-# LANGUAGE NoImplicitPrelude    #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE UndecidableInstances #-}
+
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
 {-# OPTIONS_GHC -fno-specialise #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-{-# LANGUAGE TypeApplications     #-}
+
 -- | Constraints for transactions
 module Ledger.Constraints.TxConstraints where
 
@@ -34,7 +35,7 @@ import PlutusTx.Prelude (Bool (False, True), Foldable (foldMap), Functor (fmap),
 import Ledger.Address (PaymentPubKeyHash, StakePubKeyHash)
 import Ledger.Address qualified as Address
 import Ledger.Tx (ChainIndexTxOut)
-import Plutus.V1.Ledger.Api (Address, Datum (Datum), DatumHash, MintingPolicyHash, POSIXTimeRange, Redeemer (Redeemer),
+import Plutus.V1.Ledger.Api (Address, Datum (Datum), DatumHash, MintingPolicyHash, POSIXTimeRange, Redeemer,
                              StakeValidatorHash, TxOutRef, Validator, ValidatorHash)
 import Plutus.V1.Ledger.Interval qualified as I
 import Plutus.V1.Ledger.Scripts (unitRedeemer)
@@ -600,9 +601,10 @@ collectFromPlutusV1ScriptFilter
     -> Validator
     -> Redeemer
     -> UntypedConstraints
-collectFromPlutusV1ScriptFilter flt am vls (Redeemer red) =
+collectFromPlutusV1ScriptFilter flt am vls red =
     let mp'  = fromMaybe Haskell.mempty $ am ^. at (Address.scriptAddress vls)
-    in collectFromTheScriptFilter @PlutusTx.BuiltinData @PlutusTx.BuiltinData flt mp' red
+        ourUtxo = Map.filterWithKey flt mp'
+    in foldMap (flip mustSpendScriptOutput red) $ Map.keys ourUtxo
 
 -- | Given the pay to script address of the 'Validator', collect from it
 -- all the outputs that match a predicate, using the 'RedeemerValue'.


### PR DESCRIPTION
Made the functions `Ledger.Constraints.TxConstraints.collectFromPlutusV1ScriptFilter` and `Ledger.Constraints.TxConstraints.collectFromTheScript` as unrelated functions.

The rationale is that if someone uses `collectFromPlutusV1ScriptFilter`,
the constraints will fail with a `TypedValidatorMissing` error for
lookups, even though we're not using typed validators.

This fix was triggered by #641 

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
