### PR TITLE
Add event channel to certification function

### DIFF
--- a/plutus-contract-certification/src/Plutus/Contract/Test/Certification/Run.hs
+++ b/plutus-contract-certification/src/Plutus/Contract/Test/Certification/Run.hs
@@ -119,7 +119,7 @@ data CertificationTask = UnitTestsTask
                        | CrashToleranceTask
                        | WhitelistTask
                        | DLTestsTask
-  deriving (Eq, Show)
+  deriving (Eq, Show, Enum, Bounded)
 
 data CertificationOptions = CertificationOptions { certOptNumTests  :: Int
                                                  , certOptOutput    :: Bool

--- a/plutus-contract-certification/src/Plutus/Contract/Test/Certification/Run.hs
+++ b/plutus-contract-certification/src/Plutus/Contract/Test/Certification/Run.hs
@@ -32,6 +32,7 @@ module Plutus.Contract.Test.Certification.Run
   , CertificationOptions(..)
   , CertificationEvent(..)
   , CertificationTask(..)
+  , hasQuickCheckTests
   , defaultCertificationOptions
   , certify
   , certifyWithOptions
@@ -120,6 +121,9 @@ data CertificationTask = UnitTestsTask
                        | WhitelistTask
                        | DLTestsTask
   deriving (Eq, Show, Enum, Bounded)
+
+hasQuickCheckTests :: CertificationTask -> Bool
+hasQuickCheckTests t = t /= UnitTestsTask
 
 data CertificationOptions = CertificationOptions { certOptNumTests  :: Int
                                                  , certOptOutput    :: Bool


### PR DESCRIPTION
You can pass an optional `Control.Concurrent.Chan` in the certification options to get events when tests pass or fail.

Pre-submit checklist:
- Branch
    - [ ] ~~Tests are provided (if possible)~~
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
