### PR TITLE
PLT-989 Improve behaviour of duplicated `MustSpend`

### DIFF
--- a/plutus-contract/test/Spec/TxConstraints/MustSpendPubKeyOutput.hs
+++ b/plutus-contract/test/Spec/TxConstraints/MustSpendPubKeyOutput.hs
@@ -45,7 +45,6 @@ tests =
         , mustSpendRemainingInitialUtxosFromOwnWallet
         , mustSpendSingleUtxoFromOtherWallet
         , mustSpendAllUtxosFromOtherWallet
-        , mustSpendTwiceTheSameUtxoIsOk
         , contractErrorWhenAttemptingToSpendNonExistentOutput
         , phase2FailureWhenTxoIsNotSpent
         ]

--- a/plutus-contract/test/Spec/TxConstraints/MustSpendPubKeyOutput.hs
+++ b/plutus-contract/test/Spec/TxConstraints/MustSpendPubKeyOutput.hs
@@ -45,6 +45,7 @@ tests =
         , mustSpendRemainingInitialUtxosFromOwnWallet
         , mustSpendSingleUtxoFromOtherWallet
         , mustSpendAllUtxosFromOtherWallet
+        , mustSpendTwiceTheSameUtxoIsOk
         , contractErrorWhenAttemptingToSpendNonExistentOutput
         , phase2FailureWhenTxoIsNotSpent
         ]
@@ -107,6 +108,8 @@ mustSpendSingleUtxoFromOwnWallet =
             let w1TxoRefs = txoRefsFromWalletState w1State
                 w1MiddleTxoRef = [S.elemAt (length w1TxoRefs `div` 2) w1TxoRefs]
             void $ Trace.activateContractWallet w1 $ mustSpendPubKeyOutputContract w1MiddleTxoRef w1MiddleTxoRef w1PaymentPubKeyHash
+                overridedW1TxoRefs = overrideW1TxOutRefs w1MiddleTxoRef -- need to override index due to bug 695
+            void $ Trace.activateContractWallet w1 $ mustSpendPubKeyOutputContract overridedW1TxoRefs overridedW1TxoRefs w1PaymentPubKeyHash
             void Trace.nextSlot
 
     in checkPredicate "Successful use of mustSpendPubKeyOutput with a single txOutRef from own wallet"

--- a/plutus-contract/test/Spec/TxConstraints/MustSpendPubKeyOutput.hs
+++ b/plutus-contract/test/Spec/TxConstraints/MustSpendPubKeyOutput.hs
@@ -107,8 +107,6 @@ mustSpendSingleUtxoFromOwnWallet =
             let w1TxoRefs = txoRefsFromWalletState w1State
                 w1MiddleTxoRef = [S.elemAt (length w1TxoRefs `div` 2) w1TxoRefs]
             void $ Trace.activateContractWallet w1 $ mustSpendPubKeyOutputContract w1MiddleTxoRef w1MiddleTxoRef w1PaymentPubKeyHash
-                overridedW1TxoRefs = overrideW1TxOutRefs w1MiddleTxoRef -- need to override index due to bug 695
-            void $ Trace.activateContractWallet w1 $ mustSpendPubKeyOutputContract overridedW1TxoRefs overridedW1TxoRefs w1PaymentPubKeyHash
             void Trace.nextSlot
 
     in checkPredicate "Successful use of mustSpendPubKeyOutput with a single txOutRef from own wallet"

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -435,7 +435,14 @@ mkSomeTx xs =
         $ execStateT (traverse process xs) initialState
 
 -- | Filtering MustSpend constraints to ensure their consistency and check that we do not try to spend them
--- with different redeemer or reference scripts
+-- with different redeemer or reference scripts.
+--
+-- When:
+--     - 2 or more MustSpendPubkeyOutput are defined for the same output, we only keep the first one
+--     - 2 or more MustSpendScriptOutpt are defined for the same output:
+--          - if they have different redeemer, we throw an 'AmbiguousRedeemer' error;
+--          - if they provide more than one reference script we throw an 'AmbiguousReferenceScript' error;
+--          - if only one define a reference script, we use that reference script.
 cleaningMustSpendConstraints :: MonadError MkTxError m => [TxConstraint] -> m [TxConstraint]
 cleaningMustSpendConstraints (x@(MustSpendScriptOutput t _ _):xs) = do
     let

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -972,5 +972,5 @@ instance Pretty MkTxError where
         NoMatchingOutputFound h        -> "No matching output found for validator hash" <+> pretty h
         MultipleMatchingOutputsFound h -> "Multiple matching outputs found for validator hash" <+> pretty h
         AmbiguousRedeemer t rs         -> "Try to spend a script output" <+> pretty t <+> "with different redeemers:" <+> pretty rs
