### PR TITLE
Fix some false-positives MustSpendScriptOutput tests using versioned minting policies

### DIFF
--- a/plutus-contract/test/Spec/TxConstraints/MustSpendScriptOutput.hs
+++ b/plutus-contract/test/Spec/TxConstraints/MustSpendScriptOutput.hs
@@ -16,26 +16,27 @@ import Data.Map as M
 import Ledger qualified
 import Ledger.Ada qualified as Ada
 import Ledger.Constraints (TxConstraints)
-import Ledger.Constraints.OffChain qualified as Constraints (MkTxError (NoMatchingOutputFound, TxOutRefWrongType),
-                                                             plutusV1MintingPolicy, plutusV1OtherScript,
-                                                             typedValidatorLookups, unspentOutputs)
-import Ledger.Constraints.OnChain.V1 qualified as Constraints (checkScriptContext)
-import Ledger.Constraints.TxConstraints qualified as Constraints (mustMintValue, mustMintValueWithRedeemer,
-                                                                  mustPayToTheScript, mustSpendScriptOutput,
-                                                                  mustSpendScriptOutputWithMatchingDatumAndValue)
-import Ledger.Test (asDatum, asRedeemer, someAddress, someTypedValidator, someValidator, someValidatorHash)
+import Ledger.Constraints.OffChain qualified as Cons (MkTxError (NoMatchingOutputFound, TxOutRefWrongType),
+                                                      mintingPolicy, typedValidatorLookups, unspentOutputs)
+import Ledger.Constraints.OnChain.V1 qualified as Cons.V1
+import Ledger.Constraints.OnChain.V2 qualified as Cons.V2
+import Ledger.Constraints.TxConstraints qualified as Cons (mustMintValueWithRedeemer, mustPayToTheScript,
+                                                           mustSpendScriptOutput,
+                                                           mustSpendScriptOutputWithMatchingDatumAndValue)
+import Ledger.Test (asDatum, asRedeemer, someAddress, someTypedValidator, someValidatorHash)
 import Ledger.Tx qualified as Tx
-import Plutus.Contract as Con (Contract, ContractError (ConstraintResolutionContractError), Empty, awaitTxConfirmed,
-                               submitTxConstraintsWith, utxosAt)
+import Plutus.Contract as Cont (Contract, ContractError (ConstraintResolutionContractError), Empty, awaitTxConfirmed,
+                                submitTxConstraintsWith, utxosAt)
 import Plutus.Contract.Test (assertContractError, assertFailedTransaction, assertValidatedTransactionCount,
                              checkPredicateOptions, defaultCheckOptions, valueAtAddress, w1, (.&&.))
 import Plutus.Script.Utils.Scripts as PSU
-import Plutus.Script.Utils.Typed as PSU
 import Plutus.Script.Utils.V1.Scripts as PSU.V1 hiding (validatorHash)
 import Plutus.Script.Utils.V1.Typed.Scripts as PSU.V1
+import Plutus.Script.Utils.V2.Scripts as PSU.V2 hiding (validatorHash)
+import Plutus.Script.Utils.V2.Typed.Scripts as PSU.V2
 import Plutus.Trace qualified as Trace
 import Plutus.V1.Ledger.Api qualified as PV1
-import Plutus.V1.Ledger.Scripts (ScriptError (EvaluationError), ValidatorHash, unitRedeemer)
+import Plutus.V1.Ledger.Scripts (ScriptError (EvaluationError), unitRedeemer)
 import Plutus.V1.Ledger.Value qualified as Value
 import Plutus.V2.Ledger.Api qualified as PV2
 import PlutusTx qualified
@@ -50,41 +51,31 @@ tests =
         , validUseOfMustSpendScriptOutputUsingSomeScriptOutputs
         , contractErrorWhenMustSpendScriptOutputUsesWrongTxoOutRef
         , phase2ErrorWhenMustSpendScriptOutputUsesWrongTxoOutRef
-        , noPhase2ErrorWhenV1ScriptUsingMustSpendScriptOutputUsesWrongRedeemer
-        --, phase2ErrorWhenV2ScriptUsingMustSpendScriptOutputUsesWrongRedeemer
+        , phase2ErrorOnlyWhenMustSpendScriptOutputUsesWrongRedeemerWithV2Script
         , validUseOfMustSpendScriptOutputWithMatchingDatumAndValue
         , contractErrorWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongDatum
         , contractErrorWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongValue
         , phase2ErrorWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongDatum
         , phase2ErrorWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongValue
-        , noPhase2ErrorWhenV1ScriptUsingMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongRedeemer
-        --, phase2ErrorWhenV2ScriptUsingMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongRedeemer
+        , phase2ErrorOnlyWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongRedeemerWithV2Script
         ]
-
-data UnitTest
-instance PSU.ValidatorTypes UnitTest
 
 -- The value in each initial wallet UTxO
 utxoValue :: Value.Value
 utxoValue = Ada.lovelaceValueOf 10_000_000
 
-mustSpendScriptOutputTokenValue :: Value.Value
-mustSpendScriptOutputTokenValue = tokenValue mustSpendScriptOutputPolicyCurrencySymbolV1
-
-mustSpendScriptOutputWithMatchingDatumAndValueTokenValue :: Value.Value
-mustSpendScriptOutputWithMatchingDatumAndValueTokenValue = tokenValue mustSpendScriptOutputWithMatchingDatumAndValuePolicyCurrencySymbolV1
-
-tokenValue :: Value.CurrencySymbol -> Value.Value
-tokenValue cs = Value.singleton cs "A" 1
+tokenValue :: PSU.Versioned MintingPolicy -> Value.Value
+tokenValue mp = Value.singleton (PSU.scriptCurrencySymbol mp) "A" 1
 
 mustPayToTheScriptWithMultipleOutputs :: Integer -> [TxConstraints i P.BuiltinData] -> TxConstraints i P.BuiltinData
 mustPayToTheScriptWithMultipleOutputs 0 constraints = mconcat constraints
-mustPayToTheScriptWithMultipleOutputs n constraints = mustPayToTheScriptWithMultipleOutputs (n-1) (constraints ++ [Constraints.mustPayToTheScript (PlutusTx.toBuiltinData (n-1)) utxoValue])
+mustPayToTheScriptWithMultipleOutputs n constraints = mustPayToTheScriptWithMultipleOutputs (n-1) (constraints ++ [Cons.mustPayToTheScript (PlutusTx.toBuiltinData (n-1)) utxoValue])
 
 -- | Contract to create multiple outputs at script address and then uses mustSpendScriptOutputs constraint to spend some of the outputs each with unique datum
