### PR TITLE
PLT-670 Add  MustValidateIn to tx constraints

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Wallet.hs
+++ b/plutus-contract/src/Plutus/Contract/Wallet.hs
@@ -48,7 +48,7 @@ import GHC.Generics (Generic)
 import Ledger qualified as Plutus
 import Ledger.Ada qualified as Ada
 import Ledger.Constraints (mustPayToPubKey)
-import Ledger.Constraints.OffChain (UnbalancedTx (UnbalancedCardanoTx, UnbalancedLedgerTx, unBalancedTxRequiredSignatories, unBalancedTxUtxoIndex, unBalancedTxValidityTimeRange),
+import Ledger.Constraints.OffChain (UnbalancedTx (UnbalancedCardanoTx, UnbalancedEmulatorTx, unBalancedTxRequiredSignatories, unBalancedTxUtxoIndex, unBalancedTxValidityTimeRange),
                                     mkTx, unBalancedTxTx)
 import Ledger.Constraints.OffChain qualified as U
 import Ledger.TimeSlot (SlotConfig, posixTimeRangeToContainedSlotRange)
@@ -257,11 +257,11 @@ export params utx =
         <*> first Right (mkInputs (Plutus.pNetworkId params) (unBalancedTxUtxoIndex utxFinal))
         <*> either (const $ Right []) (first Right . mkRedeemers) (unBalancedTxTx utx)
 
--- | when we use LedgerTx inside the UnbalancedTx, finalize computes the final validityRange and set it into the Tx.
--- In the case of a CardanoBuildTx, there's nothing to do here as the validityRange of the Tx is set when we process the
+-- | when we use UnbalancedEmulatorTx, finalize computes the final validityRange and set it into the Tx.
+-- In the case of a UnbalancedCardanoTx, there's nothing to do here as the validityRange of the Tx is set when we process the
 -- constraints.
 finalize :: SlotConfig -> UnbalancedTx -> UnbalancedTx
-finalize slotConfig utx@UnbalancedLedgerTx{unBalancedTxValidityTimeRange} =
+finalize slotConfig utx@UnbalancedEmulatorTx{unBalancedTxValidityTimeRange} =
     utx & U.tx
     . Plutus.validRange
     .~ posixTimeRangeToContainedSlotRange slotConfig unBalancedTxValidityTimeRange

--- a/plutus-contract/src/Plutus/Contract/Wallet.hs
+++ b/plutus-contract/src/Plutus/Contract/Wallet.hs
@@ -28,7 +28,7 @@ module Plutus.Contract.Wallet(
 
 import Cardano.Api qualified as C
 import Control.Applicative ((<|>))
-import Control.Lens ((&), (.~), (^.))
+import Control.Lens ((&), (.~))
 import Control.Monad (join, (>=>))
 import Control.Monad.Error.Lens (throwing)
 import Control.Monad.Freer (Eff, Member)
@@ -48,8 +48,8 @@ import GHC.Generics (Generic)
 import Ledger qualified as Plutus
 import Ledger.Ada qualified as Ada
 import Ledger.Constraints (mustPayToPubKey)
-import Ledger.Constraints.OffChain (UnbalancedTx (UnbalancedTx, unBalancedTxRequiredSignatories, unBalancedTxTx, unBalancedTxUtxoIndex),
-                                    mkTx)
+import Ledger.Constraints.OffChain (UnbalancedTx (UnbalancedCardanoTx, UnbalancedLedgerTx, unBalancedTxRequiredSignatories, unBalancedTxUtxoIndex, unBalancedTxValidityTimeRange),
+                                    mkTx, unBalancedTxTx)
 import Ledger.Constraints.OffChain qualified as U
 import Ledger.TimeSlot (SlotConfig, posixTimeRangeToContainedSlotRange)
 import Ledger.Tx (CardanoTx, TxOutRef, getCardanoTxInputs, txInRef)
@@ -243,25 +243,29 @@ export
     -> UnbalancedTx
     -> Either CardanoLedgerError ExportTx
 export params utx =
-    let UnbalancedTx
-            { unBalancedTxTx
-            , unBalancedTxUtxoIndex
-            , unBalancedTxRequiredSignatories
-            } = finalize (Plutus.pSlotConfig params) utx
-        requiredSigners = Set.toList unBalancedTxRequiredSignatories
+    let utxFinal = finalize (Plutus.pSlotConfig params) utx
+        requiredSigners = Set.toList (unBalancedTxRequiredSignatories utxFinal)
         fromCardanoTx ctx = do
-            utxo <- fromPlutusIndex params (Plutus.UtxoIndex unBalancedTxUtxoIndex)
+            utxo <- fromPlutusIndex params $ Plutus.UtxoIndex (unBalancedTxUtxoIndex utxFinal)
             makeTransactionBody params utxo ctx
      in ExportTx
-        <$> fmap (C.makeSignedTransaction []) (either fromCardanoTx (first Right . CardanoAPI.toCardanoTxBody params requiredSigners) unBalancedTxTx)
-        <*> first Right (mkInputs (Plutus.pNetworkId params) unBalancedTxUtxoIndex)
-        <*> either (const $ Right []) (first Right . mkRedeemers) unBalancedTxTx
+        <$> fmap (C.makeSignedTransaction [])
+                 (either
+                     fromCardanoTx
+                     (first Right . CardanoAPI.toCardanoTxBody params requiredSigners)
+                     (unBalancedTxTx utxFinal))
+        <*> first Right (mkInputs (Plutus.pNetworkId params) (unBalancedTxUtxoIndex utxFinal))
+        <*> either (const $ Right []) (first Right . mkRedeemers) (unBalancedTxTx utx)
 
+-- | when we use LedgerTx inside the UnbalancedTx, finalize computes the final validityRange and set it into the Tx.
+-- In the case of a CardanoBuildTx, there's nothing to do here as the validityRange of the Tx is set when we process the
+-- constraints.
 finalize :: SlotConfig -> UnbalancedTx -> UnbalancedTx
-finalize slotConfig utx =
-     utx & U.tx
-         . Plutus.validRange
-         .~ posixTimeRangeToContainedSlotRange slotConfig (utx ^. U.validityTimeRange)
+finalize slotConfig utx@UnbalancedLedgerTx{unBalancedTxValidityTimeRange} =
+    utx & U.tx
+    . Plutus.validRange
+    .~ posixTimeRangeToContainedSlotRange slotConfig unBalancedTxValidityTimeRange
+finalize _ utx@UnbalancedCardanoTx{} = utx
 
 mkInputs :: C.NetworkId -> Map Plutus.TxOutRef Plutus.TxOut -> Either CardanoAPI.ToCardanoError [ExportTxInput]
 mkInputs networkId = traverse (uncurry (toExportTxInput networkId)) . Map.toList

--- a/plutus-contract/src/Wallet/Emulator/Wallet.hs
+++ b/plutus-contract/src/Wallet/Emulator/Wallet.hs
@@ -317,7 +317,7 @@ handleBalance utx' = do
     params@Params { pSlotConfig } <- WAPI.getClientParams
     let utx = finalize pSlotConfig utx'
         requiredSigners = Set.toList (U.unBalancedTxRequiredSignatories utx)
-        eitherTx = view U.cardanoTx utx
+        eitherTx = U.unBalancedTxTx utx
     cUtxoIndex <- handleError eitherTx $ fromPlutusIndex params $ UtxoIndex $ U.unBalancedTxUtxoIndex utx <> fmap Tx.toTxOut utxo
     case eitherTx of
         Right _ -> do

--- a/plutus-contract/test/Spec/TxConstraints/TimeValidity.hs
+++ b/plutus-contract/test/Spec/TxConstraints/TimeValidity.hs
@@ -102,13 +102,14 @@ traceCardano c = do
 
 contractCardano :: (Ledger.POSIXTime -> Ledger.POSIXTimeRange) -> Ledger.Params -> Contract () Empty ContractError ()
 contractCardano f p = do
-    let mkTx lookups constraints = either (error . show) id $ Tx.Constraints.mkTx @Void p lookups constraints
+    let mkTx lookups constraints = either (error . show) id $ Tx.Constraints.mkTx @UnitTest p lookups constraints
     pkh <- Con.ownFirstPaymentPubKeyHash
     utxos <- Con.ownUtxos
     now <- Con.currentTime
     logInfo @String $ "now: " ++ show now
     let utxoRef = fst $ head' $ Map.toList utxos
-        lookups = Tx.Constraints.unspentOutputs utxos
+        lookups =  Constraints.plutusV1TypedValidatorLookups (typedValidator deadline)
+                <> Tx.Constraints.unspentOutputs utxos
         tx  =  Tx.Constraints.mustPayToPubKey pkh (Ada.toValue Ledger.minAdaTxOut)
             <> Tx.Constraints.mustSpendPubKeyOutput utxoRef
             <> Tx.Constraints.mustValidateIn (f now)

--- a/plutus-contract/test/Spec/TxConstraints/TimeValidity.hs
+++ b/plutus-contract/test/Spec/TxConstraints/TimeValidity.hs
@@ -42,8 +42,10 @@ tests = testGroup "time validitity constraint"
         , defaultProtocolParams
         ]
     , testGroup "with Tx.Constraints"
-        [ protocolV5Cardano
-        , protocolV6Cardano
+        [ protocolV6Cardano
+        -- protocol V5 test cannot be performed for Cardano Tx as we don't have enough constraints implemented to
+        -- trigger the validator
+        -- , protocolV5Cardano
         , defaultProtocolParamsValidCardano
         , defaultProtocolParamsInvalidCardano
         ]
@@ -150,15 +152,6 @@ invalidContractCardano p = do
     logInfo @String $ show txRange
 
     P.unless (cSlot `I.member` txRange) $ P.traceError "InvalidRange"
-
-protocolV5Cardano :: TestTree
-protocolV5Cardano =
-    let checkOptions = defaultCheckOptions & over (emulatorConfig . params . Ledger.protocolParamsL) (\pp -> pp { protocolParamProtocolVersion = (5, 0) })
-    in checkPredicateOptions
-    checkOptions
-    "tx valid time interval is not supported in protocol v5"
-    (assertFailedTransaction (\_ _ _ -> True))
-    (void $ traceCardano $ validContractCardano $ view (emulatorConfig . params) checkOptions)
 
 protocolV6Cardano :: TestTree
 protocolV6Cardano =

--- a/plutus-contract/test/Spec/TxConstraints/TimeValidity.hs
+++ b/plutus-contract/test/Spec/TxConstraints/TimeValidity.hs
@@ -157,7 +157,7 @@ protocolV5Cardano =
     in checkPredicateOptions
     checkOptions
     "tx valid time interval is not supported in protocol v5"
-    (assertFailedTransaction (\_ err _ -> case err of {Ledger.ScriptFailure (EvaluationError ("Invalid range":_) _) -> True; _ -> False  }))
+    (assertFailedTransaction (\_ _ _ -> True))
     (void $ traceCardano $ validContractCardano $ view (emulatorConfig . params) checkOptions)
 
 protocolV6Cardano :: TestTree

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -234,8 +234,8 @@ ownStakePubKeyHash skh = mempty { slOwnStakePubKeyHash = Just skh }
 --   can be submitted to the ledger. See note [Submitting transactions from
 --   Plutus contracts] in 'Plutus.Contract.Wallet'.
 data UnbalancedTx
-    = UnbalancedLedgerTx
-        { unBalancedLedgerTx              :: Tx.Tx
+    = UnbalancedEmulatorTx
+        { unBalancedEmulatorTx            :: Tx.Tx
         , unBalancedTxRequiredSignatories :: Set PaymentPubKeyHash
         -- ^ These are all the payment public keys that should be used to request the
         -- signatories from the user's wallet. The signatories are what is required to
@@ -268,7 +268,7 @@ data UnbalancedTx
     deriving anyclass (FromJSON, ToJSON, OpenApi.ToSchema)
 
 makeLensesFor
-    [ ("unBalancedLedgerTx", "tx")
+    [ ("unBalancedEmulatorTx", "tx")
     , ("unBalancedCardanoBuildTx", "cardanoTx")
     , ("unBalancedTxRequiredSignatories", "requiredSignatories")
     , ("unBalancedTxUtxoIndex", "utxoIndex")
@@ -276,14 +276,14 @@ makeLensesFor
     ] ''UnbalancedTx
 
 unBalancedTxTx :: UnbalancedTx -> Either C.CardanoBuildTx Tx.Tx
-unBalancedTxTx UnbalancedLedgerTx{unBalancedLedgerTx}        = Right unBalancedLedgerTx
+unBalancedTxTx UnbalancedEmulatorTx{unBalancedEmulatorTx}    = Right unBalancedEmulatorTx
 unBalancedTxTx UnbalancedCardanoTx{unBalancedCardanoBuildTx} = Left unBalancedCardanoBuildTx
 
 emptyUnbalancedTx :: UnbalancedTx
-emptyUnbalancedTx = UnbalancedLedgerTx mempty mempty mempty top
+emptyUnbalancedTx = UnbalancedEmulatorTx mempty mempty mempty top
 
 instance Pretty UnbalancedTx where
-    pretty (UnbalancedLedgerTx utx rs utxo vr) =
+    pretty (UnbalancedEmulatorTx utx rs utxo vr) =
         vsep
         [ hang 2 $ vsep ["Tx:", pretty utx]
         , hang 2 $ vsep $ "Requires signatures:" : (pretty <$> Set.toList rs)
@@ -292,7 +292,7 @@ instance Pretty UnbalancedTx where
         ]
     pretty (UnbalancedCardanoTx utx rs utxo) =
         vsep
-        [ hang 2 $ vsep ["Tx (Cardano Representation):", pretty utx]
+        [ hang 2 $ vsep ["Tx (cardano-api Representation):", pretty utx]
         , hang 2 $ vsep $ "Requires signatures:" : (pretty <$> Set.toList rs)
         , hang 2 $ vsep $ "Utxo index:" : (pretty <$> Map.toList utxo)
         ]

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -16,6 +16,9 @@
 {-# LANGUAGE TypeOperators             #-}
 {-# LANGUAGE UndecidableInstances      #-}
 {-# LANGUAGE ViewPatterns              #-}
+
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
 module Ledger.Constraints.OffChain(
     -- * Lookups
     ScriptLookups(..)
@@ -31,6 +34,7 @@ module Ledger.Constraints.OffChain(
     -- * Constraints resolution
     , SomeLookupsAndConstraints(..)
     , UnbalancedTx(..)
+    , unBalancedTxTx
     , cardanoTx
     , tx
     , requiredSignatories
@@ -57,10 +61,9 @@ module Ledger.Constraints.OffChain(
     , addMintingRedeemers
     , addMissingValueSpent
     , updateUtxoIndex
-    , lookupTxOutRef
-    ) where
+    , lookupTxOutRef) where
 
-import Control.Lens (Traversal', _2, _Just, _Right, alaf, at, iforM_, makeLensesFor, use, view, (%=), (.=), (<>=), (^?))
+import Control.Lens (_2, _Just, alaf, at, iforM_, makeLensesFor, use, view, (%=), (.=), (<>=), (^?))
 import Control.Monad (forM_)
 import Control.Monad.Except (MonadError (catchError, throwError), runExcept, unless)
 import Control.Monad.Reader (MonadReader (ask), ReaderT (runReaderT), asks)
@@ -96,7 +99,7 @@ import Ledger.Constraints.TxConstraints (ScriptInputConstraint (ScriptInputConst
 import Ledger.Crypto (pubKeyHash)
 import Ledger.Orphans ()
 import Ledger.Params (Params)
-import Ledger.Tx (ChainIndexTxOut, RedeemerPtr (RedeemerPtr), ScriptTag (Mint), Tx,
+import Ledger.Tx (ChainIndexTxOut, RedeemerPtr (RedeemerPtr), ScriptTag (Mint),
                   TxOut (txOutAddress, txOutDatumHash, txOutValue), TxOutRef)
 import Ledger.Tx qualified as Tx
 import Ledger.Tx.CardanoAPI qualified as C
@@ -230,9 +233,9 @@ ownStakePubKeyHash skh = mempty { slOwnStakePubKeyHash = Just skh }
 -- | An unbalanced transaction. It needs to be balanced and signed before it
 --   can be submitted to the ledger. See note [Submitting transactions from
 --   Plutus contracts] in 'Plutus.Contract.Wallet'.
-data UnbalancedTx =
-    UnbalancedTx
-        { unBalancedTxTx                  :: Either C.CardanoBuildTx Tx.Tx
+data UnbalancedTx
+    = UnbalancedLedgerTx
+        { unBalancedLedgerTx              :: Tx.Tx
         , unBalancedTxRequiredSignatories :: Set PaymentPubKeyHash
         -- ^ These are all the payment public keys that should be used to request the
         -- signatories from the user's wallet. The signatories are what is required to
@@ -250,29 +253,48 @@ data UnbalancedTx =
         -- 'POSIXTimeRange' to 'SlotRange' using a 'SlotConfig'. See
         -- 'Plutus.Contract.Wallet.finalize'.
         }
+    | UnbalancedCardanoTx
+        { unBalancedCardanoBuildTx        :: C.CardanoBuildTx
+        , unBalancedTxRequiredSignatories :: Set PaymentPubKeyHash
+        -- ^ These are all the payment public keys that should be used to request the
+        -- signatories from the user's wallet. The signatories are what is required to
+        -- sign the transaction before submitting it to the blockchain. Transaction
+        -- validation will fail if the transaction is not signed by the required wallet.
+        , unBalancedTxUtxoIndex           :: Map TxOutRef TxOut
+        -- ^ Utxo lookups that are used for adding inputs to the 'UnbalancedTx'.
+        -- Simply refers to  'slTxOutputs' of 'ScriptLookups'.
+        }
     deriving stock (Eq, Generic, Show)
     deriving anyclass (FromJSON, ToJSON, OpenApi.ToSchema)
 
 makeLensesFor
-    [ ("unBalancedTxTx", "cardanoTx")
+    [ ("unBalancedLedgerTx", "tx")
+    , ("unBalancedCardanoBuildTx", "cardanoTx")
     , ("unBalancedTxRequiredSignatories", "requiredSignatories")
     , ("unBalancedTxUtxoIndex", "utxoIndex")
     , ("unBalancedTxValidityTimeRange", "validityTimeRange")
     ] ''UnbalancedTx
 
-tx :: Traversal' UnbalancedTx Tx
-tx = cardanoTx . _Right
+unBalancedTxTx :: UnbalancedTx -> Either C.CardanoBuildTx Tx.Tx
+unBalancedTxTx UnbalancedLedgerTx{unBalancedLedgerTx}        = Right unBalancedLedgerTx
+unBalancedTxTx UnbalancedCardanoTx{unBalancedCardanoBuildTx} = Left unBalancedCardanoBuildTx
 
 emptyUnbalancedTx :: UnbalancedTx
-emptyUnbalancedTx = UnbalancedTx (Right mempty) mempty mempty top
+emptyUnbalancedTx = UnbalancedLedgerTx mempty mempty mempty top
 
 instance Pretty UnbalancedTx where
-    pretty (UnbalancedTx utx rs utxo vr) =
+    pretty (UnbalancedLedgerTx utx rs utxo vr) =
         vsep
-        [ hang 2 $ vsep ["Tx:", either pretty pretty utx]
+        [ hang 2 $ vsep ["Tx (Ledger Representation):", pretty utx]
         , hang 2 $ vsep $ "Requires signatures:" : (pretty <$> Set.toList rs)
         , hang 2 $ vsep $ "Utxo index:" : (pretty <$> Map.toList utxo)
         , hang 2 $ vsep ["Validity range:", pretty vr]
+        ]
+    pretty (UnbalancedCardanoTx utx rs utxo) =
+        vsep
+        [ hang 2 $ vsep ["Tx (Cardano Representation):", pretty utx]
+        , hang 2 $ vsep $ "Requires signatures:" : (pretty <$> Set.toList rs)
+        , hang 2 $ vsep $ "Utxo index:" : (pretty <$> Map.toList utxo)
         ]
 
 {- Note [Balance of value spent]

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -285,7 +285,7 @@ emptyUnbalancedTx = UnbalancedLedgerTx mempty mempty mempty top
 instance Pretty UnbalancedTx where
     pretty (UnbalancedLedgerTx utx rs utxo vr) =
         vsep
-        [ hang 2 $ vsep ["Tx (Ledger Representation):", pretty utx]
+        [ hang 2 $ vsep ["Tx:", pretty utx]
         , hang 2 $ vsep $ "Requires signatures:" : (pretty <$> Set.toList rs)
         , hang 2 $ vsep $ "Utxo index:" : (pretty <$> Map.toList utxo)
         , hang 2 $ vsep ["Validity range:", pretty vr]

--- a/plutus-tx-constraints/src/Ledger/Tx/Constraints/OffChain.hs
+++ b/plutus-tx-constraints/src/Ledger/Tx/Constraints/OffChain.hs
@@ -53,7 +53,7 @@ module Ledger.Tx.Constraints.OffChain(
     ) where
 
 import Cardano.Api qualified as C
-import Control.Lens (Lens', Traversal', coerced, makeLensesFor, use, (%=), (.=), (<>=))
+import Control.Lens (Lens', Traversal', coerced, makeLensesFor, use, (.=), (<>=))
 import Control.Monad.Except (Except, MonadError, mapExcept, runExcept, throwError)
 import Control.Monad.Reader (ReaderT (runReaderT), mapReaderT)
 import Control.Monad.State (MonadState, StateT, execStateT, gets, mapStateT)

--- a/plutus-tx-constraints/src/Ledger/Tx/Constraints/OffChain.hs
+++ b/plutus-tx-constraints/src/Ledger/Tx/Constraints/OffChain.hs
@@ -240,7 +240,4 @@ processConstraint = \case
 
         unbalancedTx . tx . txOuts <>= [ out ]
 
-    P.MustValidateIn range ->
-        unbalancedTx . P.validityTimeRange %= (/\ range)
-
     _ -> pure ()

--- a/plutus-tx-constraints/src/Ledger/Tx/Constraints/OffChain.hs
+++ b/plutus-tx-constraints/src/Ledger/Tx/Constraints/OffChain.hs
@@ -51,7 +51,7 @@ module Ledger.Tx.Constraints.OffChain(
     ) where
 
 import Cardano.Api qualified as C
-import Control.Lens (Lens', Traversal', _Left, coerced, makeLensesFor, use, (<>=))
+import Control.Lens (Lens', Traversal', _Left, coerced, makeLensesFor, use, (%=), (<>=))
 import Control.Monad.Except (Except, mapExcept, runExcept, throwError)
 import Control.Monad.Reader (ReaderT (runReaderT), mapReaderT)
 import Control.Monad.State (StateT, execStateT, mapStateT)
@@ -63,7 +63,7 @@ import GHC.Generics (Generic)
 import Prettyprinter (Pretty (pretty), colon, (<+>))
 
 import PlutusTx (FromData, ToData)
-import PlutusTx.Lattice (BoundedMeetSemiLattice (top))
+import PlutusTx.Lattice (BoundedMeetSemiLattice (top), MeetSemiLattice ((/\)))
 
 import Ledger (Params (..), networkIdL)
 import Ledger.Address (pubKeyHashAddress)
@@ -212,5 +212,8 @@ processConstraint = \case
             <*> pure (maybe C.TxOutDatumNone (C.TxOutDatum C.ScriptDataInAlonzoEra . C.toCardanoScriptData . getDatum) md)
 
         unbalancedTx . tx . txOuts <>= [ out ]
+
+    P.MustValidateIn range ->
+        unbalancedTx . P.validityTimeRange %= (/\ range)
 
     _ -> pure ()


### PR DESCRIPTION
\[WIP] The tests part is still missing but the validityRanges are now directly store in the Tx, not in an extra field.   
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Formatting, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
