### PR TITLE
Adding datumsAt contract request query

### DIFF
--- a/pab-blockfrost/pab-blockfrost.cabal
+++ b/pab-blockfrost/pab-blockfrost.cabal
@@ -48,13 +48,25 @@ library
     Plutus.Blockfrost.Utils
 
   hs-source-dirs:  src
+
+  --------------------
+  -- Local components
+  --------------------
   build-depends:
     , freer-extras
     , plutus-chain-index-core
     , plutus-ledger
+
+  --------------------------
+  -- Other IOG dependencies
+  --------------------------
+  build-depends:
     , plutus-ledger-api
     , plutus-tx
 
+  ------------------------
+  -- Non-IOG dependencies
+  ------------------------
   build-depends:
     , aeson
     , aeson-qq
@@ -65,6 +77,7 @@ library
     , bytestring
     , cardano-api
     , containers
+    , extra
     , freer-simple
     , hex-text
     , mtl

--- a/pab-blockfrost/src/Plutus/Blockfrost/Client.hs
+++ b/pab-blockfrost/src/Plutus/Blockfrost/Client.hs
@@ -66,3 +66,4 @@ handleBlockfrostClient event = do
             TxoSetAtAddress pq a          -> (runClientWithDef defaultGetList . getTxoAtAddressBlockfrost pq . credentialToAddress (envNetworkId bfEnv)) a >>= processGetTxos pq
             GetTip                        -> runClient getTipBlockfrost >>= processTip
             UnspentTxOutSetAtAddress pq a -> (runClientWithDef defaultGetList . getUnspentAtAddressBlockfrost pq . credentialToAddress (envNetworkId bfEnv)) a  >>= processUnspentTxOutSetAtAddress pq a
+            DatumsAtAddress pq a          -> (runClientWithDef defaultGetList . getDatumsAtAddressBlockfrost pq . credentialToAddress (envNetworkId bfEnv)) a  >>= processDatumsAtAddress pq a