-mustSpendScriptOutputsContract :: Integer -> Integer -> Bool -> Contract () Empty ContractError ()
-mustSpendScriptOutputsContract nScriptOutputs nScriptOutputsToSpend withExpectedRedeemers = do
-    let lookups1 = Constraints.typedValidatorLookups someTypedValidator
+mustSpendScriptOutputsContract :: PSU.Language -> Integer -> Integer -> Bool -> Contract () Empty ContractError ()
+mustSpendScriptOutputsContract policyVersion nScriptOutputs nScriptOutputsToSpend withExpectedRedeemers = do
+    let versionedMintingPolicy = versionedMustSpendScriptOutputPolicy policyVersion
+        lookups1 = Cons.typedValidatorLookups someTypedValidator
         tx1 = mustPayToTheScriptWithMultipleOutputs nScriptOutputs []
     ledgerTx1 <- submitTxConstraintsWith lookups1 tx1
     awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx1
@@ -93,20 +84,21 @@ mustSpendScriptOutputsContract nScriptOutputs nScriptOutputsToSpend withExpected
     let scriptUtxosToSpend = M.keys $ M.take (fromIntegral nScriptOutputsToSpend) scriptUtxos
         expectedRedeemers = L.map (\(a :: Tx.TxOutRef) -> if withExpectedRedeemers then asRedeemer a else asRedeemer a{PV1.txOutRefIdx = PV1.txOutRefIdx a + 1}) scriptUtxosToSpend
         policyRedeemer = asRedeemer $ zip scriptUtxosToSpend expectedRedeemers
-        lookups2 = Constraints.typedValidatorLookups someTypedValidator
-                <> Constraints.plutusV1MintingPolicy mustSpendScriptOutputPolicyV1
-                <> Constraints.unspentOutputs scriptUtxos
+        lookups2 = Cons.typedValidatorLookups someTypedValidator
+                <> Cons.mintingPolicy versionedMintingPolicy
+                <> Cons.unspentOutputs scriptUtxos
         tx2 = mconcat (mustSpendScriptOutputs scriptUtxosToSpend)
-           <> Constraints.mustMintValueWithRedeemer policyRedeemer mustSpendScriptOutputTokenValue
+           <> Cons.mustMintValueWithRedeemer policyRedeemer (tokenValue versionedMintingPolicy)
     ledgerTx4 <- submitTxConstraintsWith lookups2 tx2
     awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx4
     where
         mustSpendScriptOutputs :: [Tx.TxOutRef] -> [TxConstraints P.BuiltinData P.BuiltinData]
-        mustSpendScriptOutputs scriptTxOutRefs = fmap (\txOutRef -> Constraints.mustSpendScriptOutput txOutRef (asRedeemer txOutRef)) scriptTxOutRefs
+        mustSpendScriptOutputs scriptTxOutRefs = fmap (\txOutRef -> Cons.mustSpendScriptOutput txOutRef (asRedeemer txOutRef)) scriptTxOutRefs
 
-mustSpendScriptOutputUsingWrongRedeemerContract :: Integer -> Contract () Empty ContractError ()
-mustSpendScriptOutputUsingWrongRedeemerContract nScriptOutputsToSpend = do
-    let lookups1 = Constraints.typedValidatorLookups someTypedValidator
+mustSpendScriptOutputUsingWrongRedeemerContract :: PSU.Language -> Integer -> Contract () Empty ContractError ()
+mustSpendScriptOutputUsingWrongRedeemerContract policyVersion nScriptOutputsToSpend = do
+    let versionedMintingPolicy = versionedMustSpendScriptOutputPolicy policyVersion
+        lookups1 = Cons.typedValidatorLookups someTypedValidator
         tx1 = mustPayToTheScriptWithMultipleOutputs nScriptOutputsToSpend []
     ledgerTx1 <- submitTxConstraintsWith lookups1 tx1
     awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx1
@@ -115,35 +107,36 @@ mustSpendScriptOutputUsingWrongRedeemerContract nScriptOutputsToSpend = do
     let scriptUtxo1 = fst $ M.elemAt 0 scriptUtxos
         scriptUtxo2 = fst $ M.elemAt 1 scriptUtxos
         policyRedeemer = asRedeemer [(scriptUtxo1, asRedeemer scriptUtxo2)]
-        lookups2 = Constraints.typedValidatorLookups someTypedValidator
-                <> Constraints.plutusV1MintingPolicy mustSpendScriptOutputPolicyV1
-                <> Constraints.unspentOutputs scriptUtxos
-        tx2 = Constraints.mustSpendScriptOutput scriptUtxo1 unitRedeemer
-            <> Constraints.mustMintValueWithRedeemer policyRedeemer mustSpendScriptOutputTokenValue
+        lookups2 = Cons.typedValidatorLookups someTypedValidator
+                <> Cons.mintingPolicy versionedMintingPolicy
+                <> Cons.unspentOutputs scriptUtxos
+        tx2 = Cons.mustSpendScriptOutput scriptUtxo1 unitRedeemer
+           <> Cons.mustMintValueWithRedeemer policyRedeemer (tokenValue versionedMintingPolicy)
     ledgerTx4 <- submitTxConstraintsWith lookups2 tx2
     awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx4
 
-mustSpendScriptOutputWithMatchingDatumAndValueContractWithRdmr :: Integer -> (Integer, Integer) -> (Value.Value, Value.Value) -> (Ledger.Redeemer, Ledger.Redeemer) -> Contract () Empty ContractError ()
-mustSpendScriptOutputWithMatchingDatumAndValueContractWithRdmr nScriptOutputs (offChainMatchingDatum, onChainMatchingDatum) (offChainMatchingValue, onChainMatchingValue) (spendingRedeemer, expectedSpendingRedeemer) = do
-    let lookups1 = Constraints.typedValidatorLookups someTypedValidator
+mustSpendScriptOutputWithMatchingDatumAndValueContractWithRdmr :: PSU.Language -> Integer -> (Integer, Integer) -> (Value.Value, Value.Value) -> (Ledger.Redeemer, Ledger.Redeemer) -> Contract () Empty ContractError ()
+mustSpendScriptOutputWithMatchingDatumAndValueContractWithRdmr policyVersion nScriptOutputs (offChainMatchingDatum, onChainMatchingDatum) (offChainMatchingValue, onChainMatchingValue) (spendingRedeemer, expectedSpendingRedeemer) = do
+    let versionedMintingPolicy = versionedMustSpendScriptOutputWithMatchingDatumAndValuePolicy policyVersion
+        lookups1 = Cons.typedValidatorLookups someTypedValidator
         tx1 = mustPayToTheScriptWithMultipleOutputs nScriptOutputs []
     ledgerTx1 <- submitTxConstraintsWith lookups1 tx1
     awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx1
 
     scriptUtxos <- utxosAt someAddress
     let policyRedeemer = asRedeemer [(someValidatorHash, onChainMatchingDatum, onChainMatchingValue, expectedSpendingRedeemer)]