-        AmbiguousReferenceScript t rss  -> "Try to spend a script output" <+> pretty t <+> "with different referenceScript:" <+> pretty rss
+        AmbiguousReferenceScript t rss -> "Try to spend a script output" <+> pretty t <+> "with different referenceScript:" <+> pretty rss
 

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -81,6 +81,7 @@ module Ledger.Constraints.OffChain(
     , lookupTxOutRef
     , lookupScript
     , lookupScriptAsReferenceScript
+    , prepareConstraints
     , resolveScriptTxOut
     , resolveScriptTxOutValidator
     , resolveScriptTxOutDatumAndValue
@@ -463,9 +464,7 @@ cleaningMustSpendConstraints (x:xs) = (x :) <$> cleaningMustSpendConstraints xs
 
 
 prepareConstraints
-    :: ( FromData (DatumType a)
-       , ToData (DatumType a)
-       , ToData (RedeemerType a)
+    :: ( ToData (DatumType a)
        , MonadReader (ScriptLookups a) m
        , MonadError MkTxError m
        )

--- a/plutus-ledger-constraints/src/Ledger/Constraints/TxConstraints.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/TxConstraints.hs
@@ -697,6 +697,9 @@ mustProduceAtLeast = singleton . MustProduceAtLeast
 -- the 'Ledger.Constraints.OffChain.ScriptLookups' with
 -- 'Ledger.Constraints.OffChain.unspentOutputs'.
 --
+-- If several calls to 'mustSpendPubKeyOutput' are performed for the same 'TxOutRef',
+-- only one instance of the constraint is kept when the transaction is created.
+--
 -- If used in 'Ledger.Constraints.OnChain', this constraint verifies that the
 -- transaction spends this @utxo@.
 mustSpendPubKeyOutput :: forall i o. TxOutRef -> TxConstraints i o
@@ -714,6 +717,11 @@ mustSpendPubKeyOutput = singleton . MustSpendPubKeyOutput
 -- 'Ledger.Constraints.OffChain.unspentOutputs' or through
 -- 'Ledger.Constraints.OffChain.otherData'.
 --
+-- If several calls to 'mustSpendScriptOutput' are performed for the same 'TxOutRef',
+-- if the two constraints have different redeemers, an error will be thrown when the transaction will be submitted.
+-- Otherwise, only one instance of the constraint is kept.
+-- If combine with 'mustSpendScriptOutputWithReference' for the same 'TxOutRef', see 'mustSpendScriptOutputWithReference'.
+--
 -- If used in 'Ledger.Constraints.OnChain', this constraint verifies that the
 -- transaction spends this @utxo@.
 mustSpendScriptOutput :: forall i o. TxOutRef -> Redeemer -> TxConstraints i o
@@ -730,6 +738,17 @@ mustSpendScriptOutput txOutref red = singleton $ MustSpendScriptOutput txOutref 
 -- 'Ledger.Constraints.OffChain.unspentOutputs'. The datum must be either provided by
 -- 'Ledger.Constraints.OffChain.unspentOutputs' or through
 -- 'Ledger.Constraints.OffChain.otherData'.
+--
+-- If several calls to 'mustSpendScriptOutputWithReference' are performed for the same 'TxOutRef',
+-- if the two constraints have different redeemers,
+-- or if the two constraints use a different 'TxOutRef' as a TxOutRef, an error will be thrown when the transaction will
+-- be submitted.
+-- Otherwise, only one instance of the constraint is kept.
+--
+-- If combined with 'mustSpendScriptOutput' for the same 'TxOutRef', an error is throw if they have a different
+-- redeemer.
+-- Otherwise, only one instance of the 'mustSpendScriptOutputWithReference' constraint is kept, the
+-- 'mustSpendScriptOutput' constraints are ignored.
 --
 -- If used in 'Ledger.Constraints.OnChain', this constraint verifies that the
 -- transaction spends this @utxo@.

--- a/plutus-ledger-constraints/src/Ledger/Constraints/TxConstraints.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/TxConstraints.hs
@@ -718,7 +718,7 @@ mustSpendPubKeyOutput = singleton . MustSpendPubKeyOutput
 -- 'Ledger.Constraints.OffChain.otherData'.
 --
 -- If several calls to 'mustSpendScriptOutput' are performed for the same 'TxOutRef',
--- if the two constraints have different redeemers, an error will be thrown when the transaction will be submitted.
+-- if the two constraints have different redeemers, an error will be thrown when the transaction is created.
 -- Otherwise, only one instance of the constraint is kept.
 -- If combined with 'mustSpendScriptOutputWithReference' for the same 'TxOutRef', see 'mustSpendScriptOutputWithReference'.
 --
@@ -741,8 +741,8 @@ mustSpendScriptOutput txOutref red = singleton $ MustSpendScriptOutput txOutref 
 --
 -- If several calls to 'mustSpendScriptOutputWithReference' are performed for the same 'TxOutRef',
 -- if the two constraints have different redeemers,
--- or if the two constraints use a different 'TxOutRef' as a TxOutRef, an error will be thrown when the transaction will
--- be submitted.
+-- or if the two constraints use a different 'TxOutRef' as a TxOutRef, an error will be thrown when the transaction is
+-- created.
 -- Otherwise, only one instance of the constraint is kept.
 --
 -- If combined with 'mustSpendScriptOutput' for the same 'TxOutRef', an error is throw if they have a different
@@ -761,8 +761,8 @@ mustSpendScriptOutputWithReference txOutref red refTxOutref =
 -- must spend an output locked by the given validator script hash,
 -- which includes a @Datum@ that matches the given datum predicate and a @Value@ that matches the given value predicate.
 --
--- If used in 'Ledger.Constraints.OffChain', this constraint checks that there's exactly one output that matches the requirements,
--- and then adds this as an input to the transaction with the given redeemer.
+-- If used in 'Ledger.Constraints.OffChain', this constraint checks that there's exactly one output that matches the
+-- requirements, and then adds this as an input to the transaction with the given redeemer.
 --
 -- The outputs that will be considered need to be privided in the 'Ledger.Constraints.OffChain.ScriptLookups' with
 -- 'Ledger.Constraints.OffChain.unspentOutputs'.

--- a/plutus-ledger-constraints/src/Ledger/Constraints/TxConstraints.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/TxConstraints.hs
@@ -720,7 +720,7 @@ mustSpendPubKeyOutput = singleton . MustSpendPubKeyOutput
 -- If several calls to 'mustSpendScriptOutput' are performed for the same 'TxOutRef',
 -- if the two constraints have different redeemers, an error will be thrown when the transaction will be submitted.
 -- Otherwise, only one instance of the constraint is kept.
--- If combine with 'mustSpendScriptOutputWithReference' for the same 'TxOutRef', see 'mustSpendScriptOutputWithReference'.
+-- If combined with 'mustSpendScriptOutputWithReference' for the same 'TxOutRef', see 'mustSpendScriptOutputWithReference'.
 --
 -- If used in 'Ledger.Constraints.OnChain', this constraint verifies that the
 -- transaction spends this @utxo@.

--- a/plutus-ledger-constraints/test/Spec.hs
+++ b/plutus-ledger-constraints/test/Spec.hs
@@ -213,11 +213,11 @@ txOut1 =
         Nothing
         (validatorHash1, Nothing)
 
-txOutRef1 :: Ledger.TxOutRef
-txOutRef1 = Ledger.TxOutRef (Ledger.TxId "") 1
+txOutRef :: Integer -> Ledger.TxOutRef
+txOutRef = Ledger.TxOutRef (Ledger.TxId "")
 
 utxo1 :: Map.Map Ledger.TxOutRef Ledger.ChainIndexTxOut
-utxo1 = Map.fromList [(txOutRef0, txOut0), (txOutRef1, txOut1)]
+utxo1 = Map.fromList [(txOutRef0, txOut0), (txOutRef 1, txOut1)]
 
 {-# INLINABLE constraints1 #-}
 constraints1 :: Ledger.ValidatorHash -> Constraints.TxConstraints () ()
@@ -227,7 +227,7 @@ constraints1 vh =
         (Pl.== Ledger.unitDatum)
         (Pl.const True)
         Ledger.unitRedeemer
-    <> Constraints.mustSpendScriptOutput txOutRef1 Ledger.unitRedeemer
+    <> Constraints.mustSpendScriptOutput (txOutRef 1) Ledger.unitRedeemer
 
 lookups1 :: Constraints.ScriptLookups UnitTest
 lookups1

--- a/plutus-ledger-constraints/test/Spec.hs
+++ b/plutus-ledger-constraints/test/Spec.hs
@@ -9,8 +9,9 @@ module Main(main) where
 
 import Control.Lens (toListOf, view)
 import Control.Monad (forM_, guard, replicateM, void)
+import Control.Monad.Except (runExcept)
 import Control.Monad.IO.Class (MonadIO (liftIO))
-import Control.Monad.Reader (ask)
+import Control.Monad.Reader (ask, runReaderT)
 import Data.ByteString qualified as BS
 import Data.Default (def)
 import Data.Map qualified as Map
@@ -26,7 +27,9 @@ import Ledger qualified (ChainIndexTxOut (ScriptChainIndexTxOut), DatumFromQuery
 import Ledger.Ada qualified as Ada
 import Ledger.Address (StakePubKeyHash (StakePubKeyHash), addressStakingCredential, xprvToPaymentPubKeyHash,
                        xprvToStakePubKeyHash)
+import Ledger.Constraints (MkTxError, mustSpendPubKeyOutput, mustSpendScriptOutput, mustSpendScriptOutputWithReference)
 import Ledger.Constraints qualified as Constraints
+import Ledger.Constraints.OffChain (prepareConstraints)
 import Ledger.Constraints.OffChain qualified as OC
 import Ledger.Constraints.OnChain.V2 qualified as ConstraintsV2
 import Ledger.Credential (Credential (PubKeyCredential, ScriptCredential), StakingCredential (StakingHash))
@@ -35,6 +38,7 @@ import Ledger.Generators qualified as Gen
 import Ledger.Index qualified as Ledger
 import Ledger.Params (Params (pNetworkId))
 import Ledger.Scripts (WitCtx (WitCtxStake), examplePlutusScriptAlwaysSucceedsHash)
+import Ledger.Test (asRedeemer)
 import Ledger.Tx (Tx (txCollateralInputs, txOutputs), TxOut (TxOut), txOutAddress)
 import Ledger.Tx.CardanoAPI (toCardanoTxOut, toCardanoTxOutDatumHash)
 import Ledger.Value (CurrencySymbol, Value (Value))
@@ -55,10 +59,29 @@ main = defaultMain tests
 
 tests :: TestTree
 tests = testGroup "all tests"
-    [ testPropertyNamed "missing value spent" "missingValueSpentProp" missingValueSpentProp
-    , testPropertyNamed "mustPayToPubKeyAddress should create output addresses with stake pub key hash" "mustPayToPubKeyAddressStakePubKeyNotNothingProp" mustPayToPubKeyAddressStakePubKeyNotNothingProp
-    , testPropertyNamed "mustPayToOtherScriptAddress should create output addresses with stake validator hash" "mustPayToOtherScriptAddressStakeValidatorHashNotNothingProp" mustPayToOtherScriptAddressStakeValidatorHashNotNothingProp
-    , testPropertyNamed "mustUseOutputAsCollateral should add a collateral input" "mustUseOutputAsCollateralProp" mustUseOutputAsCollateralProp
+    [ testPropertyNamed "missing value spent"
+        "missingValueSpentProp" missingValueSpentProp
+    , testPropertyNamed "mustPayToPubKeyAddress should create output addresses with stake pub key hash"
+        "mustPayToPubKeyAddressStakePubKeyNotNothingProp"
+        mustPayToPubKeyAddressStakePubKeyNotNothingProp
+    , testPropertyNamed "mustPayToOtherScriptAddress should create output addresses with stake validator hash"
+         "mustPayToOtherScriptAddressStakeValidatorHashNotNothingProp"
+         mustPayToOtherScriptAddressStakeValidatorHashNotNothingProp
+    , testPropertyNamed "mustUseOutputAsCollateral should add a collateral input"
+        "mustUseOutputAsCollateralProp" mustUseOutputAsCollateralProp
+    , testPropertyNamed "prepareConstraints keep only one duplicated mustSpendPubKeyOutput constraints"
+        "mustSpendPubKeyOutputDuplicate" mustSpendPubKeyOutputDuplicate
+    , testPropertyNamed "prepareConstraints keep only one duplicated mustSpendScriptOutput constraints"
+        "mustSpendScriptOutputDuplicate" mustSpendScriptOutputDuplicate
+    , testPropertyNamed "prepareConstraints keep the constraitnt with a reference script on duplicate"
+        "mustSpendScriptOutputKeepTheOneWithAReferenceScript"
+        mustSpendScriptOutputKeepTheOneWithAReferenceScript
+    , testPropertyNamed "prepareConstraints fails if the same utxo is spent with different redeemers"
+        "mustSpendScriptOutputFailsWithDifferentRedeemers"
+        mustSpendScriptOutputFailsWithDifferentRedeemers
+    , testPropertyNamed "prepareConstraints fails if the same utxo is spent with a different referenceScript"
+        "mustSpendScriptOutputFailsWithDifferentReferenceScript"
+        mustSpendScriptOutputFailsWithDifferentReferenceScript
     ]
 
 -- | Reduce one of the elements in a 'Value' by one.
@@ -168,6 +191,47 @@ mustUseOutputAsCollateralProp = property $ do
             Hedgehog.assert $ length coll == 1
             Hedgehog.assert $ Ledger.txInputRef (head coll) == txOutRef
 
+mustSpendScriptOutputDuplicate :: Property
+mustSpendScriptOutputDuplicate = property $ do
+    let con = mustSpendScriptOutputWithReference @Void @Void (txOutRef 1) (asRedeemer ()) (txOutRef 0)
+    let dup = con <> con
+    Hedgehog.assert $ prepFromTxConstraints dup == prepFromTxConstraints con
+
+mustSpendPubKeyOutputDuplicate :: Property
+mustSpendPubKeyOutputDuplicate = property $ do
+    let con = mustSpendPubKeyOutput @Void @Void (txOutRef 1)
+    let dup = con <> con
+    Hedgehog.assert $ prepFromTxConstraints dup == prepFromTxConstraints con
+
+mustSpendScriptOutputKeepTheOneWithAReferenceScript :: Property
+mustSpendScriptOutputKeepTheOneWithAReferenceScript = property $ do
+    let con = mustSpendScriptOutputWithReference @Void @Void (txOutRef 1) (asRedeemer ()) (txOutRef 0)
+    let dup = mustSpendScriptOutput @Void @Void (txOutRef 1) (asRedeemer ()) <> con
+    Hedgehog.assert $ prepFromTxConstraints dup == prepFromTxConstraints con
+
+mustSpendScriptOutputFailsWithDifferentRedeemers :: Property
+mustSpendScriptOutputFailsWithDifferentRedeemers = property $ do
+    let con  = mustSpendScriptOutputWithReference @Void @Void (txOutRef 1) (asRedeemer ()) (txOutRef 0)
+    let con2 = mustSpendScriptOutputWithReference @Void @Void (txOutRef 1) (asRedeemer (5 :: Integer)) (txOutRef 0)
+    Hedgehog.assert $ case prepFromTxConstraints (con <> con2) of
+        Left (OC.AmbiguousRedeemer _ _) -> True
+        _                               -> False
+
+mustSpendScriptOutputFailsWithDifferentReferenceScript :: Property
+mustSpendScriptOutputFailsWithDifferentReferenceScript = property $ do
+    let con  = mustSpendScriptOutputWithReference @Void @Void (txOutRef 1) (asRedeemer ()) (txOutRef 0)
+    let con2 = mustSpendScriptOutputWithReference @Void @Void (txOutRef 1) (asRedeemer ()) (txOutRef 1)
+    Hedgehog.assert $ case prepFromTxConstraints (con <> con2) of
+        Left (OC.AmbiguousReferenceScript _ _) -> True
+        _                                      -> False
+
+prepFromTxConstraints
+    :: Constraints.TxConstraints Void Void
+    -> Either MkTxError ([Constraints.TxConstraint], [Constraints.TxConstraint])
+prepFromTxConstraints txCons = runExcept $
+        prepareConstraints @Void (Constraints.txOwnOutputs txCons) (Constraints.txConstraints txCons)
+        `runReaderT` mempty
+
 txOut0 :: Ledger.ChainIndexTxOut
 txOut0 =
     Ledger.ScriptChainIndexTxOut
@@ -176,9 +240,6 @@ txOut0 =
         (Ledger.datumHash Ledger.unitDatum, Ledger.DatumInBody Ledger.unitDatum)
         Nothing
         (alwaysSucceedValidatorHash, Nothing)
-
-txOutRef0 :: Ledger.TxOutRef
-txOutRef0 = Ledger.TxOutRef (Ledger.TxId "") 0
 
 data UnitTest
 instance Scripts.ValidatorTypes UnitTest
@@ -217,7 +278,7 @@ txOutRef :: Integer -> Ledger.TxOutRef
 txOutRef = Ledger.TxOutRef (Ledger.TxId "")
 
 utxo1 :: Map.Map Ledger.TxOutRef Ledger.ChainIndexTxOut
-utxo1 = Map.fromList [(txOutRef0, txOut0), (txOutRef 1, txOut1)]
+utxo1 = Map.fromList [(txOutRef 0, txOut0), (txOutRef 1, txOut1)]
 
 {-# INLINABLE constraints1 #-}
 constraints1 :: Ledger.ValidatorHash -> Constraints.TxConstraints () ()


### PR DESCRIPTION
Throw errors if we try to use different redeemer or different reference script in different MustSpend, ignore all but one constraint otherwise.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
