### PR TITLE
Add SECP256k1 ECDSA and Schnorr loop becnhmarking scripts

### DIFF
--- a/plutus-example/app/plutus-example.hs
+++ b/plutus-example/app/plutus-example.hs
@@ -15,9 +15,11 @@ import PlutusExample.PlutusVersion1.MintingScript (apiExamplePlutusMintingScript
 import PlutusExample.PlutusVersion1.RedeemerContextScripts
 import PlutusExample.PlutusVersion1.Sum (sumScript)
 
+import PlutusExample.PlutusVersion2.EcdsaSecp256k1Loop (v2EcdsaLoopScript)
 import PlutusExample.PlutusVersion2.MintingScript (v2mintingScript)
 import PlutusExample.PlutusVersion2.RedeemerContextEquivalence (v2ScriptContextEquivalenceScript, v2mintEquivScript)
 import PlutusExample.PlutusVersion2.RequireRedeemer (requireRedeemerScript)
+import PlutusExample.PlutusVersion2.SchnorrSecp256k1Loop (v2SchnorrLoopScript)
 import PlutusExample.PlutusVersion2.StakeScript (v2StakeScript)
 
 main :: IO ()
@@ -44,4 +46,7 @@ main = do
   _ <- writeFileTextEnvelope (v2dir </> "stake-script.plutus") Nothing v2StakeScript
   _ <- writeFileTextEnvelope (v2dir </> "context-equivalence-test.plutus") Nothing v2ScriptContextEquivalenceScript
   _ <- writeFileTextEnvelope (v2dir </> "minting-context-equivalance-test.plutus") Nothing v2mintEquivScript
+  _ <- writeFileTextEnvelope (v2dir </> "ecdsa-secp256k1-loop.plutus") Nothing v2EcdsaLoopScript
+  _ <- writeFileTextEnvelope (v2dir </> "schnorr-secp256k1-loop.plutus") Nothing v2SchnorrLoopScript
+
   return ()

--- a/plutus-example/plutus-example.cabal
+++ b/plutus-example/plutus-example.cabal
@@ -61,9 +61,11 @@ library
     PlutusExample.PlutusVersion1.MintingScript
     PlutusExample.PlutusVersion1.RedeemerContextScripts
     PlutusExample.PlutusVersion1.Sum
+    PlutusExample.PlutusVersion2.EcdsaSecp256k1Loop
     PlutusExample.PlutusVersion2.MintingScript
     PlutusExample.PlutusVersion2.RedeemerContextEquivalence
     PlutusExample.PlutusVersion2.RequireRedeemer
+    PlutusExample.PlutusVersion2.SchnorrSecp256k1Loop
     PlutusExample.PlutusVersion2.StakeScript
     PlutusExample.ScriptContextChecker
 

--- a/plutus-example/src/PlutusExample/PlutusVersion2/EcdsaSecp256k1Loop.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion2/EcdsaSecp256k1Loop.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeFamilies      #-}
+
+module PlutusExample.PlutusVersion2.EcdsaSecp256k1Loop
+    ( v2EcdsaLoopScript
+    , v2EcdsaLoopScriptShortBs
+    ) where
+
+import Cardano.Api (PlutusScript, PlutusScriptV2)
+import Cardano.Api.Shelley (PlutusScript (..))
+import Codec.Serialise (serialise)
+import Data.ByteString.Lazy qualified as LBS
+import Data.ByteString.Short qualified as SBS
+import Plutus.V2.Ledger.Api qualified as PlutusV2
+import PlutusTx qualified
+import PlutusTx.Builtins qualified as BI
+import PlutusTx.Prelude as P hiding (Semigroup (..), unless, (.))
+import Prelude ((.))
+
+{-# INLINEABLE mkValidator #-}
+mkValidator :: BuiltinData -> BuiltinData -> BuiltinData -> ()
+mkValidator _datum red _txContext =
+  case PlutusV2.fromBuiltinData red of
+    Nothing -> P.traceError "Trace error: Invalid redeemer"
+    Just (n, vkey, msg, sig) ->
+      if n < (0 :: Integer)
+      then traceError "redeemer is < 0"
+      else loop n vkey msg sig
+  where
+    loop i v m s
+      | i == 0 = ()
+      | BI.verifyEcdsaSecp256k1Signature v m s = loop (pred i) v m s
+      | otherwise = P.traceError "Trace error: Ecdsa validation failed"
+
+validator :: PlutusV2.Validator
+validator = PlutusV2.mkValidatorScript $$(PlutusTx.compile [|| mkValidator ||])
+
+script :: PlutusV2.Script
+script = PlutusV2.unValidatorScript validator
+
+v2EcdsaLoopScriptShortBs :: SBS.ShortByteString
+v2EcdsaLoopScriptShortBs = SBS.toShort . LBS.toStrict $ serialise script
+
+v2EcdsaLoopScript :: PlutusScript PlutusScriptV2
+v2EcdsaLoopScript = PlutusScriptSerialised v2EcdsaLoopScriptShortBs

--- a/plutus-example/src/PlutusExample/PlutusVersion2/SchnorrSecp256k1Loop.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion2/SchnorrSecp256k1Loop.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeFamilies      #-}
+
+module PlutusExample.PlutusVersion2.SchnorrSecp256k1Loop
+    ( v2SchnorrLoopScript
+    , v2SchnorrLoopScriptShortBs
+    ) where
+
+import Cardano.Api (PlutusScript, PlutusScriptV2)
+import Cardano.Api.Shelley (PlutusScript (..))
+import Codec.Serialise (serialise)
+import Data.ByteString.Lazy qualified as LBS
+import Data.ByteString.Short qualified as SBS
+import Plutus.V2.Ledger.Api qualified as PlutusV2
+import PlutusTx qualified
+import PlutusTx.Builtins qualified as BI
+import PlutusTx.Prelude as P hiding (Semigroup (..), unless, (.))
+import Prelude ((.))
+
+{-# INLINEABLE mkValidator #-}
+mkValidator :: BuiltinData -> BuiltinData -> BuiltinData -> ()
+mkValidator _datum red _txContext =
+  case PlutusV2.fromBuiltinData red of
+    Nothing -> P.traceError "Trace error: Invalid redeemer"
+    Just (n, vkey, msg, sig) ->
+      if n < (0 :: Integer)
+      then traceError "redeemer is < 0"
+      else loop n vkey msg sig
+  where
+    loop i v m s
+      | i == 0 = ()
+      | BI.verifySchnorrSecp256k1Signature v m s = loop (pred i) v m s
+      | otherwise = P.traceError "Trace error: Schnorr validation failed"
+
+validator :: PlutusV2.Validator
+validator = PlutusV2.mkValidatorScript $$(PlutusTx.compile [|| mkValidator ||])
+
+script :: PlutusV2.Script
+script = PlutusV2.unValidatorScript validator
+
+v2SchnorrLoopScriptShortBs :: SBS.ShortByteString
+v2SchnorrLoopScriptShortBs = SBS.toShort . LBS.toStrict $ serialise script
+
+v2SchnorrLoopScript :: PlutusScript PlutusScriptV2
+v2SchnorrLoopScript = PlutusScriptSerialised v2SchnorrLoopScriptShortBs


### PR DESCRIPTION
Two new plutus V2 scripts for looping over SECP256k1 ECDSA and Schnorr verify builtin functions.

Can use the following redeemers (cli json format). Change the `int` for number of loops:

ECDSA
```
{"constructor":0,"fields":[{"int":10},{"bytes":"0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"},{"bytes":"16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"},{"bytes":"5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"}]}
```

Schnorr
```
{"constructor":0,"fields":[{"int":10},{"bytes":"599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b"},{"bytes":"30303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030"},{"bytes":"5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a9b"}]}
```