-    let lookups2 = Constraints.typedValidatorLookups someTypedValidator
-                <> Constraints.plutusV1MintingPolicy mustSpendScriptOutputWithMatchingDatumAndValuePolicyV1
-                <> Constraints.unspentOutputs scriptUtxos
-        tx2 = Constraints.mustSpendScriptOutputWithMatchingDatumAndValue someValidatorHash (\d -> d == asDatum offChainMatchingDatum) (\v -> v == offChainMatchingValue) spendingRedeemer
-           <> Constraints.mustMintValueWithRedeemer policyRedeemer mustSpendScriptOutputWithMatchingDatumAndValueTokenValue
+    let lookups2 = Cons.typedValidatorLookups someTypedValidator
+                <> Cons.mintingPolicy versionedMintingPolicy
+                <> Cons.unspentOutputs scriptUtxos
+        tx2 = Cons.mustSpendScriptOutputWithMatchingDatumAndValue someValidatorHash (\d -> d == asDatum offChainMatchingDatum) (\v -> v == offChainMatchingValue) spendingRedeemer
+           <> Cons.mustMintValueWithRedeemer policyRedeemer (tokenValue versionedMintingPolicy)
     ledgerTx4 <- submitTxConstraintsWith lookups2 tx2
     awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx4
 
 -- | Contract to create multiple outputs at script address and then uses mustSpendScriptOutputWithMatchingDatumAndValue constraint to spend one of the outputs
-mustSpendScriptOutputWithMatchingDatumAndValueContract :: Integer -> (Integer, Integer) -> (Value.Value, Value.Value) -> Contract () Empty ContractError ()
-mustSpendScriptOutputWithMatchingDatumAndValueContract nScriptOutputs (offChainMatchingDatum, onChainMatchingDatum) (offChainMatchingValue, onChainMatchingValue) =
-    mustSpendScriptOutputWithMatchingDatumAndValueContractWithRdmr nScriptOutputs (offChainMatchingDatum, onChainMatchingDatum) (offChainMatchingValue, onChainMatchingValue) (asRedeemer @P.BuiltinByteString "R", asRedeemer @P.BuiltinByteString "R")
+mustSpendScriptOutputWithMatchingDatumAndValueContract :: PSU.Language -> Integer -> (Integer, Integer) -> (Value.Value, Value.Value) -> Contract () Empty ContractError ()
+mustSpendScriptOutputWithMatchingDatumAndValueContract policyVersion nScriptOutputs (offChainMatchingDatum, onChainMatchingDatum) (offChainMatchingValue, onChainMatchingValue) =
+    mustSpendScriptOutputWithMatchingDatumAndValueContractWithRdmr policyVersion nScriptOutputs (offChainMatchingDatum, onChainMatchingDatum) (offChainMatchingValue, onChainMatchingValue) (asRedeemer @P.BuiltinByteString "R", asRedeemer @P.BuiltinByteString "R")
 
 trace :: Contract () Empty ContractError () -> Trace.EmulatorTrace ()
 trace contract = do
@@ -158,7 +151,7 @@ validUseOfMustSpendScriptOutputUsingAllScriptOutputs =
     "Successful use of mustSpendScriptOutput for all script's UtxOs"
     (valueAtAddress someAddress (== Ada.lovelaceValueOf 0)
     .&&. assertValidatedTransactionCount 2)
-    (void $ trace $ mustSpendScriptOutputsContract 5 5 True)
+    (void $ trace $ mustSpendScriptOutputsContract PlutusV1 5 5 True)
 
 -- | Uses onchain and offchain constraint mustSpendScriptOutput to spend some of the UtxOs locked by the script
 validUseOfMustSpendScriptOutputUsingSomeScriptOutputs :: TestTree
@@ -168,13 +161,13 @@ validUseOfMustSpendScriptOutputUsingSomeScriptOutputs =
     "Successful use of mustSpendScriptOutput for some of the script's UtxOs"
     (valueAtAddress someAddress (== Value.scale 2 utxoValue)
     .&&. assertValidatedTransactionCount 2)
-    (void $ trace $ mustSpendScriptOutputsContract 5 3 True)
+    (void $ trace $ mustSpendScriptOutputsContract PlutusV1 5 3 True)
 
 -- | Contract error occurs when offchain mustSpendScriptOutput constraint is used with a UTxO belonging to the w1 pubkey address, not the script (not of type ScriptChainIndexTxOut).
 contractErrorWhenMustSpendScriptOutputUsesWrongTxoOutRef :: TestTree
 contractErrorWhenMustSpendScriptOutputUsesWrongTxoOutRef =
     let contract :: Contract () Empty ContractError () = do
-            let lookups1 = Constraints.typedValidatorLookups someTypedValidator
+            let lookups1 = Cons.typedValidatorLookups someTypedValidator
                 tx1 = mustPayToTheScriptWithMultipleOutputs 3 []
             ledgerTx1 <- submitTxConstraintsWith lookups1 tx1
             awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx1
@@ -182,24 +175,25 @@ contractErrorWhenMustSpendScriptOutputUsesWrongTxoOutRef =
             scriptUtxos <- utxosAt someAddress
             w1Utxos <- utxosAt (mockWalletAddress w1)
             let w1Utxo = fst $ M.elemAt 2 w1Utxos
-                lookups2 = Constraints.typedValidatorLookups someTypedValidator <>
-                    Constraints.unspentOutputs (scriptUtxos <> w1Utxos)
-                tx2 = Constraints.mustSpendScriptOutput w1Utxo unitRedeemer
+                lookups2 = Cons.typedValidatorLookups someTypedValidator <>
+                    Cons.unspentOutputs (scriptUtxos <> w1Utxos)
+                tx2 = Cons.mustSpendScriptOutput w1Utxo unitRedeemer
             ledgerTx4 <- submitTxConstraintsWith lookups2 tx2
             awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx4
 
     in checkPredicateOptions
         defaultCheckOptions
         "Contract error occurs when offchain mustSpendScriptOutput is used with a UTxO belonging to the w1 pubkey address, not the script."
