### PR TITLE
PLT-1035 Fix an off by one error in Prism test preconditions

### DIFF
--- a/plutus-use-cases/test/Spec/Prism.hs
+++ b/plutus-use-cases/test/Spec/Prism.hs
@@ -157,7 +157,7 @@ instance ContractModel PrismModel where
     instanceContract _ UserH{} _ = C.subscribeSTO
 
     precondition s (Issue w) = (s ^. contractState . isIssued w) /= Issued  -- Multiple Issue (without Revoke) breaks the contract
-    precondition s (Call _)  = (s ^. contractState . numberOfCalls < 11) -- We have to limit the number of calls otherwise fails with non-ada collateral error.
+    precondition s (Call _)  = s ^. contractState . numberOfCalls < 10 -- We have to limit the number of calls otherwise fails with non-ada collateral error.
     precondition _ _         = True
 
     nextState cmd = do
@@ -214,7 +214,5 @@ tests = testGroup "PRISM"
         .&&. walletFundsChange user (Ada.lovelaceValueOf (negate numTokens) <> STO.coins stoData numTokens)
         )
         prismTrace
-    -- TODO: Linked to https://github.com/input-output-hk/plutus-apps/issues/760
-    -- Re-activate once issue is resolved
-    -- , testProperty "QuickCheck property" prop_Prism
+    , testProperty "QuickCheck property" prop_Prism
     ]

--- a/plutus-use-cases/test/Spec/Prism.hs
+++ b/plutus-use-cases/test/Spec/Prism.hs
@@ -29,6 +29,7 @@ import Plutus.Contract.Test.ContractModel as ContractModel
 
 import Test.QuickCheck as QC hiding ((.&&.))
 import Test.Tasty
+import Test.Tasty.QuickCheck (testProperty)
 
 import Plutus.Contracts.Prism hiding (mirror)
 import Plutus.Contracts.Prism.Credential qualified as Credential

--- a/plutus-use-cases/test/Spec/Prism.hs
+++ b/plutus-use-cases/test/Spec/Prism.hs
@@ -192,8 +192,8 @@ instance ContractModel PrismModel where
 
 finalPredicate :: ModelState PrismModel -> TracePredicate
 finalPredicate _ =
-    assertNotDone @_ @() @C.STOSubscriberSchema     C.subscribeSTO      (Trace.walletInstanceTag user)              "User stopped"               .&&.
-    assertNotDone @_ @() @C.MirrorSchema            C.mirror            (Trace.walletInstanceTag mirror)            "Mirror stopped"
+       assertNotDone @_ @() @C.STOSubscriberSchema C.subscribeSTO (Trace.walletInstanceTag user) "User stopped"
+  .&&. assertNotDone @_ @() @C.MirrorSchema C.mirror (Trace.walletInstanceTag mirror) "Mirror stopped"
 
 
 


### PR DESCRIPTION
Fix #760.

It was an off by one error, successfully passed the property check with 200 tests.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [] Reviewer requested
