### PR TITLE
certification: Send CertificationDone event when finished running.

### DIFF
--- a/plutus-contract-certification/src/Plutus/Contract/Test/Certification/Run.hs
+++ b/plutus-contract-certification/src/Plutus/Contract/Test/Certification/Run.hs
@@ -111,6 +111,7 @@ certResJSON = unpack . encode
 data CertificationEvent = QuickCheckTestEvent (Maybe Bool)  -- ^ Nothing if discarded, otherwise test result
                         | StartCertificationTask CertificationTask
                         | FinishedTask Bool
+                        | CertificationDone
   deriving (Eq, Show)
 
 data CertificationTask = UnitTestsTask
@@ -306,6 +307,9 @@ certifyWithOptions opts Certification{..} = runCertMonad $ do
   wlRes        <- checkWhitelist @m certWhitelist opts certCoverageIndex
   -- DL tests
   dlRes        <- checkDLTests @m certDLTests opts certCoverageIndex
+  case certEventChannel opts of
+    Just ch -> liftIO $ writeChan ch CertificationDone
+    Nothing -> pure ()
   -- Final results
   return $ CertificationReport
             { _certRes_standardPropertyResult       = qcRes


### PR DESCRIPTION
Chan has no built-in closing mechanism, relying instead on BlockedIndefinitelyOnMVar to signal that no new messages are coming. Unfortunately, due to
https://gitlab.haskell.org/ghc/ghc/-/issues/18370, any thread using this mechanism to detect end-of-channel will not be able to reliably signal other threads of later work. So we use an application-level end-of-channel signal instead.
