### PR TITLE
Added the 'Contract.DeleteState' effect in PAB and call it when an instance is stopped

### DIFF
--- a/plutus-pab/src/Plutus/PAB/Core.hs
+++ b/plutus-pab/src/Plutus/PAB/Core.hs
@@ -322,6 +322,7 @@ stopInstance instanceId = do
                 Active -> STM.putTMVar issStop () >> pure Nothing
                 _      -> pure (Just $ InstanceAlreadyStopped instanceId)
     traverse_ throwError r'
+    Contract.deleteState @t instanceId
 
 -- | The 'Activity' of the instance.
 instanceActivity :: forall t env. ContractInstanceId -> PABAction t env Activity

--- a/plutus-pab/src/Plutus/PAB/Db/Beam/ContractStore.hs
+++ b/plutus-pab/src/Plutus/PAB/Db/Beam/ContractStore.hs
@@ -24,7 +24,7 @@ import Control.Monad (join)
 import Control.Monad.Freer (Eff, Member, type (~>))
 import Control.Monad.Freer.Error (Error, throwError)
 import Control.Monad.Freer.Extras (LogMsg)
-import Control.Monad.Freer.Extras.Beam.Effects (BeamEffect (..), Synt, addRows, selectList, selectOne, updateRows)
+import Control.Monad.Freer.Extras.Beam (BeamEffect (..), Synt, addRows, deleteRows, selectList, selectOne, updateRows)
 import Data.Aeson (FromJSON, ToJSON, decode, encode)
 import Data.ByteString.Builder (toLazyByteString)
 import Data.ByteString.Char8 qualified as B
@@ -176,3 +176,9 @@ handleContractStore = \case
             Just s -> guard_ ( ci ^. contractInstanceActive ==. val_ (s == Active) )
             _      -> pure ()
           pure ci
+
+  DeleteState instanceId ->
+    deleteRows @dbt
+      $ delete
+          (_contractInstances db)
+          (\ci -> ci ^. contractInstanceId ==. val_ (uuidStr instanceId))

--- a/plutus-pab/src/Plutus/PAB/Db/Memory/ContractStore.hs
+++ b/plutus-pab/src/Plutus/PAB/Db/Memory/ContractStore.hs
@@ -86,3 +86,6 @@ handleContractStore = \case
         fmap _contractDef <$> liftIO (IORef.readIORef instancesTVar)
     Contract.PutStartInstance{} -> pure ()
     Contract.PutStopInstance{} -> pure ()
+    Contract.DeleteState i -> do
+      instancesTVar <- unInMemInstances <$> ask @(InMemInstances t)
+      liftIO (IORef.modifyIORef' instancesTVar (Map.delete i))

--- a/plutus-pab/src/Plutus/PAB/Effects/Contract.hs
+++ b/plutus-pab/src/Plutus/PAB/Effects/Contract.hs
@@ -27,6 +27,7 @@ module Plutus.PAB.Effects.Contract(
     , getContracts
     , putStartInstance
     , putStopInstance
+    , deleteState
     -- * Storing and retrieving definitions of contracts
     , ContractDefinition(..)
     , addDefinition
@@ -123,6 +124,7 @@ data ContractStore t r where
     GetState :: ContractInstanceId -> ContractStore t (State t) -- ^ Retrieve the last recorded state of the contract instance
     PutStopInstance :: ContractInstanceId -> ContractStore t () -- ^ Record the fact that a contract instance has stopped
     GetContracts :: Maybe ContractActivityStatus -> ContractStore t (Map ContractInstanceId (ContractActivationArgs (ContractDef t))) -- ^ Get contracts with their activation args by status (all by default)
+    DeleteState :: ContractInstanceId -> ContractStore t () -- ^ Delete the state of a contract instance
 
 putStartInstance ::
     forall t effs.
@@ -191,6 +193,16 @@ getContracts ::
     -> Eff effs (Map ContractInstanceId (ContractActivationArgs (ContractDef t)))
 getContracts mStatus =
     let command :: ContractStore t (Map ContractInstanceId (ContractActivationArgs (ContractDef t))) = GetContracts mStatus
+    in send command
+
+deleteState ::
+    forall t effs.
+    ( Member (ContractStore t) effs
+    )
+    => ContractInstanceId
+    -> Eff effs ()
+deleteState i =
+    let command :: ContractStore t () = DeleteState i
     in send command
 
 -- | Get the definition of a running contract

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -638,6 +638,9 @@ handleContractStore = \case
         fmap _contractDef <$> liftIO (STM.readTVarIO instancesTVar)
     Contract.PutStartInstance{} -> pure ()
     Contract.PutStopInstance{} -> pure ()
+    Contract.DeleteState i -> do
+        instancesTVar <- view instances <$> (Core.askUserEnv @t @(SimulatorState t))
+        void $ liftIO $ STM.atomically $ STM.modifyTVar instancesTVar (Map.delete i)
 
 render :: forall a. Pretty a => a -> Text
 render = Render.renderStrict . layoutPretty defaultLayoutOptions . pretty


### PR DESCRIPTION
Cherry-picked from:

* https://github.com/etiennejf/plutus-apps/commit/ab7b05a2b4db8e4f86470b75bb35fcd29b17b27c
* https://github.com/etiennejf/plutus-apps/commit/09bd551c7a0ecdb7c742f8cc16c83e2e9bc2a6a3

Summary:

Added the 'Contract.DeleteState' effect in Plutus.PAB.Effects.ContractStore and call it in Plutus.PAB.Core.stopInstance so that the state is deleted when the contract instance is done.

CC @etiennejf 
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
