### PR TITLE
PLT-885 fix a bug in onchain MustPayToOtherScript

### DIFF
--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToOtherScript.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToOtherScript.hs
@@ -14,6 +14,7 @@ import Control.Monad (void)
 import Test.Tasty (TestTree, testGroup)
 
 import Ledger qualified
+import Ledger qualified as PSU
 import Ledger.Ada qualified as Ada
 import Ledger.Constraints qualified as Constraints
 import Ledger.Constraints.OnChain.V1 qualified as Constraints
@@ -49,15 +50,15 @@ v1Tests :: SubmitTx -> TestTree
 v1Tests sub = testGroup "Plutus V1" $
    [ v1FeaturesTests
    , v2FeaturesNotAvailableTests
-   ] ?? sub ?? languageContextV1
+   ] ?? sub ?? PSU.PlutusV1
 
 v2Tests :: SubmitTx -> TestTree
 v2Tests sub = testGroup "Plutus V2" $
   [ v1FeaturesTests
   , v2FeaturesTests
-  ] ?? sub ?? languageContextV2
+  ] ?? sub ?? PSU.PlutusV2
 
-v1FeaturesTests :: SubmitTx -> LanguageContext -> TestTree
+v1FeaturesTests :: SubmitTx -> PSU.Language -> TestTree
 v1FeaturesTests sub t = testGroup "Plutus V1 features" $
     [ successfulUseOfMustPayToOtherScriptWithDatumInTxWithMintedToken
     , successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOffchainIncludesTokenAndOnchainChecksOnlyToken
@@ -70,12 +71,12 @@ v1FeaturesTests sub t = testGroup "Plutus V1 features" $
     , phase2ErrorWhenExpectingMoreThanValue
     ] ?? sub ?? t
 
-v2FeaturesTests :: SubmitTx -> LanguageContext -> TestTree
+v2FeaturesTests :: SubmitTx -> PSU.Language -> TestTree
 v2FeaturesTests sub t = testGroup "Plutus V2 features" $
     [ successfulUseOfMustPayToOtherScriptWithInlineDatumWithMintedTokenV2
     ] ?? sub ?? t
 
-v2FeaturesNotAvailableTests :: SubmitTx -> LanguageContext -> TestTree
+v2FeaturesNotAvailableTests :: SubmitTx -> PSU.Language -> TestTree
 v2FeaturesNotAvailableTests sub t = testGroup "Plutus V2 features" $
     [ phase1FailureWhenPayToOtherScriptV1ScriptUseInlineDatum
     ] ?? sub ?? t
@@ -98,13 +99,13 @@ tknAmount = 5_000_000
 adaValue :: Value.Value
 adaValue = Ada.lovelaceValueOf adaAmount
 
-tknValueOf :: Integer -> LanguageContext -> Value.Value
+tknValueOf :: Integer -> PSU.Language -> Value.Value
 tknValueOf x tc = Value.singleton (mustPayToOtherScriptPolicyCurrencySymbol tc) "mint-me" x
 
-tknValue :: LanguageContext -> Value.Value
+tknValue :: PSU.Language -> Value.Value
 tknValue = tknValueOf tknAmount
 
-adaAndTokenValue :: LanguageContext -> Value.Value
+adaAndTokenValue :: PSU.Language -> Value.Value
 adaAndTokenValue = (adaValue <>) . tknValue
 
 otherTokenValue :: Value.Value
@@ -119,7 +120,7 @@ trace contract = do
 -- constraint and mint with policy using matching onchain constraint.
 mustPayToOtherScriptWithDatumInTxContract
     :: SubmitTx
-    -> LanguageContext
+    -> PSU.Language
     -> Value.Value
     -> Ledger.Redeemer
     -> Contract () Empty ContractError ()
@@ -136,7 +137,7 @@ mustPayToOtherScriptWithDatumInTxContract submitTxFromConstraints lc offChainVal
 
 -- | Valid scenario using offchain and onchain constraint
 -- 'mustPayToOtherScriptWithDatumInTx' with exact token value being minted.
