### PR TITLE
Adding a specifc timeout option for 'Plutus.PAB.Core.waitForInstanceState

### DIFF
--- a/plutus-pab-executables/demo/pab-nami/pab/plutus-pab.yaml
+++ b/plutus-pab-executables/demo/pab-nami/pab/plutus-pab.yaml
@@ -10,6 +10,11 @@ pabWebserverConfig:
   # available. If this is not set, calls to unavailable endpoints fail
   # immediately.
   endpointTimeout: 5
+  # Optional timeout (in seconds) when querying the status of an invoked endpoint for
+  # which the expected contract status must be set to Done.
+  # If this is not set, the query will wait until the instance state is updated.
+  waitStatusTimeout: 60
+  enableMarconi: False
 
 walletServerConfig:
   tag: RemoteWalletConfig
@@ -27,6 +32,10 @@ nodeServerConfig:
     - getWallet: 1
     - getWallet: 2
     - getWallet: 3
+  # Which cardano-node to use
+  # Options are
+  # - MockNode          (plutus-apps internal mock version of the node)
+  # - AlonzoNode        (cardano-node via socket connection)
   pscNodeMode: AlonzoNode
 
 # Unfortunately, the 'chainIndexConfig' is mandatory in the PAB, even though we don't use it

--- a/plutus-pab-executables/plutus-pab.yaml.sample
+++ b/plutus-pab-executables/plutus-pab.yaml.sample
@@ -20,6 +20,10 @@ pabWebserverConfig:
   # available. If this is not set, calls to unavailable endpoints fail
   # immediately.
   endpointTimeout: 5
+  # Optional timeout (in seconds) when querying the status of an invoked endpoint for
+  # which the expected contract status must be set to Done.
+  # If this is not set, the query will wait until the instance state is updated.
+  waitStatusTimeout: 60
   enableMarconi: False
 
 walletServerConfig:
@@ -39,6 +43,10 @@ nodeServerConfig:
     - getWallet: 1
     - getWallet: 2
     - getWallet: 3
+  # Which cardano-node to use
+  # Options are
+  # - MockNode          (plutus-apps internal mock version of the node)
+  # - AlonzoNode        (cardano-node via socket connection)
   pscNodeMode: MockNode
 
 chainIndexConfig:

--- a/plutus-pab/src/Plutus/PAB/App.hs
+++ b/plutus-pab/src/Plutus/PAB/App.hs
@@ -87,7 +87,7 @@ import Plutus.PAB.Types (ChainQueryConfig (..), ChainQueryEnv (..), Config (Conf
                          PABError (BeamEffectError, ChainIndexError, NodeClientError, RemoteWalletWithMockNodeError, WalletClientError, WalletError),
                          WebserverConfig (WebserverConfig), _PostgresPool, _SqlitePool, chainQueryConfig, dbConfig,
                          endpointTimeout, getBlockfrostEnv, getChainIndexEnv, nodeServerConfig, pabWebserverConfig,
-                         walletServerConfig)
+                         waitStatusTimeout, walletServerConfig)
 import Servant.Client (ClientEnv, ClientError, mkClientEnv)
 import Wallet.API (NodeClientEffect)
 import Wallet.Effects (WalletEffect)
@@ -264,8 +264,8 @@ runApp
     storageBackend
     trace
     contractHandler
-    config@Config{pabWebserverConfig=WebserverConfig{endpointTimeout}} =
-    Core.runPAB (Timeout endpointTimeout) (appEffectHandlers storageBackend config trace contractHandler)
+    config@Config{pabWebserverConfig=WebserverConfig{endpointTimeout, waitStatusTimeout}} =
+    Core.runPAB (Timeout endpointTimeout) (Timeout waitStatusTimeout) (appEffectHandlers storageBackend config trace contractHandler)
 
 type App a b = PABAction (Builtin a) (AppEnv a) b
 

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -422,7 +422,7 @@ waitNSlots = Core.waitNSlots
 type Simulation t a = Core.PABAction t (SimulatorState t) a
 
 runSimulationWith :: SimulatorEffectHandlers t -> Simulation t a -> IO (Either PABError a)
-runSimulationWith = Core.runPAB def
+runSimulationWith = Core.runPAB def def
 
 -- | Handle a 'LogMsg' effect in terms of a "larger" 'State' effect from which we have a setter.
 logIntoTQueue ::

