### PR TITLE
export `getUnspentTxOutsAtAddress`

### DIFF
--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Client.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Client.hs
@@ -20,6 +20,7 @@ module Plutus.ChainIndex.Client(
     , getUnspentTxOut
     , getIsUtxo
     , getUtxoSetAtAddress
+    , getUnspentTxOutsAtAddress
     , getUtxoSetWithCurrency
     , getTxs
     , getTxoSetAtAddress


### PR DESCRIPTION
This PR brings back export of `getUnspentTxOutsAtAddress` to `Plutus.ChainIndex.Client` module.
We are using `plutus-chain-index-core` in our application, working extensively with `next-node` branch, and it would be great to have `getUnspentTxOutsAtAddress` back.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