-successfulUseOfMustPayToOtherScriptWithDatumInTxWithMintedToken :: SubmitTx -> LanguageContext -> TestTree
+successfulUseOfMustPayToOtherScriptWithDatumInTxWithMintedToken :: SubmitTx -> PSU.Language -> TestTree
 successfulUseOfMustPayToOtherScriptWithDatumInTxWithMintedToken submitTxFromConstraints lc =
     let onChainConstraint =
             asRedeemer
@@ -160,7 +161,7 @@ successfulUseOfMustPayToOtherScriptWithDatumInTxWithMintedToken submitTxFromCons
 -- matching onchain constraint, using Plutus V2 script and inline datum
 mustPayToOtherScriptWithInlineDatumContractV2
     :: SubmitTx
-    -> LanguageContext
+    -> PSU.Language
     -> Value.Value
     -> Redeemer
     -> Contract () Empty ContractError ()
@@ -179,7 +180,7 @@ mustPayToOtherScriptWithInlineDatumContractV2 submitTxFromConstraints lc offChai
 -- using inline datum.
 successfulUseOfMustPayToOtherScriptWithInlineDatumWithMintedTokenV2
     :: SubmitTx
-    -> LanguageContext
+    -> PSU.Language
     -> TestTree
 successfulUseOfMustPayToOtherScriptWithInlineDatumWithMintedTokenV2 submitTxFromConstraints lc =
     let onChainConstraint =
@@ -203,7 +204,7 @@ successfulUseOfMustPayToOtherScriptWithInlineDatumWithMintedTokenV2 submitTxFrom
 -- | Valid scenario using mustPayToOtherScript offchain constraint to include ada and token whilst onchain constraint checks for token value only
 successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOffchainIncludesTokenAndOnchainChecksOnlyToken
     :: SubmitTx
-    -> LanguageContext
+    -> PSU.Language
     -> TestTree
 successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOffchainIncludesTokenAndOnchainChecksOnlyToken
         submitTxFromConstraints lc =
@@ -225,7 +226,7 @@ successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOffchainIncludesTokenAndOnch
 -- | Valid scenario using mustPayToOtherScript offchain constraint to include ada and token whilst onchain constraint checks for ada value only
 successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOffchainIncludesTokenAndOnchainChecksOnlyAda
     :: SubmitTx
-    -> LanguageContext
+    -> PSU.Language
     -> TestTree
 successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOffchainIncludesTokenAndOnchainChecksOnlyAda
         submitTxFromConstraints lc =
@@ -247,7 +248,7 @@ successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOffchainIncludesTokenAndOnch
 -- script's exact token balance.
 successfulUseOfMustPayToOtherScriptWithDatumInTxWithScriptsExactTokenBalance
     :: SubmitTx
-    -> LanguageContext
+    -> PSU.Language
     -> TestTree
 successfulUseOfMustPayToOtherScriptWithDatumInTxWithScriptsExactTokenBalance submitTxFromConstraints lc =
     let otherValidatorHash = alwaysSucceedValidatorHash
@@ -288,7 +289,7 @@ successfulUseOfMustPayToOtherScriptWithDatumInTxWithScriptsExactTokenBalance sub
 -- | Valid scenario where onchain mustPayToOtherScript constraint expects less ada than the actual value
 successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOnchainExpectsLowerAdaValue
     :: SubmitTx
-    -> LanguageContext
+    -> PSU.Language
     -> TestTree
 successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOnchainExpectsLowerAdaValue
         submitTxFromConstraints lc =
@@ -313,7 +314,7 @@ successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOnchainExpectsLowerAdaValue
 -- | Valid scenario where onchain mustPayToOtherScript constraint expects less token than the actual value
 successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOnchainExpectsLowerTokenValue
     :: SubmitTx
-    -> LanguageContext
+    -> PSU.Language
     -> TestTree
 successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOnchainExpectsLowerTokenValue
         submitTxFromConstraints lc =
@@ -338,7 +339,7 @@ successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOnchainExpectsLowerTokenValu
 -- | Invalid contract that tries to use inline datum in a V1 script
 mustPayToOtherScriptWithInlineDatumContract
     :: SubmitTx
