### PR TITLE
Considering ChainTipAtGenesis case in getTipSlot

### DIFF
--- a/plutus-chain-index/src/Plutus/ChainIndex/App.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/App.hs
@@ -34,6 +34,7 @@ import Plutus.ChainIndex.Logging qualified as Logging
 import Plutus.ChainIndex.Server qualified as Server
 import Plutus.ChainIndex.SyncStats (SyncLog)
 import Plutus.Monitoring.Util (PrettyObject)
+import System.Exit (exitFailure)
 
 main :: IO ()
 main = do
@@ -77,9 +78,14 @@ runMainWithLog :: (String -> IO ()) -> CM.Configuration -> Config.ChainIndexConf
 runMainWithLog logger logConfig config = do
   withRunRequirements logConfig config $ \runReq -> do
 
-    slotNo <- getTipSlot config
-    let slotNoStr = "\nThe tip of the local node: " <> show slotNo
-    logger slotNoStr
+    mslotNo <- getTipSlot config
+    case mslotNo of
+      Just slotNo -> do
+        let slotNoStr = "\nThe tip of the local node: " <> show slotNo
+        logger slotNoStr
+      Nothing -> do
+        putStrLn "\nLocal node still at Genesis Tip !!!"
+        exitFailure
 
     -- Queue for processing events
     let maxQueueSize = Config.cicAppendTransactionQueueSize config

--- a/plutus-chain-index/src/Plutus/ChainIndex/Lib.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Lib.hs
@@ -169,14 +169,17 @@ filterTxs isAccepted isStored handler (RollForward (CI.Block blockTip txs) chain
 filterTxs _ _ handler evt = handler evt
 
 -- | Get the slot number of the current tip of the node.
-getTipSlot :: Config.ChainIndexConfig -> IO C.SlotNo
+getTipSlot :: Config.ChainIndexConfig -> IO (Maybe C.SlotNo)
 getTipSlot config = do
-  C.ChainTip slotNo _ _ <- C.getLocalChainTip $ C.LocalNodeConnectInfo
-    { C.localConsensusModeParams = C.CardanoModeParams epochSlots
-    , C.localNodeNetworkId = Config.cicNetworkId config
-    , C.localNodeSocketPath = Config.cicSocketPath config
-    }
-  pure slotNo
+  tip <- C.getLocalChainTip $ C.LocalNodeConnectInfo
+         { C.localConsensusModeParams = C.CardanoModeParams epochSlots
+         , C.localNodeNetworkId = Config.cicNetworkId config
+         , C.localNodeSocketPath = Config.cicSocketPath config
+         }
+  case tip of
+    C.ChainTip slotNo _ _ -> pure $ Just slotNo
+    C.ChainTipAtGenesis   -> pure $ Nothing
+
 
 -- | Synchronise the chain index with the node using the given handler.
 syncChainIndex :: Config.ChainIndexConfig -> RunRequirements -> ChainSyncHandler -> IO ()


### PR DESCRIPTION
This patch explicitly considers the `ChainTipAtGenesis` case in `getTipSlo`t so as to avoid a pattern matching error whenever the chain-index is trying to sync with a local node that is still at genesis tip.
If this happens then chain-index will exit with an appropriate failure message.