-        (assertContractError contract (Trace.walletInstanceTag w1) (\case ConstraintResolutionContractError (Constraints.TxOutRefWrongType _) -> True; _ -> False) "failed to throw error"
+        (assertContractError contract (Trace.walletInstanceTag w1) (\case ConstraintResolutionContractError (Cons.TxOutRefWrongType _) -> True; _ -> False) "failed to throw error"
         .&&. assertValidatedTransactionCount 1)
         (void $ trace contract)
 
 -- | Phase-2 validation failure when onchain mustSpendScriptOutput constraint expects a different TxOutRef belonging to the script
 phase2ErrorWhenMustSpendScriptOutputUsesWrongTxoOutRef :: TestTree
 phase2ErrorWhenMustSpendScriptOutputUsesWrongTxoOutRef =
-    let contract :: Contract () Empty ContractError () = do
-            let lookups1 = Constraints.typedValidatorLookups someTypedValidator
+    let vMintingPolicy = Versioned mustSpendScriptOutputPolicyV1 PlutusV1
+        contract = do
+            let lookups1 = Cons.typedValidatorLookups someTypedValidator
                 tx1 = mustPayToTheScriptWithMultipleOutputs 3 []
             ledgerTx1 <- submitTxConstraintsWith lookups1 tx1
             awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx1
@@ -208,11 +202,11 @@ phase2ErrorWhenMustSpendScriptOutputUsesWrongTxoOutRef =
             let scriptUtxo1 = fst $ M.elemAt 0 scriptUtxos
                 scriptUtxo2 = fst $ M.elemAt 1 scriptUtxos
                 policyRedeemer = asRedeemer [(scriptUtxo2, asRedeemer scriptUtxo2)]
-                lookups2 = Constraints.typedValidatorLookups someTypedValidator
-                        <> Constraints.plutusV1MintingPolicy mustSpendScriptOutputPolicyV1
-                        <> Constraints.unspentOutputs scriptUtxos
-                tx2 = Constraints.mustSpendScriptOutput scriptUtxo1 unitRedeemer
-                   <> Constraints.mustMintValueWithRedeemer policyRedeemer mustSpendScriptOutputTokenValue
+                lookups2 = Cons.typedValidatorLookups someTypedValidator
+                        <> Cons.mintingPolicy vMintingPolicy
+                        <> Cons.unspentOutputs scriptUtxos
+                tx2 = Cons.mustSpendScriptOutput scriptUtxo1 unitRedeemer
+                   <> Cons.mustMintValueWithRedeemer policyRedeemer (tokenValue vMintingPolicy)
             ledgerTx4 <- submitTxConstraintsWith lookups2 tx2
             awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx4
 
@@ -222,42 +216,24 @@ phase2ErrorWhenMustSpendScriptOutputUsesWrongTxoOutRef =
         (assertFailedTransaction (\_ err _ -> case err of {Ledger.ScriptFailure (EvaluationError ("L8":_) _) -> True; _ -> False }))
         (void $ trace contract)
 
--- | No phase-2 validation failure when V1 script using onchain mustSpendScriptOutput constraint expects a different redeeemer (check is only V2+)
-noPhase2ErrorWhenV1ScriptUsingMustSpendScriptOutputUsesWrongRedeemer :: TestTree
-noPhase2ErrorWhenV1ScriptUsingMustSpendScriptOutputUsesWrongRedeemer =
-    checkPredicateOptions
-    defaultCheckOptions
-    "No phase-2 validation failure when V1 script using onchain mustSpendScriptOutput constraint expects a different redeemer"
-    (valueAtAddress someAddress (== Value.scale 2 utxoValue)
-    .&&. assertValidatedTransactionCount 2)
-    (void $ trace $ mustSpendScriptOutputUsingWrongRedeemerContract 3)
+-- | Phase-2 validation failure only when V2 script using onchain mustSpendScriptOutput constraint expects a different redeeemer with V2+ script
+phase2ErrorOnlyWhenMustSpendScriptOutputUsesWrongRedeemerWithV2Script :: TestTree
+phase2ErrorOnlyWhenMustSpendScriptOutputUsesWrongRedeemerWithV2Script =
+    testGroup "phase2 error only when mustSpendScriptOutput uses wrong redeemer with V2+ script"
 
--- | Phase-2 validation failure when V2 script using onchain mustSpendScriptOutput constraint expects a different redeeemer
--- phase2ErrorWhenV2MustSpendScriptOutputUsesWrongRedeemer :: TestTree
--- phase2ErrorWhenV2MustSpendScriptOutputUsesWrongRedeemer =
---     let contract :: Contract () Empty ContractError () = do
---             let lookups1 = Constraints.typedValidatorLookups someTypedValidator
---                 tx1 = mustPayToTheScriptWithMultipleOutputs 3 []
---             ledgerTx1 <- submitTxConstraintsWith lookups1 tx1
---             awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx1
+    [ checkPredicateOptions
+      defaultCheckOptions
+      "No phase-2 validation failure when V1 script using onchain mustSpendScriptOutput constraint expects a different redeemer"
+      (valueAtAddress someAddress (== Value.scale 2 utxoValue)
+      .&&. assertValidatedTransactionCount 2)
+      (void $ trace $ mustSpendScriptOutputUsingWrongRedeemerContract PlutusV1 3)
 
---             scriptUtxos <- utxosAt someAddress
---             let scriptUtxo1 = fst $ M.elemAt 0 scriptUtxos
---                 scriptUtxo2 = fst $ M.elemAt 1 scriptUtxos
---                 policyRedeemer = asRedeemer [(scriptUtxo1, asRedeemer scriptUtxo2)]
---                 lookups2 = Constraints.typedValidatorLookups someTypedValidator
---                         <> Constraints.plutusV1MintingPolicy mustSpendScriptOutputPolicyV1
---                         <> Constraints.unspentOutputs scriptUtxos
---                 tx2 = Constraints.mustSpendScriptOutput scriptUtxo1 unitRedeemer
---                    <> Constraints.mustMintValueWithRedeemer policyRedeemer mustSpendScriptOutputTokenValue
---             ledgerTx4 <- submitTxConstraintsWith lookups2 tx2
---             awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx4
-
---     in checkPredicateOptions
---         defaultCheckOptions
---         "Phase-2 validation failure when V2 script using onchain mustSpendScriptOutput constraint expects a different redeemer"
---         (assertFailedTransaction (\_ err _ -> case err of {Ledger.ScriptFailure (EvaluationError ("L8":_) _) -> True; _ -> False }))
---         (void $ trace contract)
+    , checkPredicateOptions
+      defaultCheckOptions
+      "Phase-2 validation failure when V2 script using onchain mustSpendScriptOutput constraint expects a different redeemer"
+      (assertFailedTransaction (\_ err _ -> case err of {Ledger.ScriptFailure (EvaluationError ("L8":_) _) -> True; _ -> False }))
+      (void $ trace $ mustSpendScriptOutputUsingWrongRedeemerContract PlutusV2 3)
+    ]
 
 -- | Uses onchain and offchain constraint mustSpendScriptOutputWithMatchingDatumAndValue to spend a UTxO locked by the script with matching datum and value
 validUseOfMustSpendScriptOutputWithMatchingDatumAndValue :: TestTree
@@ -269,18 +245,18 @@ validUseOfMustSpendScriptOutputWithMatchingDatumAndValue =
         "Successful use of mustSpendScriptOutputWithMatchingDatumAndValue to spend a UTxO locked by the script with matching datum and value"
         (valueAtAddress someAddress (== Value.scale 4 utxoValue)
         .&&. assertValidatedTransactionCount 2)
-        (void $ trace $ mustSpendScriptOutputWithMatchingDatumAndValueContract nScriptOutputs (scriptOutputIdx, scriptOutputIdx) (utxoValue, utxoValue))
+        (void $ trace $ mustSpendScriptOutputWithMatchingDatumAndValueContract PlutusV1 nScriptOutputs (scriptOutputIdx, scriptOutputIdx) (utxoValue, utxoValue))
 
 -- | Contract error occurs when offchain mustSpendScriptOutputWithMatchingDatumAndValue constraint is used with a datum that does not match with one of the script's UTxOs
 contractErrorWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongDatum :: TestTree
 contractErrorWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongDatum =
     let nScriptOutputs  = 5
         wrongDatum = nScriptOutputs -- value is greater than any datum at script address
-        contract = mustSpendScriptOutputWithMatchingDatumAndValueContract nScriptOutputs (wrongDatum, wrongDatum) (utxoValue, utxoValue)
+        contract = mustSpendScriptOutputWithMatchingDatumAndValueContract PlutusV1 nScriptOutputs (wrongDatum, wrongDatum) (utxoValue, utxoValue)
     in checkPredicateOptions
         defaultCheckOptions
         "Contract error occurs when offchain mustSpendScriptOutputWithMatchingDatumAndValue constraint is used with a datum that cannot be matched"
-        (assertContractError contract (Trace.walletInstanceTag w1) (\case ConstraintResolutionContractError (Constraints.NoMatchingOutputFound _) -> True; _ -> False) "failed to throw error"
+        (assertContractError contract (Trace.walletInstanceTag w1) (\case ConstraintResolutionContractError (Cons.NoMatchingOutputFound _) -> True; _ -> False) "failed to throw error"
         .&&. assertValidatedTransactionCount 1)
         (void $ trace contract)
 
@@ -290,15 +266,15 @@ contractErrorWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongValue =
     let nScriptOutputs  = 5
         scriptOutputIdx = nScriptOutputs - 1
         wrongValue = Ada.lovelaceValueOf (1 + (Ada.getLovelace $ Ada.fromValue utxoValue))
-        contract = mustSpendScriptOutputWithMatchingDatumAndValueContract nScriptOutputs (scriptOutputIdx, scriptOutputIdx) (wrongValue, wrongValue)
+        contract = mustSpendScriptOutputWithMatchingDatumAndValueContract PlutusV1 nScriptOutputs (scriptOutputIdx, scriptOutputIdx) (wrongValue, wrongValue)
     in checkPredicateOptions
         defaultCheckOptions
         "Contract error occurs when offchain mustSpendScriptOutputWithMatchingDatumAndValue constraint is used with a value that cannot be matched"
-        (assertContractError contract (Trace.walletInstanceTag w1) (\case ConstraintResolutionContractError (Constraints.NoMatchingOutputFound _) -> True; _ -> False) "failed to throw error"
+        (assertContractError contract (Trace.walletInstanceTag w1) (\case ConstraintResolutionContractError (Cons.NoMatchingOutputFound _) -> True; _ -> False) "failed to throw error"
         .&&. assertValidatedTransactionCount 1)
         (void $ trace contract)
 
--- | Phase-2 validation failure when onchain mustSpendScriptOutputWithMatchingDatumAndValue constraint expects a different Datum the tx input
+-- | Phase-2 validation failure when onchain mustSpendScriptOutputWithMatchingDatumAndValue constraint expects a different Datum
 phase2ErrorWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongDatum :: TestTree
 phase2ErrorWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongDatum =
     let nScriptOutputs  = 5
@@ -308,9 +284,9 @@ phase2ErrorWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongDatum =
         defaultCheckOptions
         "Phase-2 validation failure when onchain mustSpendScriptOutputWithMatchingDatumAndValue constraint expects a different TxOutRef"
         (assertFailedTransaction (\_ err _ -> case err of {Ledger.ScriptFailure (EvaluationError ("Le":_) _) -> True; _ -> False }))
-        (void $ trace $ mustSpendScriptOutputWithMatchingDatumAndValueContract nScriptOutputs (scriptOutputIdx, wrongDatum) (utxoValue, utxoValue))
+        (void $ trace $ mustSpendScriptOutputWithMatchingDatumAndValueContract PlutusV1 nScriptOutputs (scriptOutputIdx, wrongDatum) (utxoValue, utxoValue))
 
--- | Phase-2 validation failure when onchain mustSpendScriptOutputWithMatchingDatumAndValue constraint expects a different Value the tx input
+-- | Phase-2 validation failure when onchain mustSpendScriptOutputWithMatchingDatumAndValue constraint expects a different Value
 phase2ErrorWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongValue :: TestTree
 phase2ErrorWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongValue =
     let nScriptOutputs  = 5
@@ -320,44 +296,57 @@ phase2ErrorWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongValue =
         defaultCheckOptions
         "Phase-2 validation failure when onchain mustSpendScriptOutputWithMatchingDatumAndValue constraint expects a different TxOutRef"
         (assertFailedTransaction (\_ err _ -> case err of {Ledger.ScriptFailure (EvaluationError ("Le":_) _) -> True; _ -> False }))
-        (void $ trace $ mustSpendScriptOutputWithMatchingDatumAndValueContract nScriptOutputs (scriptOutputIdx, scriptOutputIdx) (utxoValue, wrongValue))
+        (void $ trace $ mustSpendScriptOutputWithMatchingDatumAndValueContract PlutusV1 nScriptOutputs (scriptOutputIdx, scriptOutputIdx) (utxoValue, wrongValue))
 
-noPhase2ErrorWhenV1ScriptUsingMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongRedeemer :: TestTree
-noPhase2ErrorWhenV1ScriptUsingMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongRedeemer =
+-- | Phase-2 validation failure only when onchain mustSpendScriptOutputWithMatchingDatumAndValue constraint expects a different Redeemer with V2+ script
+phase2ErrorOnlyWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongRedeemerWithV2Script :: TestTree
+phase2ErrorOnlyWhenMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongRedeemerWithV2Script =
     let nScriptOutputs  = 5
         scriptOutputIdx = nScriptOutputs - 1
         spendingRedeemer = asRedeemer @Integer 42
         policyRedeemer = asRedeemer @Integer 41
-    in checkPredicateOptions
-        defaultCheckOptions
-        "No phase-2 validation failure when V1 script using onchain mustSpendScriptOutputWithMatchingDatumAndValue constraint expects a different redeemer"
-        (valueAtAddress someAddress (== Value.scale 4 utxoValue)
-        .&&. assertValidatedTransactionCount 2)
-        (void $ trace $ mustSpendScriptOutputWithMatchingDatumAndValueContractWithRdmr nScriptOutputs (scriptOutputIdx, scriptOutputIdx) (utxoValue, utxoValue) (spendingRedeemer, policyRedeemer))
 
--- phase2ErrorWhenV1ScriptUsingMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongRedeemer :: TestTree
--- phase2ErrorWhenV1ScriptUsingMustSpendScriptOutputWithMatchingDatumAndValueUsesWrongRedeemer =
---     let nScriptOutputs  = 5
---         scriptOutputIdx = nScriptOutputs - 1
---         spendingRedeemer = asRedeemer @Integer 42
---         policyRedeemer = asRedeemer @Integer 41
---     in checkPredicateOptions
---         defaultCheckOptions
---         "Phase-2 validation failure when V2 script using onchain mustSpendScriptOutputWithMatchingDatumAndValue constraint expects a different redeemer"
---         (assertFailedTransaction (\_ err _ -> case err of {Ledger.ScriptFailure (EvaluationError ("Le":_) _) -> True; _ -> False }))
---         (void $ trace $ mustSpendScriptOutputWithMatchingDatumAndValueContractWithRdmr nScriptOutputs (scriptOutputIdx, scriptOutputIdx) (utxoValue, utxoValue) (spendingRedeemer, policyRedeemer))
+    in testGroup "phase2 error only when mustSpendScriptOutputWithMatchingDatumAndValue uses wrong redeemer with V2+ script"
+
+        [ checkPredicateOptions
+          defaultCheckOptions
+          "No phase-2 validation failure when V1 script using onchain mustSpendScriptOutputWithMatchingDatumAndValue constraint expects a different redeemer"
+          (valueAtAddress someAddress (== Value.scale 4 utxoValue)
+            .&&. assertValidatedTransactionCount 2)
+          (void $ trace $ mustSpendScriptOutputWithMatchingDatumAndValueContractWithRdmr PlutusV1 nScriptOutputs (scriptOutputIdx, scriptOutputIdx) (utxoValue, utxoValue) (spendingRedeemer, policyRedeemer))
+
+        , checkPredicateOptions
+          defaultCheckOptions
+          "Phase-2 validation failure when V2 script using onchain mustSpendScriptOutputWithMatchingDatumAndValue constraint expects a different redeemer"
+          (assertFailedTransaction (\_ err _ -> case err of {Ledger.ScriptFailure (EvaluationError ("Le":_) _) -> True; _ -> False }))
+          (void $ trace $ mustSpendScriptOutputWithMatchingDatumAndValueContractWithRdmr PlutusV2 nScriptOutputs (scriptOutputIdx, scriptOutputIdx) (utxoValue, utxoValue) (spendingRedeemer, policyRedeemer))
+        ]
 
 {-
-   Plutus V1 Policies
+    Versioned Policies
+-}
+
+versionedMustSpendScriptOutputPolicy :: PSU.Language -> PSU.Versioned PV1.MintingPolicy
+versionedMustSpendScriptOutputPolicy l = case l of
+    PlutusV1 -> Versioned mustSpendScriptOutputPolicyV1 PlutusV1
+    PlutusV2 -> Versioned mustSpendScriptOutputPolicyV2 PlutusV2
+
+versionedMustSpendScriptOutputWithMatchingDatumAndValuePolicy :: PSU.Language -> PSU.Versioned PV1.MintingPolicy
+versionedMustSpendScriptOutputWithMatchingDatumAndValuePolicy l = case l of
+    PlutusV1 -> Versioned mustSpendScriptOutputWithMatchingDatumAndValuePolicyV1 PlutusV1
+    PlutusV2 -> Versioned mustSpendScriptOutputWithMatchingDatumAndValuePolicyV2 PlutusV2
+
+{-
+    V1 Policies
 -}
 
 {-# INLINEABLE mkMustSpendScriptOutputPolicyV1 #-}
 mkMustSpendScriptOutputPolicyV1 :: [(Tx.TxOutRef,  Redeemer)] -> PV1.ScriptContext -> Bool
-mkMustSpendScriptOutputPolicyV1 constraintParams ctx = P.traceIfFalse "mustSpendScriptOutput not satisfied" (Constraints.checkScriptContext @() @() (P.mconcat mustSpendScriptOutputs) ctx)
+mkMustSpendScriptOutputPolicyV1 constraintParams ctx = P.traceIfFalse "mustSpendScriptOutput not satisfied" (Cons.V1.checkScriptContext @() @() (P.mconcat mustSpendScriptOutputs) ctx)
     where
-        mustSpendScriptOutputs = P.map (\(txOutRef, redeemer) -> Constraints.mustSpendScriptOutput txOutRef redeemer) constraintParams
+        mustSpendScriptOutputs = P.map (\(txOutRef, redeemer) -> Cons.mustSpendScriptOutput txOutRef redeemer) constraintParams
 
-mustSpendScriptOutputPolicyV1 :: PSU.V1.MintingPolicy
+mustSpendScriptOutputPolicyV1 :: PV1.MintingPolicy
 mustSpendScriptOutputPolicyV1 = PV1.mkMintingPolicyScript $$(PlutusTx.compile [||wrap||])
     where
         wrap = PSU.V1.mkUntypedMintingPolicy mkMustSpendScriptOutputPolicyV1
@@ -373,12 +362,12 @@ mustSpendScriptOutputPolicyCurrencySymbolV1 = Value.mpsSymbol mustSpendScriptOut
 
 {-# INLINEABLE mkMustSpendScriptOutputWithMatchingDatumAndValuePolicyV1 #-}
 mkMustSpendScriptOutputWithMatchingDatumAndValuePolicyV1 :: [(ValidatorHash, Ledger.Datum, Value.Value, Ledger.Redeemer)] -> PV1.ScriptContext -> Bool
-mkMustSpendScriptOutputWithMatchingDatumAndValuePolicyV1 constraintParams ctx = P.traceIfFalse "mustSpendScriptOutputWithMatchingDatumAndValue not satisfied" (Constraints.checkScriptContext @() @() (P.mconcat mustSpendScriptOutputsWithMatchingDatumAndValue) ctx)
+mkMustSpendScriptOutputWithMatchingDatumAndValuePolicyV1 constraintParams ctx = P.traceIfFalse "mustSpendScriptOutputWithMatchingDatumAndValue not satisfied" (Cons.V1.checkScriptContext @() @() (P.mconcat mustSpendScriptOutputsWithMatchingDatumAndValue) ctx)
     where
         mustSpendScriptOutputsWithMatchingDatumAndValue = P.map (\(vh, datum, value, redeemer) ->
-            Constraints.mustSpendScriptOutputWithMatchingDatumAndValue vh (\d -> d P.== datum) (\v -> v P.==  value) redeemer) constraintParams
+            Cons.mustSpendScriptOutputWithMatchingDatumAndValue vh (\d -> d P.== datum) (\v -> v P.==  value) redeemer) constraintParams
 
-mustSpendScriptOutputWithMatchingDatumAndValuePolicyV1 :: PSU.V1.MintingPolicy
+mustSpendScriptOutputWithMatchingDatumAndValuePolicyV1 :: PV1.MintingPolicy
 mustSpendScriptOutputWithMatchingDatumAndValuePolicyV1 = PV1.mkMintingPolicyScript $$(PlutusTx.compile [||wrap||])
     where
         wrap = PSU.V1.mkUntypedMintingPolicy mkMustSpendScriptOutputWithMatchingDatumAndValuePolicyV1
@@ -390,5 +379,43 @@ mustSpendScriptOutputWithMatchingDatumAndValuePolicyCurrencySymbolV1 :: Value.Cu
 mustSpendScriptOutputWithMatchingDatumAndValuePolicyCurrencySymbolV1 = Value.mpsSymbol mustSpendScriptOutputWithMatchingDatumAndValuePolicyHashV1
 
 {-
-   Plutus V2 Policies
+    V2 Policies
 -}
+
+{-# INLINEABLE mkMustSpendScriptOutputPolicyV2 #-}
+mkMustSpendScriptOutputPolicyV2 :: [(Tx.TxOutRef,  Redeemer)] -> PV2.ScriptContext -> Bool
+mkMustSpendScriptOutputPolicyV2 constraintParams ctx = P.traceIfFalse "mustSpendScriptOutput not satisfied" (Cons.V2.checkScriptContext @() @() (P.mconcat mustSpendScriptOutputs) ctx)
+    where
+        mustSpendScriptOutputs = P.map (\(txOutRef, redeemer) -> Cons.mustSpendScriptOutput txOutRef redeemer) constraintParams
+
+mustSpendScriptOutputPolicyV2 :: PV2.MintingPolicy
+mustSpendScriptOutputPolicyV2 = PV2.mkMintingPolicyScript $$(PlutusTx.compile [||wrap||])
+    where
+        wrap = PSU.V2.mkUntypedMintingPolicy mkMustSpendScriptOutputPolicyV2
+
+mustSpendScriptOutputPolicyHashV2 :: Ledger.MintingPolicyHash
+mustSpendScriptOutputPolicyHashV2 = PSU.V2.mintingPolicyHash mustSpendScriptOutputPolicyV2
+
+mustSpendScriptOutputPolicyCurrencySymbolV2 :: Value.CurrencySymbol
+mustSpendScriptOutputPolicyCurrencySymbolV2 = Value.mpsSymbol mustSpendScriptOutputPolicyHashV2
+
+
+-----
+
+{-# INLINEABLE mkMustSpendScriptOutputWithMatchingDatumAndValuePolicyV2 #-}
+mkMustSpendScriptOutputWithMatchingDatumAndValuePolicyV2 :: [(ValidatorHash, Ledger.Datum, Value.Value, Ledger.Redeemer)] -> PV2.ScriptContext -> Bool
+mkMustSpendScriptOutputWithMatchingDatumAndValuePolicyV2 constraintParams ctx = P.traceIfFalse "mustSpendScriptOutputWithMatchingDatumAndValue not satisfied" (Cons.V2.checkScriptContext @() @() (P.mconcat mustSpendScriptOutputsWithMatchingDatumAndValue) ctx)
+    where
+        mustSpendScriptOutputsWithMatchingDatumAndValue = P.map (\(vh, datum, value, redeemer) ->
+            Cons.mustSpendScriptOutputWithMatchingDatumAndValue vh (\d -> d P.== datum) (\v -> v P.==  value) redeemer) constraintParams
+
+mustSpendScriptOutputWithMatchingDatumAndValuePolicyV2 :: PSU.V2.MintingPolicy
+mustSpendScriptOutputWithMatchingDatumAndValuePolicyV2 = PV2.mkMintingPolicyScript $$(PlutusTx.compile [||wrap||])
+    where
+        wrap = PSU.V2.mkUntypedMintingPolicy mkMustSpendScriptOutputWithMatchingDatumAndValuePolicyV2
+
+mustSpendScriptOutputWithMatchingDatumAndValuePolicyHashV2 :: Ledger.MintingPolicyHash
+mustSpendScriptOutputWithMatchingDatumAndValuePolicyHashV2 = PSU.V2.mintingPolicyHash mustSpendScriptOutputWithMatchingDatumAndValuePolicyV2
+
+mustSpendScriptOutputWithMatchingDatumAndValuePolicyCurrencySymbolV2 :: Value.CurrencySymbol
+mustSpendScriptOutputWithMatchingDatumAndValuePolicyCurrencySymbolV2 = Value.mpsSymbol mustSpendScriptOutputWithMatchingDatumAndValuePolicyHashV2

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OnChain/V2.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OnChain/V2.hs
@@ -30,7 +30,7 @@ import Plutus.Script.Utils.V2.Contexts qualified as PV2 hiding (findTxInByTxOutR
 import Plutus.V1.Ledger.Address (Address (Address))
 import Plutus.V1.Ledger.Interval (contains)
 import Plutus.V1.Ledger.Value (leq)
-import Plutus.V2.Ledger.Contexts (ScriptContext (ScriptContext, scriptContextTxInfo),
+import Plutus.V2.Ledger.Contexts (ScriptContext (ScriptContext, scriptContextTxInfo), ScriptPurpose (Spending),
                                   TxInInfo (TxInInfo, txInInfoOutRef, txInInfoResolved),
                                   TxInfo (txInfoData, txInfoInputs, txInfoMint, txInfoRedeemers, txInfoValidRange),
                                   TxOut (TxOut, txOutAddress, txOutDatum, txOutValue))
@@ -38,8 +38,13 @@ import Plutus.V2.Ledger.Contexts qualified as PV2
 import Plutus.V2.Ledger.Tx (OutputDatum (NoOutputDatum, OutputDatum, OutputDatumHash))
 import PlutusTx (ToData (toBuiltinData))
 import PlutusTx.AssocMap qualified as AMap
-import PlutusTx.Prelude (AdditiveSemigroup ((+)), Bool (False, True), Eq ((==)), Maybe (Just, Nothing),
-                         Ord ((<=), (>=)), all, any, elem, isJust, maybe, traceIfFalse, ($), (&&), (.), (>>))
+import PlutusTx.Prelude (AdditiveSemigroup ((+)), Bool (False, True), BuiltinString, Eq ((==)), Maybe (Just, Nothing),
+                         Ord ((<=), (>=)), all, any, elem, isJust, maybe, traceError, traceIfFalse, ($), (&&), (.),
+                         (>>))
+
+fromJust' :: BuiltinString -> Maybe a -> a
+fromJust' err Nothing = traceError err
+fromJust' _ (Just x)  = x
 
 {-# INLINABLE checkScriptContext #-}
 -- | Does the 'ScriptContext' satisfy the constraints?
@@ -108,7 +113,7 @@ checkTxConstraint ctx@ScriptContext{scriptContextTxInfo} = \case
         $ maybe False (isNoOutputDatum . txOutDatum . txInInfoResolved) (PV2.findTxInByTxOutRef txOutRef scriptContextTxInfo)
     MustSpendScriptOutput txOutRef rdmr ->
         traceIfFalse "L8" -- "Script output not spent"
-        $ rdmr `elem` (txInfoRedeemers scriptContextTxInfo)
+        $ rdmr == fromJust' "L8" (AMap.lookup (Spending txOutRef) (txInfoRedeemers scriptContextTxInfo))
         && isJust (PV2.findTxInByTxOutRef txOutRef scriptContextTxInfo)
     MustMintValue mps _ tn v ->
         traceIfFalse "L9" -- "Value minted not OK"
@@ -162,10 +167,11 @@ checkTxConstraintFun ScriptContext{scriptContextTxInfo} = \case
         let findDatum NoOutputDatum        = Nothing
             findDatum (OutputDatumHash dh) = PV2.findDatum dh scriptContextTxInfo
             findDatum (OutputDatum d)      = PV2.findDatumHash d scriptContextTxInfo >> Just d
-            isMatch (TxOut (Ledger.Address (ScriptCredential vh') _) val (findDatum -> Just d) _refScript) =
+            txOutIsMatch (TxOut (Ledger.Address (ScriptCredential vh') _) val (findDatum -> Just d) _refScript) =
                 vh == vh' && valuePred val && datumPred d
-            isMatch _ = False
+            txOutIsMatch _ = False
+            rdmrIsMatch txOutRef = rdmr == fromJust' "Le" (AMap.lookup (Spending txOutRef) (txInfoRedeemers scriptContextTxInfo))
         in
         traceIfFalse "Le" -- "MustSpendScriptOutputWithMatchingDatumAndValue"
-        $ any (isMatch . txInInfoResolved) (txInfoInputs scriptContextTxInfo)
-        && rdmr `elem` (txInfoRedeemers scriptContextTxInfo)
+        $ any (txOutIsMatch . txInInfoResolved) (txInfoInputs scriptContextTxInfo)
+        && any (rdmrIsMatch . txInInfoOutRef) (txInfoInputs scriptContextTxInfo)

--- a/plutus-ledger/src/Ledger/Test.hs
+++ b/plutus-ledger/src/Ledger/Test.hs
@@ -3,9 +3,12 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
 module Ledger.Test where
 
 import Ledger qualified
+import Ledger.Typed.Scripts qualified as Scripts
+import Plutus.Script.Utils.Typed as PSU
 import Plutus.Script.Utils.V1.Scripts qualified as PV1
 import Plutus.Script.Utils.V1.Typed.Scripts.MonetaryPolicies qualified as MPS
 import Plutus.V1.Ledger.Api (Address, CurrencySymbol (CurrencySymbol), ToData (toBuiltinData),
@@ -22,6 +25,9 @@ someValidatorHash = PV1.validatorHash someValidator
 
 someValidator :: Validator
 someValidator = Ledger.mkValidatorScript $$(PlutusTx.compile [|| \(_ :: PlutusTx.BuiltinData) (_ :: PlutusTx.BuiltinData) (_ :: PlutusTx.BuiltinData) -> () ||])
+
+someTypedValidator :: Scripts.TypedValidator Any
+someTypedValidator = Scripts.unsafeMkTypedValidator someValidator
 
 {-# INLINABLE mkPolicy #-}
 mkPolicy :: () -> Ledger.ScriptContext -> Bool


### PR DESCRIPTION
- Improved onchain Redeemer check for MustSpendScriptOutput and MustSpendScriptOutputWithMatchingDatumAndValue constraints
- Fixed some MustSpendScriptOutput constraint tests that were reporting false-positives
- Added additional scenarios including V2 scripts in tests for checking Redeemer with MustSpendScriptOutput
- Using versioned minting policies instead of validators for MustSpendScriptOutput tests