-    -> LanguageContext
+    -> PSU.Language
     -> Value.Value
     -> Redeemer
     -> Contract () Empty ContractError ()
@@ -354,7 +355,7 @@ mustPayToOtherScriptWithInlineDatumContract submitTxFromConstraints lc offChainV
     awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx1
 
 -- | Contract error when ada amount to send to other script is greater than wallet balance
-contractErrorWhenAttemptingToSpendMoreThanAdaBalance :: SubmitTx -> LanguageContext -> TestTree
+contractErrorWhenAttemptingToSpendMoreThanAdaBalance :: SubmitTx -> PSU.Language -> TestTree
 contractErrorWhenAttemptingToSpendMoreThanAdaBalance submitTxFromConstraints lc =
     let onChainConstraint = asRedeemer $ MustPayToOtherScriptWithDatumInTx someValidatorHash someDatum adaValue
         walletAdaBalance = Value.scale 10 utxoValue -- with fees this exceeds wallet balance
@@ -371,7 +372,7 @@ contractErrorWhenAttemptingToSpendMoreThanAdaBalance submitTxFromConstraints lc 
     (void $ trace contract)
 
 -- | Contract error when token amount to send to other script is greater than wallet balance
-contractErrorWhenAttemptingToSpendMoreThanTokenBalance :: SubmitTx -> LanguageContext -> TestTree
+contractErrorWhenAttemptingToSpendMoreThanTokenBalance :: SubmitTx -> PSU.Language -> TestTree
 contractErrorWhenAttemptingToSpendMoreThanTokenBalance submitTxFromConstraints lc =
     let onChainConstraint =
             asRedeemer
@@ -389,7 +390,7 @@ contractErrorWhenAttemptingToSpendMoreThanTokenBalance submitTxFromConstraints l
     (void $ trace contract)
 
 -- | Phase-1 failure when mustPayToOtherScript in a V1 script use inline datum
-phase1FailureWhenPayToOtherScriptV1ScriptUseInlineDatum :: SubmitTx -> LanguageContext -> TestTree
+phase1FailureWhenPayToOtherScriptV1ScriptUseInlineDatum :: SubmitTx -> PSU.Language -> TestTree
 phase1FailureWhenPayToOtherScriptV1ScriptUseInlineDatum submitTxFromConstraints lc =
     let onChainConstraint = asRedeemer $ MustPayToOtherScriptWithInlineDatum someValidatorHash someDatum (adaAndTokenValue lc)
         contract = mustPayToOtherScriptWithInlineDatumContract submitTxFromConstraints lc (adaAndTokenValue lc) onChainConstraint
@@ -402,7 +403,7 @@ phase1FailureWhenPayToOtherScriptV1ScriptUseInlineDatum submitTxFromConstraints 
 
 
 -- | Phase-2 validation failure when onchain mustSpendScriptOutput constraint expects more than actual ada value
-phase2ErrorWhenExpectingMoreThanValue :: SubmitTx -> LanguageContext -> TestTree
+phase2ErrorWhenExpectingMoreThanValue :: SubmitTx -> PSU.Language -> TestTree
 phase2ErrorWhenExpectingMoreThanValue submitTxFromConstraints lc =
     let onChainConstraint =
             asRedeemer
