### PR TITLE
Replace LedgerPlutusVersion with Language type

### DIFF
--- a/playground-common/src/PSGenerator/Common.hs
+++ b/playground-common/src/PSGenerator/Common.hs
@@ -33,10 +33,10 @@ import Ledger.Interval (Extended, Interval, LowerBound, UpperBound)
 import Ledger.Scripts (ScriptError)
 import Ledger.Slot (Slot)
 import Ledger.TimeSlot (SlotConfig, SlotConversionError)
+import Ledger.Tx qualified as Tx (Language)
 import Ledger.Tx.CardanoAPI (FromCardanoError, ToCardanoError)
 import Ledger.Value (AssetClass, CurrencySymbol, TokenName, Value)
 import Playground.Types (ContractCall, FunctionSchema, KnownCurrency)
-import Plutus.ApiCommon (LedgerPlutusVersion)
 import Plutus.ChainIndex.Api (IsUtxoResponse, QueryResponse, TxosResponse, UtxosResponse)
 import Plutus.ChainIndex.ChainIndexError (ChainIndexError)
 import Plutus.ChainIndex.ChainIndexLog (ChainIndexLog)
@@ -335,7 +335,7 @@ scriptAnyLangType = SumType (
 ------------------------------------------------------------
 ledgerTypes :: [SumType 'Haskell]
 ledgerTypes =
-    [ order . genericShow . argonaut $ mkSumType @LedgerPlutusVersion
+    [ order . genericShow . argonaut $ mkSumType @Tx.Language
     , equal . genericShow . argonaut $ mkSumType @Slot
     , equal . genericShow . argonaut $ mkSumType @Ada
     , equal . genericShow . argonaut $ mkSumType @SlotConfig

--- a/playground-common/src/Schema.hs
+++ b/playground-common/src/Schema.hs
@@ -58,11 +58,11 @@ import Data.Text qualified as Text
 import Data.UUID (UUID)
 import GHC.Generics (C1, Constructor, D1, Generic, K1 (K1), M1 (M1), Rec0, Rep, S1, Selector, U1, conIsRecord, conName,
                      from, selName, (:*:) ((:*:)), (:+:) (L1, R1))
-import Ledger (Ada, AssetClass, CurrencySymbol, Interval, POSIXTime, POSIXTimeRange, PaymentPubKey, PaymentPubKeyHash,
-               PubKey, PubKeyHash, Signature, Slot, StakePubKey, StakePubKeyHash, TokenName, TxId, TxOutRef, Value)
+import Ledger (Ada, AssetClass, CurrencySymbol, Interval, Language, POSIXTime, POSIXTimeRange, PaymentPubKey,
+               PaymentPubKeyHash, PubKey, PubKeyHash, Signature, Slot, StakePubKey, StakePubKeyHash, TokenName, TxId,
+               TxOutRef, Value)
 import Ledger.Bytes (LedgerBytes)
 import Ledger.CardanoWallet (WalletNumber)
-import Plutus.ApiCommon (LedgerPlutusVersion)
 import Plutus.Contract.Secrets (SecretArgument (EndpointSide, UserSide))
 import Plutus.Contract.StateMachine.ThreadToken (ThreadToken)
 import Plutus.V1.Ledger.Api (DatumHash, RedeemerHash, ValidatorHash)
@@ -404,7 +404,7 @@ deriving anyclass instance ToSchema PaymentPubKey
 
 deriving anyclass instance ToSchema PaymentPubKeyHash
 
-deriving anyclass instance ToSchema LedgerPlutusVersion
+deriving anyclass instance ToSchema Language
 
 deriving anyclass instance ToSchema StakePubKey
 

--- a/plutus-contract/test/Spec/Emulator.hs
+++ b/plutus-contract/test/Spec/Emulator.hs
@@ -25,7 +25,7 @@ import Hedgehog (Property, forAll, property)
 import Hedgehog qualified
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
-import Ledger (CardanoTx (..), LedgerPlutusVersion (PlutusV1), OnChainTx (Valid), PaymentPubKeyHash, Tx (txMint),
+import Ledger (CardanoTx (..), Language (PlutusV1), OnChainTx (Valid), PaymentPubKeyHash, Tx (txMint),
                ValidationError (ScriptFailure), cardanoTxMap, getCardanoTxFee, getCardanoTxOutRefs, getCardanoTxOutputs,
                onCardanoTx, outputs, scriptTxIn, unspentOutputs)
 import Ledger.Ada qualified as Ada

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -98,8 +98,8 @@ import Ledger.Crypto (pubKeyHash)
 import Ledger.Index (minAdaTxOut)
 import Ledger.Orphans ()
 import Ledger.Params (Params)
-import Ledger.Tx (ChainIndexTxOut, LedgerPlutusVersion (PlutusV1, PlutusV2), RedeemerPtr (RedeemerPtr),
-                  ScriptTag (Mint, Spend), Tx, TxOut (txOutAddress, txOutDatumHash, txOutValue), TxOutRef)
+import Ledger.Tx (ChainIndexTxOut, Language (PlutusV1, PlutusV2), RedeemerPtr (RedeemerPtr), ScriptTag (Mint, Spend),
+                  Tx, TxOut (txOutAddress, txOutDatumHash, txOutValue), TxOutRef)
 import Ledger.Tx qualified as Tx
 import Ledger.Tx.CardanoAPI qualified as C
 import Ledger.Typed.Scripts (Any, ConnectionError (UnknownRef), TypedValidator,
@@ -124,7 +124,7 @@ data ScriptLookups a =
         -- ^ Minting policies that the script interacts with
         , slTxOutputs              :: Map TxOutRef ChainIndexTxOut
         -- ^ Unspent outputs that the script may want to spend
-        , slOtherScripts           :: Map ValidatorHash (Validator, LedgerPlutusVersion)
+        , slOtherScripts           :: Map ValidatorHash (Validator, Language)
         -- ^ Validators of scripts other than "our script"
         , slOtherData              :: Map DatumHash Datum
         -- ^ Datums that we might need
@@ -620,7 +620,7 @@ lookupValidator
        , MonadError MkTxError m
        )
     => ValidatorHash
-    -> m (Validator, LedgerPlutusVersion)
+    -> m (Validator, Language)
 lookupValidator vh =
     let err = throwError (ValidatorHashNotFound vh) in
     asks slOtherScripts >>= maybe err pure . view (at vh)
@@ -749,7 +749,7 @@ resolveScriptTxOut
     :: ( MonadReader (ScriptLookups a) m
        , MonadError MkTxError m
        )
-    => ChainIndexTxOut -> m (Maybe ((ValidatorHash, Validator, LedgerPlutusVersion), (DatumHash, Datum), Value))
+    => ChainIndexTxOut -> m (Maybe ((ValidatorHash, Validator, Language), (DatumHash, Datum), Value))
 resolveScriptTxOut
         Tx.ScriptChainIndexTxOut
             { Tx._ciTxOutValidator = (vh, v)

--- a/plutus-ledger/src/Ledger/Index.hs
+++ b/plutus-ledger/src/Ledger/Index.hs
@@ -270,7 +270,7 @@ checkMintingScripts tx = do
 -- | A matching pair of transaction input and transaction output, ensuring that they are of matching types also.
 data InOutMatch =
     ScriptMatch
-        LedgerPlutusVersion
+        Language
         TxOutRef
         Validator
         Redeemer

--- a/plutus-ledger/src/Ledger/Orphans.hs
+++ b/plutus-ledger/src/Ledger/Orphans.hs
@@ -30,7 +30,7 @@ import GHC.Generics (Generic)
 import Ledger.Ada (Ada (Lovelace))
 import Ledger.Crypto (PrivateKey (PrivateKey, getPrivateKey), PubKey (PubKey), Signature (Signature))
 import Ledger.Slot (Slot (Slot))
-import Ledger.Tx.Internal (LedgerPlutusVersion, Tx, TxIn, TxInType)
+import Ledger.Tx.Internal (Language, Tx, TxIn, TxInType)
 import Plutus.V1.Ledger.Api (Address, Credential, CurrencySymbol (CurrencySymbol), Extended, Interval,
                              LedgerBytes (LedgerBytes), LowerBound, MintingPolicy (MintingPolicy),
                              MintingPolicyHash (MintingPolicyHash), POSIXTime (POSIXTime), PubKeyHash (PubKeyHash),
@@ -117,7 +117,7 @@ deriving instance OpenApi.ToSchema TxInType
 deriving instance OpenApi.ToSchema TxIn
 deriving instance OpenApi.ToSchema PV1.TxOut
 deriving instance OpenApi.ToSchema PV2.TxOut
-deriving instance OpenApi.ToSchema LedgerPlutusVersion
+deriving instance OpenApi.ToSchema Language
 deriving newtype instance OpenApi.ToSchema Validator
 deriving newtype instance OpenApi.ToSchema TxId
 deriving newtype instance OpenApi.ToSchema Slot

--- a/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
+++ b/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
@@ -742,7 +742,7 @@ fromCardanoScriptData = PV1.dataToBuiltinData . C.toPlutusData
 toCardanoScriptData :: PV1.BuiltinData -> C.ScriptData
 toCardanoScriptData = C.fromPlutusData . PV1.builtinDataToData
 
-fromCardanoScriptInEra :: C.ScriptInEra era -> Maybe (P.Script, P.LedgerPlutusVersion)
+fromCardanoScriptInEra :: C.ScriptInEra era -> Maybe (P.Script, P.Language)
 fromCardanoScriptInEra (C.ScriptInEra C.PlutusScriptV1InAlonzo (C.PlutusScript C.PlutusScriptV1 script)) =
     Just (fromCardanoPlutusScript script, P.PlutusV1)
 fromCardanoScriptInEra (C.ScriptInEra C.PlutusScriptV1InBabbage (C.PlutusScript C.PlutusScriptV1 script)) =
@@ -751,7 +751,7 @@ fromCardanoScriptInEra (C.ScriptInEra C.PlutusScriptV2InBabbage (C.PlutusScript 
     Just (fromCardanoPlutusScript script, P.PlutusV2)
 fromCardanoScriptInEra (C.ScriptInEra _ C.SimpleScript{}) = Nothing
 
-toCardanoScriptInEra :: P.Script -> P.LedgerPlutusVersion -> Either ToCardanoError (C.ScriptInEra C.BabbageEra)
+toCardanoScriptInEra :: P.Script -> P.Language -> Either ToCardanoError (C.ScriptInEra C.BabbageEra)
 toCardanoScriptInEra script P.PlutusV1 = C.ScriptInEra C.PlutusScriptV1InBabbage . C.PlutusScript C.PlutusScriptV1 <$> toCardanoPlutusScript (C.AsPlutusScript C.AsPlutusScriptV1) script
 toCardanoScriptInEra script P.PlutusV2 = C.ScriptInEra C.PlutusScriptV2InBabbage . C.PlutusScript C.PlutusScriptV2 <$> toCardanoPlutusScript (C.AsPlutusScript C.AsPlutusScriptV2) script
 
@@ -767,7 +767,7 @@ toCardanoPlutusScript asPlutusScriptType =
     tag "toCardanoPlutusScript"
     . deserialiseFromRawBytes asPlutusScriptType . BSL.toStrict . Codec.serialise
 
-fromCardanoScriptInAnyLang :: C.ScriptInAnyLang -> Maybe (P.Script, P.LedgerPlutusVersion)
+fromCardanoScriptInAnyLang :: C.ScriptInAnyLang -> Maybe (P.Script, P.Language)
 fromCardanoScriptInAnyLang (C.ScriptInAnyLang _sl (C.SimpleScript _ssv _ss)) = Nothing
 fromCardanoScriptInAnyLang (C.ScriptInAnyLang _sl (C.PlutusScript psv ps)) = Just $ case psv of
      C.PlutusScriptV1 -> (fromCardanoPlutusScript ps, P.PlutusV1)
@@ -799,7 +799,7 @@ data ToCardanoError
     | MissingMintingPolicyRedeemer
     | MissingMintingPolicy
     | ScriptPurposeNotSupported PV1.ScriptTag
-    | UnsupportedPlutusVersion P.LedgerPlutusVersion
+    | UnsupportedPlutusVersion P.Language
     | Tag String ToCardanoError
     deriving stock (Show, Eq, Generic)
     deriving anyclass (FromJSON, ToJSON)

--- a/plutus-ledger/src/Ledger/Typed/Scripts.hs
+++ b/plutus-ledger/src/Ledger/Typed/Scripts.hs
@@ -13,7 +13,7 @@ module Ledger.Typed.Scripts
   , makeTypedScriptTxIn
   ) where
 
-import Ledger.Tx.Internal (LedgerPlutusVersion, TxIn (TxIn), TxInType (ConsumeScriptAddress))
+import Ledger.Tx.Internal (Language, TxIn (TxIn), TxInType (ConsumeScriptAddress))
 import Ledger.Typed.Scripts.Orphans as Export ()
 import Plutus.Script.Utils.V1.Typed.Scripts as Export
 import Plutus.Script.Utils.V1.Typed.TypeUtils as Export
@@ -34,7 +34,7 @@ instance Eq (DatumType a) => Eq (TypedScriptTxIn a) where
 makeTypedScriptTxIn ::
   forall inn.
   (ToData (RedeemerType inn), ToData (DatumType inn)) =>
-  LedgerPlutusVersion ->
+  Language ->
   TypedValidator inn ->
   RedeemerType inn ->
   TypedScriptTxOutRef inn ->

--- a/plutus-pab/src/Plutus/PAB/Arbitrary.hs
+++ b/plutus-pab/src/Plutus/PAB/Arbitrary.hs
@@ -227,7 +227,7 @@ instance Arbitrary PlutusTx.BuiltinData where
     arbitrary = PlutusTx.dataToBuiltinData <$> arbitrary
     shrink d = PlutusTx.dataToBuiltinData <$> shrink (PlutusTx.builtinDataToData d)
 
-instance Arbitrary Ledger.LedgerPlutusVersion where
+instance Arbitrary Ledger.Language where
     arbitrary = genericArbitrary
     shrink = genericShrink
 


### PR DESCRIPTION
@michaelpj said we shouldn't be using `LedgerPlutusVersion`. We can use `Cardano.Ledger.Alonzo.Language` instead.
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