--- a/pab-blockfrost/src/Plutus/Blockfrost/Queries.hs
+++ b/pab-blockfrost/src/Plutus/Blockfrost/Queries.hs
@@ -13,6 +13,7 @@ module Plutus.Blockfrost.Queries (
     , getIsUtxoBlockfrost
     , getUtxoAtAddressBlockfrost
     , getUnspentAtAddressBlockfrost
+    , getDatumsAtAddressBlockfrost
     , getTxoAtAddressBlockfrost
     , getUtxoSetWithCurrency
     , getTxFromTxIdBlockfrost
@@ -79,6 +80,13 @@ getUtxoAtAddressBlockfrost _ addr = do
 
 getUnspentAtAddressBlockfrost :: MonadBlockfrost m => PageQuery a -> Address -> m [AddressUtxo]
 getUnspentAtAddressBlockfrost _ addr = allPages (wrapperPaged getAddressUtxos' addr)
+
+getDatumsAtAddressBlockfrost :: MonadBlockfrost m => PageQuery a -> Address -> m [Value]
+getDatumsAtAddressBlockfrost p a = do
+  -- get all txouts at address
+  txos <- getTxoAtAddressBlockfrost p a
+  let dhs = catMaybes $ _utxoInputDataHash <$> txos
+  liftIO $ mapConcurrently getDatumBlockfrost dhs
 
 getTxoAtAddressBlockfrost :: MonadBlockfrost m => PageQuery a -> Address -> m [UtxoInput]
 getTxoAtAddressBlockfrost _ a = do

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Api.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Api.hs
@@ -177,6 +177,7 @@ type API
     :<|> "is-utxo" :> Description "Check if the reference is an UTxO." :> ReqBody '[JSON] TxOutRef :> Post '[JSON] IsUtxoResponse
     :<|> "utxo-at-address" :> Description "Get all UTxOs at an address." :> ReqBody '[JSON] UtxoAtAddressRequest :> Post '[JSON] UtxosResponse
     :<|> "unspent-txouts-at-address" :> Description "Get all unspent transaction output at an address." :> ReqBody '[JSON] QueryAtAddressRequest :> Post '[JSON] (QueryResponse [(TxOutRef, ChainIndexTxOut)])
+    :<|> "datums-at-address" :> Description "Get all Datums at an address." :> ReqBody '[JSON] QueryAtAddressRequest :> Post '[JSON] (QueryResponse [Datum])
     :<|> "utxo-with-currency" :> Description "Get all UTxOs with a currency." :> ReqBody '[JSON] UtxoWithCurrencyRequest :> Post '[JSON] UtxosResponse
     :<|> "txs" :> Description "Get transactions from a list of their ids." :> ReqBody '[JSON] [TxId] :> Post '[JSON] [ChainIndexTx]
     :<|> "txo-at-address" :> Description "Get TxOs at an address." :> ReqBody '[JSON] TxoAtAddressRequest :> Post '[JSON] TxosResponse

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Client.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Client.hs
@@ -64,13 +64,14 @@ getUnspentTxOut :: TxOutRef -> ClientM ChainIndexTxOut
 getIsUtxo :: TxOutRef -> ClientM IsUtxoResponse
 getUtxoSetAtAddress :: UtxoAtAddressRequest -> ClientM UtxosResponse
 getUnspentTxOutsAtAddress :: QueryAtAddressRequest -> ClientM (QueryResponse [(TxOutRef, ChainIndexTxOut)])
+getDatumsAtAddress :: QueryAtAddressRequest -> ClientM (QueryResponse [Datum])
 getUtxoSetWithCurrency :: UtxoWithCurrencyRequest -> ClientM UtxosResponse
 getTxs :: [TxId] -> ClientM [ChainIndexTx]
 getTxoSetAtAddress :: TxoAtAddressRequest -> ClientM TxosResponse
 getTip :: ClientM Tip
 
-(healthCheck, (getDatum, getValidator, getMintingPolicy, getStakeValidator, getRedeemer), getTxOut, getUnspentTxOut, getTx, getIsUtxo, getUtxoSetAtAddress, getUnspentTxOutsAtAddress, getUtxoSetWithCurrency, getTxs, getTxoSetAtAddress, getTip, collectGarbage) =
-    (healthCheck_, (getDatum_, getValidator_, getMintingPolicy_, getStakeValidator_, getRedeemer_), getTxOut_, getUnspentTxOut_, getTx_, getIsUtxo_, getUtxoSetAtAddress_, getUnspentTxOutsAtAddress_, getUtxoSetWithCurrency_, getTxs_, getTxoSetAtAddress_, getTip_, collectGarbage_) where
+(healthCheck, (getDatum, getValidator, getMintingPolicy, getStakeValidator, getRedeemer), getTxOut, getUnspentTxOut, getTx, getIsUtxo, getUtxoSetAtAddress, getUnspentTxOutsAtAddress, getDatumsAtAddress, getUtxoSetWithCurrency, getTxs, getTxoSetAtAddress, getTip, collectGarbage) =
+    (healthCheck_, (getDatum_, getValidator_, getMintingPolicy_, getStakeValidator_, getRedeemer_), getTxOut_, getUnspentTxOut_, getTx_, getIsUtxo_, getUtxoSetAtAddress_, getUnspentTxOutsAtAddress_, getDatumsAtAddress_, getUtxoSetWithCurrency_, getTxs_, getTxoSetAtAddress_, getTip_, collectGarbage_) where
         healthCheck_
             :<|> (getDatum_ :<|> getValidator_ :<|> getMintingPolicy_ :<|> getStakeValidator_ :<|> getRedeemer_)
             :<|> getTxOut_
@@ -79,6 +80,7 @@ getTip :: ClientM Tip
             :<|> getIsUtxo_
             :<|> getUtxoSetAtAddress_
             :<|> getUnspentTxOutsAtAddress_
+            :<|> getDatumsAtAddress_
             :<|> getUtxoSetWithCurrency_
             :<|> getTxs_
             :<|> getTxoSetAtAddress_
@@ -123,6 +125,7 @@ handleChainIndexClient event = do
         UtxoSetMembership r           -> runClient (getIsUtxo r)
         UtxoSetAtAddress pq a         -> runClient (getUtxoSetAtAddress $ UtxoAtAddressRequest (Just pq) a)
         UnspentTxOutSetAtAddress pq a -> runClient (getUnspentTxOutsAtAddress $ QueryAtAddressRequest (Just pq) a)
+        DatumsAtAddress pq a          -> runClient (getDatumsAtAddress $ QueryAtAddressRequest (Just pq) a)
         UtxoSetWithCurrency pq a      -> runClient (getUtxoSetWithCurrency $ UtxoWithCurrencyRequest (Just pq) a)
         TxsFromTxIds t                -> runClient (getTxs t)
         TxoSetAtAddress pq a          -> runClient (getTxoSetAtAddress $ TxoAtAddressRequest (Just pq) a)

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/DbSchema.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/DbSchema.hs
@@ -25,6 +25,7 @@ module Plutus.ChainIndex.DbSchema where
 
 import Codec.Serialise (Serialise, deserialiseOrFail, serialise)
 import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.Coerce (coerce)
 import Data.Either (fromRight)
@@ -40,12 +41,14 @@ import Ledger (BlockId (..), ChainIndexTxOut (..), Slot, Versioned)
 import Plutus.ChainIndex.Tx (ChainIndexTx)
 import Plutus.ChainIndex.Tx qualified as CI
 import Plutus.ChainIndex.Types (BlockNumber (..), Tip (..))
+
 import Plutus.V1.Ledger.Api (Credential, Datum, DatumHash (..), MintingPolicy, MintingPolicyHash (..), Redeemer,
                              RedeemerHash (..), Script, StakeValidator, StakeValidatorHash (..), TxId (..),
                              TxOutRef (..), Validator, ValidatorHash (..))
 import Plutus.V1.Ledger.Scripts (ScriptHash (..))
 import Plutus.V1.Ledger.Value (AssetClass)
 import PlutusTx.Builtins qualified as PlutusTx
+import PlutusTx.Builtins.Internal (BuiltinByteString (..), emptyByteString)
 
 data DatumRowT f = DatumRow
     { _datumRowHash  :: Columnar f ByteString
@@ -92,8 +95,11 @@ instance Table TxRowT where
     primaryKey = TxRowId . _txRowTxId
 
 data AddressRowT f = AddressRow
-    { _addressRowCred   :: Columnar f ByteString
-    , _addressRowOutRef :: Columnar f ByteString
+    { _addressRowCred      :: Columnar f ByteString
+    , _addressRowOutRef    :: Columnar f ByteString
+    -- Keep datumHash in address row which is useful to retrieve all datum associated to a partial
+    -- address
+    , _addressRowDatumHash :: Columnar f ByteString
     } deriving (Generic, Beamable)
 
 type AddressRow = AddressRowT Identity
@@ -101,8 +107,8 @@ type AddressRow = AddressRowT Identity
 instance Table AddressRowT where
     -- We also need an index on just the _addressRowCred column, but the primary key index provides this
     -- as long as _addressRowCred is the first column in the primary key.
-    data PrimaryKey AddressRowT f = AddressRowId (Columnar f ByteString) (Columnar f ByteString) deriving (Generic, Beamable)
-    primaryKey (AddressRow c o) = AddressRowId c o
+    data PrimaryKey AddressRowT f = AddressRowId (Columnar f ByteString) (Columnar f ByteString) (Columnar f ByteString) deriving (Generic, Beamable)
+    primaryKey (AddressRow c o d) = AddressRowId c o d
 
 data AssetClassRowT f = AssetClassRow
     { _assetClassRowAssetClass :: Columnar f ByteString
@@ -306,10 +312,17 @@ instance HasDbType (TxId, ChainIndexTx) where
     toDbValue (txId, tx) = TxRow (toDbValue txId) (toDbValue tx)
     fromDbValue (TxRow txId tx) = (fromDbValue txId, fromDbValue tx)
 
-instance HasDbType (Credential, TxOutRef) where
-    type DbType (Credential, TxOutRef) = AddressRow
-    toDbValue (cred, outRef) = AddressRow (toDbValue cred) (toDbValue outRef)
-    fromDbValue (AddressRow cred outRef) = (fromDbValue cred, fromDbValue outRef)
+instance HasDbType (Credential, TxOutRef, Maybe DatumHash) where
+  type DbType (Credential, TxOutRef, Maybe DatumHash) = AddressRow
+  toDbValue (cred, outRef, Nothing) = AddressRow (toDbValue cred) (toDbValue outRef) (toDbValue $ DatumHash emptyByteString)
+  toDbValue (cred, outRef, Just dh) = AddressRow (toDbValue cred) (toDbValue outRef) (toDbValue dh)
+  fromDbValue (AddressRow cred outRef dh) =
+    let dh'@(DatumHash (BuiltinByteString bs)) = fromDbValue dh in
+      if BS.null bs then
+        (fromDbValue cred, fromDbValue outRef, Nothing)
+      else
+        (fromDbValue cred, fromDbValue outRef, Just dh')
+
 
 instance HasDbType (AssetClass, TxOutRef) where
     type DbType (AssetClass, TxOutRef) = AssetClassRow

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Effects.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Effects.hs
@@ -17,6 +17,7 @@ module Plutus.ChainIndex.Effects(
     , utxoSetMembership
     , utxoSetAtAddress
     , unspentTxOutSetAtAddress
+    , datumsAtAddress
     , utxoSetWithCurrency
     , txoSetAtAddress
     , txsFromTxIds
@@ -76,6 +77,9 @@ data ChainIndexQueryEffect r where
     -- | Get the unspent txouts located at an address
     -- This is to avoid multiple queries from chain-index when using utxosAt
     UnspentTxOutSetAtAddress :: PageQuery TxOutRef -> Credential -> ChainIndexQueryEffect (QueryResponse [(TxOutRef, ChainIndexTxOut)])
+
+    -- | get the datums located at addresses with the given credential.
+    DatumsAtAddress :: PageQuery TxOutRef -> Credential -> ChainIndexQueryEffect (QueryResponse [Datum])
 
     -- | Unspent outputs containing a specific currency ('AssetClass').
     --

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Handlers.hs
@@ -44,7 +44,7 @@ import Database.Beam (Columnar, Identity, SqlSelect, TableEntity, aggregate_, al
                       limit_, nub_, select, val_)
 import Database.Beam.Backend.SQL (BeamSqlBackendCanSerialize)
 import Database.Beam.Query (HasSqlEqualityCheck, asc_, desc_, exists_, guard_, isJust_, isNothing_, leftJoin_, orderBy_,
-                            update, (&&.), (<-.), (<.), (==.), (>.))
+                            update, (&&.), (/=.), (<-.), (<.), (==.), (>.))
 import Database.Beam.Schema.Tables (zipTables)
 import Database.Beam.Sqlite (Sqlite)
 import Ledger (Datum, DatumHash (..), TxId, TxOutRef (..))
@@ -67,6 +67,7 @@ import Plutus.ChainIndex.UtxoState (InsertUtxoSuccess (..), RollbackResult (..),
 import Plutus.ChainIndex.UtxoState qualified as UtxoState
 import Plutus.Script.Utils.Scripts (datumHash)
 import Plutus.V2.Ledger.Api (Credential (..))
+import PlutusTx.Builtins.Internal (emptyByteString)
 
 type ChainIndexState = UtxoIndex TxUtxoBalance
 
@@ -98,6 +99,7 @@ handleQuery = \case
             tp           -> pure (IsUtxoResponse tp (TxUtxoBalance.isUnspentOutput r utxoState))
     UtxoSetAtAddress pageQuery cred -> getUtxoSetAtAddress pageQuery cred
     UnspentTxOutSetAtAddress pageQuery cred -> getTxOutSetAtAddress pageQuery cred
+    DatumsAtAddress pageQuery cred -> getDatumsAtAddress pageQuery cred
     UtxoSetWithCurrency pageQuery assetClass ->
       getUtxoSetWithCurrency pageQuery assetClass
     TxoSetAtAddress pageQuery cred -> getTxoSetAtAddress pageQuery cred
@@ -152,12 +154,14 @@ queryOne ::
     -> Eff effs (Maybe o)
 queryOne = fmap (fmap fromDbValue) . selectOne
 
+
 queryList ::
     ( Member (BeamEffect Sqlite) effs
     , HasDbType o
     ) => SqlSelect Sqlite (DbType o)
     -> Eff effs [o]
 queryList = fmap (fmap fromDbValue) . selectList
+
 
 -- | Get the 'ChainIndexTxOut' for a 'TxOutRef'.
 getTxOutFromRef ::
@@ -173,6 +177,7 @@ getTxOutFromRef ref@TxOutRef{txOutRefId, txOutRefIdx} = do
   case mTx ^? _Just . to txOuts . ix (fromIntegral txOutRefIdx) of
     Nothing    -> logWarn (TxOutNotFound ref) >> pure Nothing
     Just txout -> makeChainIndexTxOut txout
+
 
 -- | Get the 'ChainIndexTxOut' for a 'TxOutRef'.
 getUtxoutFromRef ::
@@ -271,6 +276,47 @@ getTxOutSetAtAddress pageQuery cred = do
       mtxouts <- mapM getUtxoutFromRef (pageItems page)
       let txouts = [ (t, o) | (t, mo) <- List.zip (pageItems page) mtxouts, o <- maybeToList mo]
       pure $ QueryResponse txouts (nextPageQuery page)
+
+
+getDatumsAtAddress ::
+  forall effs.
+    ( Member (State ChainIndexState) effs
+    , Member (BeamEffect Sqlite) effs
+    , Member (LogMsg ChainIndexLog) effs
+    )
+  => PageQuery TxOutRef
+  -> Credential
+  -> Eff effs (QueryResponse [Datum])
+getDatumsAtAddress pageQuery (toDbValue -> cred) = do
+  utxoState <- gets @ChainIndexState UtxoState.utxoState
+  case UtxoState.tip utxoState of
+    TipAtGenesis -> do
+      logWarn TipIsGenesis
+      pure (QueryResponse [] Nothing)
+
+    _             -> do
+      let emptyHash = toDbValue $ DatumHash emptyByteString
+          queryPage =
+            fmap _addressRowOutRef
+            $ filter_ (\row ->
+                         ( _addressRowCred row ==. val_ cred )
+                         &&. (_addressRowDatumHash row /=. val_ emptyHash) )
+            $ all_ (addressRows db)
+          queryAll =
+            select
+            $ filter_ (\row -> _addressRowCred row ==. val_ cred
+                       &&. (_addressRowDatumHash row /=. val_ emptyHash ) )
+            $ all_ (addressRows db)
+      pRefs <- selectPage (fmap toDbValue pageQuery) queryPage
+      let page = fmap fromDbValue pRefs
+      row_l <- List.filter (\(_, t, _) -> List.elem t (pageItems page)) <$> queryList queryAll
+      datums <- catMaybes <$> mapM f_map row_l
+      pure $ QueryResponse datums (nextPageQuery page)
+
+  where
+    f_map :: (Credential, TxOutRef, Maybe DatumHash) -> Eff effs (Maybe Datum)
+    f_map (_, _, Nothing) = pure Nothing
+    f_map (_, _, Just dh) = getDatumFromHash dh
 
 
 getUtxoSetWithCurrency
@@ -546,17 +592,17 @@ insertRows = getConst . zipTables Proxy (\tbl (InsertRows rows) -> Const $ AddRo
 
 fromTx :: ChainIndexTx -> Db InsertRows
 fromTx tx = mempty
-    { datumRows = fromMap citxData
+    { datumRows = InsertRows . fmap toDbValue $ (Map.toList $ updateMapWithInlineDatum (_citxData tx) (txOuts tx))
     , scriptRows = fromMap citxScripts
     , redeemerRows = fromPairs (Map.toList . txRedeemersWithHash)
     , txRows = InsertRows [toDbValue (_citxTxId tx, tx)]
-    , addressRows = fromPairs (fmap credential . txOutsWithRef)
+    , addressRows = InsertRows . fmap toDbValue . (fmap credential . txOutsWithRef) $ tx
     , assetClassRows = fromPairs (concatMap assetClasses . txOutsWithRef)
     }
     where
-        credential :: (ChainIndex.ChainIndexTxOut, TxOutRef) -> (Credential, TxOutRef)
-        credential (ChainIndexTxOut{citoAddress=Address{addressCredential}}, ref) =
-          (addressCredential, ref)
+        credential :: (ChainIndex.ChainIndexTxOut, TxOutRef) -> (Credential, TxOutRef, Maybe DatumHash)
+        credential (ChainIndexTxOut{citoAddress=Address{addressCredential},citoDatum}, ref) =
+          (addressCredential, ref, getHashFromDatum citoDatum)
         assetClasses :: (ChainIndex.ChainIndexTxOut, TxOutRef) -> [(AssetClass, TxOutRef)]
         assetClasses (ChainIndexTxOut{citoValue}, ref) =
           fmap (\(c, t, _) -> (AssetClass (c, t), ref))
@@ -573,6 +619,18 @@ fromTx tx = mempty
             => (ChainIndexTx -> [(k, v)])
             -> InsertRows (TableEntity t)
         fromPairs l = InsertRows . fmap toDbValue . l $ tx
+
+        updateMapWithInlineDatum :: Map.Map DatumHash Datum -> [ChainIndex.ChainIndexTxOut] -> Map.Map DatumHash Datum
+        updateMapWithInlineDatum witness [] = witness
+        updateMapWithInlineDatum witness ((ChainIndexTxOut{citoDatum=OutputDatum d}) : tl) =
+          updateMapWithInlineDatum (Map.insert (datumHash d) d witness) tl
+        updateMapWithInlineDatum witness (_ : tl) = updateMapWithInlineDatum witness tl
+
+        getHashFromDatum :: OutputDatum -> Maybe DatumHash
+        getHashFromDatum NoOutputDatum        = Nothing
+        getHashFromDatum (OutputDatumHash dh) = Just dh
+        getHashFromDatum (OutputDatum d)      = Just (datumHash d)
+        -- note that the datum hash for inline datum is implicitly added in datumRows
 
 
 diagnostics ::

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Server.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Server.hs
@@ -67,6 +67,7 @@ serveChainIndex =
     :<|> E.utxoSetMembership
     :<|> (\(UtxoAtAddressRequest pq c) -> E.utxoSetAtAddress (fromMaybe def pq) c)
     :<|> (\(QueryAtAddressRequest pq c) -> E.unspentTxOutSetAtAddress (fromMaybe def pq) c)
+    :<|> (\(QueryAtAddressRequest pq c) -> E.datumsAtAddress (fromMaybe def pq) c)
     :<|> (\(UtxoWithCurrencyRequest pq c) -> E.utxoSetWithCurrency (fromMaybe def pq) c)
     :<|> E.txsFromTxIds
     :<|> (\(TxoAtAddressRequest pq c) -> E.txoSetAtAddress (fromMaybe def pq) c)

--- a/plutus-contract/src/Plutus/Contract.hs
+++ b/plutus-contract/src/Plutus/Contract.hs
@@ -54,6 +54,7 @@ module Plutus.Contract(
     , Request.utxoIsProduced
     -- * Chain index requests
     , Request.datumFromHash
+    , Request.datumsAt
     , Request.validatorFromHash
     , Request.mintingPolicyFromHash
     , Request.stakeValidatorFromHash

--- a/plutus-contract/src/Plutus/Contract/Effects.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects.hs
@@ -244,6 +244,7 @@ chainIndexMatches q r = case (q, r) of
     (UtxoSetMembership{}, UtxoSetMembershipResponse{})       -> True
     (UtxoSetAtAddress{}, UtxoSetAtResponse{})                -> True
     (UnspentTxOutSetAtAddress{}, UnspentTxOutsAtResponse{})  -> True
+    (DatumsAtAddress{}, DatumsAtResponse{})                  -> True
     (UtxoSetWithCurrency{}, UtxoSetWithCurrencyResponse{})   -> True
     (TxoSetAtAddress{}, TxoSetAtResponse{})                  -> True
     (TxsFromTxIds{}, TxIdsResponse{})                        -> True
@@ -265,6 +266,7 @@ data ChainIndexQuery =
   | UtxoSetMembership TxOutRef
   | UtxoSetAtAddress (PageQuery TxOutRef) Credential
   | UnspentTxOutSetAtAddress (PageQuery TxOutRef) Credential
+  | DatumsAtAddress (PageQuery TxOutRef) Credential
   | UtxoSetWithCurrency (PageQuery TxOutRef) AssetClass
   | TxsFromTxIds [TxId]
   | TxoSetAtAddress (PageQuery TxOutRef) Credential
@@ -280,11 +282,12 @@ instance Pretty ChainIndexQuery where
         StakeValidatorFromHash h     -> "requesting stake validator from hash" <+> pretty h
         RedeemerFromHash h           -> "requesting redeemer from hash" <+> pretty h
         TxOutFromRef r               -> "requesting utxo from utxo reference" <+> pretty r
-        UnspentTxOutFromRef r        -> "requesting utxo from utxo reference" <+> pretty r
+        UnspentTxOutFromRef r        -> "requesting unspent txos from utxo reference" <+> pretty r
         TxFromTxId i                 -> "requesting chain index tx from id" <+> pretty i
         UtxoSetMembership txOutRef   -> "whether tx output is part of the utxo set" <+> pretty txOutRef
         UtxoSetAtAddress _ c         -> "requesting utxos located at addresses with the credential" <+> pretty c
-        UnspentTxOutSetAtAddress _ c -> "requesting unspent utxos located at addresses with the credential" <+> pretty c
+        UnspentTxOutSetAtAddress _ c -> "requesting unspent txos located at addresses with the credential" <+> pretty c
+        DatumsAtAddress _ c          -> "requesting datums located at addresses with the credential" <+> pretty c
         UtxoSetWithCurrency _ ac     -> "requesting utxos containing the asset class" <+> pretty ac
         TxsFromTxIds i               -> "requesting chain index txs from ids" <+> pretty i
         TxoSetAtAddress _ c          -> "requesting txos located at addresses with the credential" <+> pretty c
@@ -305,6 +308,7 @@ data ChainIndexResponse =
   | UtxoSetMembershipResponse IsUtxoResponse
   | UtxoSetAtResponse UtxosResponse
   | UnspentTxOutsAtResponse (QueryResponse [(TxOutRef, ChainIndexTxOut)])
+  | DatumsAtResponse (QueryResponse [Datum])
   | UtxoSetWithCurrencyResponse UtxosResponse
   | TxIdsResponse [ChainIndexTx]
   | TxoSetAtResponse TxosResponse
@@ -320,7 +324,7 @@ instance Pretty ChainIndexResponse where
         StakeValidatorHashResponse m -> "Chain index stake validator from hash response:" <+> pretty m
         RedeemerHashResponse r -> "Chain index redeemer from hash response:" <+> pretty r
         TxOutRefResponse t -> "Chain index utxo from utxo ref response:" <+> pretty t
-        UnspentTxOutResponse t -> "Chain index utxo from utxo ref response:" <+> pretty t
+        UnspentTxOutResponse t -> "Chain index unspent txo from utxo ref response:" <+> pretty t
         TxIdResponse t -> "Chain index tx from tx id response:" <+> pretty (_citxTxId <$> t)
         UtxoSetMembershipResponse (IsUtxoResponse tip b) ->
                 "Chain index response whether tx output ref is part of the UTxO set:"
@@ -334,7 +338,9 @@ instance Pretty ChainIndexResponse where
             <+> "and utxo refs are"
             <+> hsep (fmap pretty $ pageItems txOutRefPage)
         UnspentTxOutsAtResponse (QueryResponse txouts _) ->
-          "Chain index datums from address response:" <+> hsep (fmap pretty txouts)
+          "Unspent txos from address response:" <+> hsep (fmap pretty txouts)
+        DatumsAtResponse (QueryResponse datums _) ->
+          "Chain index datums from address response:" <+> hsep (fmap pretty datums)
         UtxoSetWithCurrencyResponse (UtxosResponse tip txOutRefPage) ->
                 "Chain index UTxO with asset class response:"
             <+> "Current tip is"

--- a/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
+++ b/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
@@ -269,6 +269,7 @@ handleChainIndexQueries = RequestHandler $ \chainIndexQuery ->
         UtxoSetMembership txOutRef    -> UtxoSetMembershipResponse <$> ChainIndexEff.utxoSetMembership txOutRef
         UtxoSetAtAddress pq c         -> UtxoSetAtResponse <$> ChainIndexEff.utxoSetAtAddress pq c
         UnspentTxOutSetAtAddress pq c -> UnspentTxOutsAtResponse <$> ChainIndexEff.unspentTxOutSetAtAddress pq c
+        DatumsAtAddress pq c          -> DatumsAtResponse <$> ChainIndexEff.datumsAtAddress pq c
         UtxoSetWithCurrency pq ac     -> UtxoSetWithCurrencyResponse <$> ChainIndexEff.utxoSetWithCurrency pq ac
         TxoSetAtAddress pq c          -> TxoSetAtResponse <$> ChainIndexEff.txoSetAtAddress pq c
         TxsFromTxIds txids            -> TxIdsResponse <$> ChainIndexEff.txsFromTxIds txids

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -595,6 +595,7 @@ handleChainIndexEffect = runChainIndexEffects @t . \case
     UtxoSetMembership ref            -> ChainIndex.utxoSetMembership ref
     UtxoSetAtAddress pq addr         -> ChainIndex.utxoSetAtAddress pq addr
     UnspentTxOutSetAtAddress pq addr -> ChainIndex.unspentTxOutSetAtAddress pq addr
+    DatumsAtAddress pq addr          -> ChainIndex.datumsAtAddress pq addr
     UtxoSetWithCurrency pq ac        -> ChainIndex.utxoSetWithCurrency pq ac
     TxoSetAtAddress pq addr          -> ChainIndex.txoSetAtAddress pq addr
     TxsFromTxIds txids               -> ChainIndex.txsFromTxIds txids


### PR DESCRIPTION
Cherry-picked from:

*  https://github.com/etiennejf/plutus-apps/commit/6f827e1d5596adc52d94de38162600156567af31
*  https://github.com/etiennejf/plutus-apps/commit/e19627cbcac23190b1cdcbf350be5bdfb8137e4f
*  https://github.com/etiennejf/plutus-apps/commit/4fddda6273a77ba6d0ee2e81d16426b89537667f
*  https://github.com/etiennejf/plutus-apps/commit/ec541ad66a956dcf33894b9278562f6e7c3f2480

Summary:

* Added `Plutus.Contract.Request.datumsAt` which returns all datums associated with a target address

* Added datum in address row of plutus-chain-index DbSchema to avoid recording transaction in db and facilitate retrival and added datumsAtAddress query

* Added DatumAtAddress query to pab-blockfrost

CC @etiennejf 

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