@@ -446,26 +447,20 @@ mustPayToOtherScriptPolicyV2 = Ledger.mkMintingPolicyScript $$(PlutusTx.compile 
         checkedMkMustPayToOtherScriptPolicy = mkMustPayToOtherScriptPolicy V2.Constraints.checkScriptContext
         wrap = V2.Scripts.mkUntypedMintingPolicy checkedMkMustPayToOtherScriptPolicy
 
-data LanguageContext
-   = LanguageContext
-   { mustPayToOtherScriptPolicy :: Ledger.MintingPolicy
-   , mintingPolicy              :: forall a. Ledger.MintingPolicy -> Constraints.ScriptLookups a
-   , mintingPolicyHash          :: Ledger.MintingPolicy -> Ledger.MintingPolicyHash
-   }
+mustPayToOtherScriptPolicy :: PSU.Language -> Ledger.MintingPolicy
+mustPayToOtherScriptPolicy = \case
+  PSU.PlutusV1 -> mustPayToOtherScriptPolicyV1
+  PSU.PlutusV2 -> mustPayToOtherScriptPolicyV2
 
-languageContextV1 :: LanguageContext
-languageContextV1 = LanguageContext
-    mustPayToOtherScriptPolicyV1
-    Constraints.plutusV1MintingPolicy
-    PSU.V1.mintingPolicyHash
+mintingPolicy :: PSU.Language -> forall a. Ledger.MintingPolicy -> Constraints.ScriptLookups a
+mintingPolicy = \case
+  PSU.PlutusV1 -> Constraints.plutusV1MintingPolicy
+  PSU.PlutusV2 -> Constraints.plutusV2MintingPolicy
 
-
-languageContextV2 :: LanguageContext
-languageContextV2 = LanguageContext
-    mustPayToOtherScriptPolicyV2
-    Constraints.plutusV2MintingPolicy
-    PSU.V2.mintingPolicyHash
-
+mintingPolicyHash :: PSU.Language -> Ledger.MintingPolicy -> Ledger.MintingPolicyHash
+mintingPolicyHash = \case
+  PSU.PlutusV1 -> PSU.V1.mintingPolicyHash
+  PSU.PlutusV2 -> PSU.V2.mintingPolicyHash
 
 type SubmitTx
   =  Constraints.ScriptLookups UnitTest
@@ -481,10 +476,10 @@ ledgerSubmitTx :: SubmitTx
 ledgerSubmitTx = submitTxConstraintsWith
 
 
-mustPayToOtherScriptPolicyHash :: LanguageContext -> Ledger.MintingPolicyHash
+mustPayToOtherScriptPolicyHash :: PSU.Language -> Ledger.MintingPolicyHash
 mustPayToOtherScriptPolicyHash lc = mintingPolicyHash lc $ mustPayToOtherScriptPolicy lc
 
-mustPayToOtherScriptPolicyCurrencySymbol :: LanguageContext -> Ledger.CurrencySymbol
+mustPayToOtherScriptPolicyCurrencySymbol :: PSU.Language -> Ledger.CurrencySymbol
 mustPayToOtherScriptPolicyCurrencySymbol = Value.mpsSymbol . mustPayToOtherScriptPolicyHash
 
 data ConstraintParams =

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToOtherScript.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToOtherScript.hs
@@ -62,7 +62,7 @@ v1FeaturesTests :: SubmitTx -> PSU.Language -> TestTree
 v1FeaturesTests sub t = testGroup "Plutus V1 features" $
     [ successfulUseOfMustPayToOtherScriptWithDatumInTxWithMintedToken
     , successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOffchainIncludesTokenAndOnchainChecksOnlyToken
-    , successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOffchainIncludesTokenAndOnchainChecksOnlyAda -- FAILING when onchain checks for only ada value and token is present -- PLT-885
+    , successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOffchainIncludesTokenAndOnchainChecksOnlyAda
     , successfulUseOfMustPayToOtherScriptWithDatumInTxWithScriptsExactTokenBalance
     , successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOnchainExpectsLowerAdaValue
     , successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOnchainExpectsLowerTokenValue

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToOtherScript.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToOtherScript.hs
@@ -61,7 +61,7 @@ v1FeaturesTests :: SubmitTx -> LanguageContext -> TestTree
 v1FeaturesTests sub t = testGroup "Plutus V1 features" $
     [ successfulUseOfMustPayToOtherScriptWithDatumInTxWithMintedToken
     , successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOffchainIncludesTokenAndOnchainChecksOnlyToken
-    --, successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOffchainIncludesTokenAndOnchainChecksOnlyAda -- FAILING when onchain checks for only ada value and token is present -- PLT-885
+    , successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOffchainIncludesTokenAndOnchainChecksOnlyAda -- FAILING when onchain checks for only ada value and token is present -- PLT-885
     , successfulUseOfMustPayToOtherScriptWithDatumInTxWithScriptsExactTokenBalance
     , successfulUseOfMustPayToOtherScriptWithDatumInTxWhenOnchainExpectsLowerAdaValue
     , contractErrorWhenAttemptingToSpendMoreThanAdaBalance
@@ -106,7 +106,7 @@ otherTokenValue = someTokenValue "someToken" 1
 trace :: Contract () Empty ContractError () -> Trace.EmulatorTrace ()
 trace contract = do
     void $ Trace.activateContractWallet w1 contract
-    void $ Trace.waitNSlots 1
+    void Trace.nextSlot
 
 -- | Contract to a single transaction with mustSpendScriptOutputs offchain
 -- constraint and mint with policy using matching onchain constraint.

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToOtherScript.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToOtherScript.hs
@@ -88,10 +88,10 @@ otherDatum :: Ledger.Datum
 otherDatum = asDatum @P.BuiltinByteString "other datum"
 
 utxoValue :: Value.Value
-utxoValue = Ada.lovelaceValueOf 10_000_000
+utxoValue = Ada.lovelaceValueOf 50_000_000
 
 adaAmount :: Integer
-adaAmount = 5_000_000
+adaAmount = 25_000_000
 
 tknAmount :: Integer
 tknAmount = 5_000_000

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OnChain/V1.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OnChain/V1.hs
@@ -30,6 +30,7 @@ import Ledger.Constraints.TxConstraints (ScriptInputConstraint (ScriptInputConst
                                          TxConstraints (TxConstraints, txConstraintFuns, txConstraints, txOwnInputs, txOwnOutputs),
                                          TxOutDatum (TxOutDatumHash, TxOutDatumInTx), getTxOutDatum)
 import Ledger.Credential (Credential (ScriptCredential))
+import Ledger.Value (geq, leq)
 import Ledger.Value qualified as Value
 import Plutus.V1.Ledger.Address qualified as Address
 import Plutus.V1.Ledger.Contexts (ScriptContext (ScriptContext, scriptContextTxInfo),
@@ -38,7 +39,6 @@ import Plutus.V1.Ledger.Contexts (ScriptContext (ScriptContext, scriptContextTxI
                                   TxOut (TxOut, txOutAddress, txOutDatumHash, txOutValue))
 import Plutus.V1.Ledger.Contexts qualified as V
 import Plutus.V1.Ledger.Interval (contains)
-import Plutus.V1.Ledger.Value (leq)
 
 {-# INLINABLE checkScriptContext #-}
 -- | Does the 'ScriptContext' satisfy the constraints?
@@ -140,12 +140,12 @@ checkTxConstraint ctx@ScriptContext{scriptContextTxInfo} = \case
                 -- provide datum.
                    Ada.fromValue txOutValue >= Ada.fromValue vl
                 && Ada.fromValue txOutValue <= Ada.fromValue vl + Ledger.maxMinAdaTxOut
-                && Value.noAdaValue txOutValue == Value.noAdaValue vl
+                && geq (Value.noAdaValue txOutValue) (Value.noAdaValue vl)
                 && txOutAddress == addr
             checkOutput (TxOutDatumInTx d) TxOut{txOutAddress, txOutValue, txOutDatumHash=Just h} =
                    Ada.fromValue txOutValue >= Ada.fromValue vl
                 && Ada.fromValue txOutValue <= Ada.fromValue vl + Ledger.maxMinAdaTxOut
-                && Value.noAdaValue txOutValue == Value.noAdaValue vl
+                && geq (Value.noAdaValue txOutValue) (Value.noAdaValue vl)
                 && hsh d == Just h
                 && txOutAddress == addr
             -- By ledger rules, a script output with no datum is unspendable.

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OnChain/V1.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OnChain/V1.hs
@@ -139,12 +139,10 @@ checkTxConstraint ctx@ScriptContext{scriptContextTxInfo} = \case
                 -- that the tx output's datum hash is the correct one w.r.t the
                 -- provide datum.
                    Ada.fromValue txOutValue >= Ada.fromValue vl
-                && Ada.fromValue txOutValue <= Ada.fromValue vl + Ledger.maxMinAdaTxOut
                 && geq (Value.noAdaValue txOutValue) (Value.noAdaValue vl)
                 && txOutAddress == addr
             checkOutput (TxOutDatumInTx d) TxOut{txOutAddress, txOutValue, txOutDatumHash=Just h} =
                    Ada.fromValue txOutValue >= Ada.fromValue vl
-                && Ada.fromValue txOutValue <= Ada.fromValue vl + Ledger.maxMinAdaTxOut
                 && geq (Value.noAdaValue txOutValue) (Value.noAdaValue vl)
                 && hsh d == Just h
                 && txOutAddress == addr

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OnChain/V1.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OnChain/V1.hs
@@ -30,7 +30,7 @@ import Ledger.Constraints.TxConstraints (ScriptInputConstraint (ScriptInputConst
                                          TxConstraints (TxConstraints, txConstraintFuns, txConstraints, txOwnInputs, txOwnOutputs),
                                          TxOutDatum (TxOutDatumHash, TxOutDatumInTx), getTxOutDatum)
 import Ledger.Credential (Credential (ScriptCredential))
-import Ledger.Value (geq, leq)
+import Ledger.Value (leq)
 import Ledger.Value qualified as Value
 import Plutus.V1.Ledger.Address qualified as Address
 import Plutus.V1.Ledger.Contexts (ScriptContext (ScriptContext, scriptContextTxInfo),
@@ -138,12 +138,10 @@ checkTxConstraint ctx@ScriptContext{scriptContextTxInfo} = \case
                 -- The datum is not added in the tx body with so we can't verify
                 -- that the tx output's datum hash is the correct one w.r.t the
                 -- provide datum.
-                   Ada.fromValue txOutValue >= Ada.fromValue vl
-                && geq (Value.noAdaValue txOutValue) (Value.noAdaValue vl)
+                   vl `leq` txOutValue
                 && txOutAddress == addr
             checkOutput (TxOutDatumInTx d) TxOut{txOutAddress, txOutValue, txOutDatumHash=Just h} =
-                   Ada.fromValue txOutValue >= Ada.fromValue vl
-                && geq (Value.noAdaValue txOutValue) (Value.noAdaValue vl)
+                   vl `leq` txOutValue
                 && hsh d == Just h
                 && txOutAddress == addr
             -- By ledger rules, a script output with no datum is unspendable.

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OnChain/V2.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OnChain/V2.hs
@@ -31,7 +31,7 @@ import Ledger.Value qualified as Value
 import Plutus.Script.Utils.V2.Contexts qualified as PV2 hiding (findTxInByTxOutRef)
 import Plutus.V1.Ledger.Address (Address (Address))
 import Plutus.V1.Ledger.Interval (contains)
-import Plutus.V1.Ledger.Value (leq)
+import Plutus.V1.Ledger.Value (geq, leq)
 import Plutus.V2.Ledger.Contexts (ScriptContext (ScriptContext, scriptContextTxInfo), ScriptPurpose (Spending),
                                   TxInInfo (TxInInfo, txInInfoOutRef, txInInfoResolved),
                                   TxInfo (txInfoData, txInfoInputs, txInfoMint, txInfoRedeemers, txInfoValidRange),
@@ -153,12 +153,12 @@ checkTxConstraint ctx@ScriptContext{scriptContextTxInfo} = \case
                 -- provide datum.
                    Ada.fromValue txOutValue >= Ada.fromValue vl
                 && Ada.fromValue txOutValue <= Ada.fromValue vl + Ledger.maxMinAdaTxOut
-                && Value.noAdaValue txOutValue == Value.noAdaValue vl
+                && geq (Value.noAdaValue txOutValue) (Value.noAdaValue vl)
                 && txOutAddress == addr
             checkOutput (TxOutDatumInTx _) TxOut{txOutAddress, txOutValue, txOutDatum=OutputDatumHash h} =
                    Ada.fromValue txOutValue >= Ada.fromValue vl
                 && Ada.fromValue txOutValue <= Ada.fromValue vl + Ledger.maxMinAdaTxOut
-                && Value.noAdaValue txOutValue == Value.noAdaValue vl
+                && geq (Value.noAdaValue txOutValue) (Value.noAdaValue vl)
                 && hsh == Just h
                 && txOutAddress == addr
             -- With regards to inline datum, we have the actual datum in the tx

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OnChain/V2.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OnChain/V2.hs
@@ -31,7 +31,7 @@ import Ledger.Value qualified as Value
 import Plutus.Script.Utils.V2.Contexts qualified as PV2 hiding (findTxInByTxOutRef)
 import Plutus.V1.Ledger.Address (Address (Address))
 import Plutus.V1.Ledger.Interval (contains)
-import Plutus.V1.Ledger.Value (geq, leq)
+import Plutus.V1.Ledger.Value (leq)
 import Plutus.V2.Ledger.Contexts (ScriptContext (ScriptContext, scriptContextTxInfo), ScriptPurpose (Spending),
                                   TxInInfo (TxInInfo, txInInfoOutRef, txInInfoResolved),
                                   TxInfo (txInfoData, txInfoInputs, txInfoMint, txInfoRedeemers, txInfoValidRange),
@@ -151,20 +151,16 @@ checkTxConstraint ctx@ScriptContext{scriptContextTxInfo} = \case
                 -- The datum is not added in the tx body with so we can't verify
                 -- that the tx output's datum hash is the correct one w.r.t the
                 -- provide datum.
-                   Ada.fromValue txOutValue >= Ada.fromValue vl
-                && geq (Value.noAdaValue txOutValue) (Value.noAdaValue vl)
+                   vl `leq` txOutValue
                 && txOutAddress == addr
             checkOutput (TxOutDatumInTx _) TxOut{txOutAddress, txOutValue, txOutDatum=OutputDatumHash h} =
-                   Ada.fromValue txOutValue >= Ada.fromValue vl
-                && geq (Value.noAdaValue txOutValue) (Value.noAdaValue vl)
+                   vl `leq` txOutValue
                 && hsh == Just h
                 && txOutAddress == addr
             -- With regards to inline datum, we have the actual datum in the tx
             -- output. Therefore, we can compare it with the provided datum.
             checkOutput (TxOutDatumInline d) TxOut{txOutAddress, txOutValue, txOutDatum=OutputDatum id} =
-                   Ada.fromValue txOutValue >= Ada.fromValue vl
-                && Ada.fromValue txOutValue <= Ada.fromValue vl + Ledger.maxMinAdaTxOut
-                && Value.noAdaValue txOutValue == Value.noAdaValue vl
+                   vl `leq` txOutValue
                 && d == id
                 && txOutAddress == addr
             checkOutput _ _ = False

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OnChain/V2.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OnChain/V2.hs
@@ -152,12 +152,10 @@ checkTxConstraint ctx@ScriptContext{scriptContextTxInfo} = \case
                 -- that the tx output's datum hash is the correct one w.r.t the
                 -- provide datum.
                    Ada.fromValue txOutValue >= Ada.fromValue vl
-                && Ada.fromValue txOutValue <= Ada.fromValue vl + Ledger.maxMinAdaTxOut
                 && geq (Value.noAdaValue txOutValue) (Value.noAdaValue vl)
                 && txOutAddress == addr
             checkOutput (TxOutDatumInTx _) TxOut{txOutAddress, txOutValue, txOutDatum=OutputDatumHash h} =
                    Ada.fromValue txOutValue >= Ada.fromValue vl
-                && Ada.fromValue txOutValue <= Ada.fromValue vl + Ledger.maxMinAdaTxOut
                 && geq (Value.noAdaValue txOutValue) (Value.noAdaValue vl)
                 && hsh == Just h
                 && txOutAddress == addr

--- a/plutus-ledger-constraints/src/Ledger/Constraints/TxConstraints.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/TxConstraints.hs
@@ -567,6 +567,9 @@ mustPayToOtherScriptWithInlineDatum vh dv vl =
 -- If used in 'Ledger.Constraints.OnChain', this constraint verifies that @d@ is
 -- part of the datum witness set and that the script transaction output with
 -- @vh@, @svh@, @d@ and @v@ is part of the transaction's outputs.
+-- For @v@, tt meants that the transactions output must be at least the given value.
+-- The output can contain more, or different tokens, but the requested value @v@ must
+-- be present.
 mustPayToOtherScriptAddress :: forall i o. ValidatorHash -> StakeValidatorHash -> Datum -> Value -> TxConstraints i o
 mustPayToOtherScriptAddress vh svh dv vl =
     singleton (MustPayToOtherScript vh (Just svh) (TxOutDatumHash dv) Nothing vl)
@@ -582,6 +585,9 @@ mustPayToOtherScriptAddress vh svh dv vl =
 -- If used in 'Ledger.Constraints.OnChain', this constraint verifies that @d@ is
 -- part of the datum witness set and that the script transaction output with
 -- @vh@, @svh@, @d@ and @v@ is part of the transaction's outputs.
+-- For @v@, tt meants that the transactions output must be at least the given value.
+-- The output can contain more, or different tokens, but the requested value @v@ must
+-- be present.
 mustPayToOtherScriptAddressWithDatumInTx
     :: forall i o. ValidatorHash
     -> StakeValidatorHash
@@ -626,7 +632,7 @@ mustMintValueWithRedeemer red = mustMintValueWithRedeemerAndReference red Nothin
 --
 -- Note that we can derive the 'MintingPolicyHash' from the 'Value'\'s currency
 -- symbol.
-mustMintValueWithRedeemerAndReference :: forall i o. Redeemer -> (Maybe TxOutRef) -> Value -> TxConstraints i o
+mustMintValueWithRedeemerAndReference :: forall i o. Redeemer -> Maybe TxOutRef -> Value -> TxConstraints i o
 mustMintValueWithRedeemerAndReference red mref =
     foldMap valueConstraint . (AssocMap.toList . Value.getValue)
     where

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -550,7 +550,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       674baeaf3ed431067b51dc5ef201c76513c9df3b48f3fd73d399142772c7f28b
+TxId:       497cada58e5e2ba134d25052bb7d363757c40f46c4b0a784cc8ca34388dd122b
 Fee:        Ada:      Lovelace:  178173
 Mint:       -
 Inputs:
@@ -573,7 +573,7 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  Script: 51efd7da3e711d12c69d47b391600ed26be15d776b25a3af320b1e76
+  Destination:  Script: 6771a61bedd67c6ba5c9cfcbfda22f6c8a1223c2118ba65fa54de97f
   Value:
     Ada:      Lovelace:  8000000
 
@@ -624,6 +624,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 51efd7da3e711d12c69d47b391600ed26be15d776b25a3af320b1e76
+  Script: 6771a61bedd67c6ba5c9cfcbfda22f6c8a1223c2118ba65fa54de97f
   Value:
     Ada:      Lovelace:  8000000

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -550,7 +550,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       59cce8a906cb07debcd8d67f7501d2429befc1e31cf8c4519fa93200220160a9
+TxId:       674baeaf3ed431067b51dc5ef201c76513c9df3b48f3fd73d399142772c7f28b
 Fee:        Ada:      Lovelace:  178173
 Mint:       -
 Inputs:
@@ -573,7 +573,7 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  Script: b88ccc3d7f4979e08dff26423096527d0dc7e82bec20a379463b3cc4
+  Destination:  Script: 51efd7da3e711d12c69d47b391600ed26be15d776b25a3af320b1e76
   Value:
     Ada:      Lovelace:  8000000
 
@@ -624,6 +624,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: b88ccc3d7f4979e08dff26423096527d0dc7e82bec20a379463b3cc4
+  Script: 51efd7da3e711d12c69d47b391600ed26be15d776b25a3af320b1e76
   Value:
     Ada:      Lovelace:  8000000


### PR DESCRIPTION
We were making an exact comparison for non-ada values while we must have checked that the provided values of the tx cover the expectations of the constraint.

I added a test for partial spending of other tokens. 

While at it, I refactored the `MustPayToOtherScript` test suite to harmonise it with the other constraints suites.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
