### PR TITLE
Upgrade gitignore-nix version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
     "gitignore-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1646480205,
-        "narHash": "sha256-kekOlTlu45vuK2L9nq8iVN17V3sB0WWPqTTW3a2SQG0=",
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "bff2832ec341cf30acb3a4d3e2e7f1f7b590116a",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
         "type": "github"
       },
       "original": {

--- a/marconi/README.md
+++ b/marconi/README.md
@@ -143,7 +143,7 @@ The `marconi` executable is available as a nix flake.
 You may either clone the [`plutus-apps`](https://github.com/input-output-hk/plutus-apps)
 repository and run from the top-level:
 ```
-nix build --impure .#marconi
+nix build .#marconi
 ```
 Or you may run from anywhere:
 ```


### PR DESCRIPTION
By upgrading `gitignore-nix` (which includes the relevant fix via https://github.com/hercules-ci/gitignore.nix/pull/58), we can now use flakes to build Marconi in pure mode (i.e. without the `--impure` flag).
Also see our related PR https://github.com/input-output-hk/plutus-apps/pull/702
Tested locally with 
`nix build .#marconi` 
And with 
`nix build github:input-output-hk/plutus-apps/7f45669dfe4b9e5440d0d9c74eea18b2104eb7f0#marconi`