--- a/plutus-pab/src/Plutus/PAB/Timeout.hs
+++ b/plutus-pab/src/Plutus/PAB/Timeout.hs
@@ -8,8 +8,8 @@ module Plutus.PAB.Timeout (Timeout(..), startTimeout) where
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.STM (TMVar)
 import Control.Concurrent.STM qualified as STM
-import Control.Monad (void)
 import Data.Default (Default (..))
+import Data.Foldable (traverse_)
 import Data.Time.Units (Second, toMicroseconds)
 
 newtype Timeout = Timeout { unTimeout :: Maybe Second }
@@ -17,12 +17,13 @@ newtype Timeout = Timeout { unTimeout :: Maybe Second }
 instance Default Timeout where
     def = Timeout Nothing
 
--- | Create a 'TMVar' that is filled when the timeout expires.
+-- | Create a 'TMVar' that is filled when the timeout expires. If the timeout
+--   is 'Nothing', the 'TMVar' is never filled.
 startTimeout :: Timeout -> IO (TMVar ())
-startTimeout (Timeout Nothing) = STM.newTMVarIO ()
-startTimeout (Timeout (Just s)) = do
+startTimeout (Timeout t) = do
     tmv <- STM.newEmptyTMVarIO
-    void $ forkIO $ do
-        threadDelay $ fromIntegral $ toMicroseconds s
-        STM.atomically $ STM.putTMVar tmv ()
+    flip traverse_ t $ \s -> do
+        forkIO $ do
+            threadDelay $ fromIntegral $ toMicroseconds s
+            STM.atomically $ STM.putTMVar tmv ()
     pure tmv

--- a/plutus-pab/src/Plutus/PAB/Types.hs
+++ b/plutus-pab/src/Plutus/PAB/Types.hs
@@ -250,6 +250,9 @@ data WebserverConfig =
         , staticDir            :: Maybe FilePath
         , permissiveCorsPolicy :: Bool -- ^ If true; use a very permissive CORS policy (any website can interact.)
         , endpointTimeout      :: Maybe Second
+        -- ^ timeout to be used when endpoint is not available on invocation.
+        , waitStatusTimeout    :: Maybe Second
+        -- ^ timeout to be used when querying endpoint result when expected contract status must be set to Done.
         , enableMarconi        :: Bool
         }
     deriving (Show, Eq, Generic)
@@ -264,6 +267,7 @@ defaultWebServerConfig =
     , staticDir            = Nothing
     , permissiveCorsPolicy = False
     , endpointTimeout      = Nothing
+    , waitStatusTimeout    = Nothing
     , enableMarconi        = False
     }
 

--- a/plutus-pab/test-node/testnet/pab-config.yml
+++ b/plutus-pab/test-node/testnet/pab-config.yml
@@ -10,6 +10,10 @@ pabWebserverConfig:
   # available. If this is not set, calls to unavailable endpoints fail
   # immediately.
   endpointTimeout: 5
+  # Optional timeout (in seconds) when querying the status of an invoked endpoint for
+  # which the expected contract status must be set to Done.
+  # If this is not set, the query will wait until the instance state is updated.
+  waitStatusTimeout: 60
 
 walletServerConfig:
   tag: LocalWalletConfig
@@ -25,6 +29,10 @@ nodeServerConfig:
     scSlotZeroTime: 1596059091000 # Wednesday, July 29, 2020 21:44:51 - shelley launch time in milliseconds
     scSlotLength: 1000 # In milliseconds
   pscInitialTxWallets: []
+  # Which cardano-node to use
+  # Options are
+  # - MockNode          (plutus-apps internal mock version of the node)
+  # - AlonzoNode        (cardano-node via socket connection)
   pscNodeMode: AlonzoNode
 
 chainIndexConfig:


### PR DESCRIPTION
Cherry-picked commits:

* https://github.com/etiennejf/plutus-apps/commit/e1ce0ef32ae6354950b807121f2dc96a769c5084
* https://github.com/etiennejf/plutus-apps/commit/2b484001a3d6b4b34bbcc0df308fb2ac422f7983
* https://github.com/etiennejf/plutus-apps/commit/ca9a3b9ccbe5fd578b790014a444aa993dfdea05

Summary:

* 'Plutus.PAB.Core.waitForInstanceState' now waits for a user-specified amount of time

* Bug fix in 'Plutus.PAB.Timeout'

* Modified the PAB configuration file to allow users to set the timeout value

cc @etiennejf 

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
