### PR TITLE
PLT-1219 Remove offchain logic for MustProduceAtLeast and MustSpendAtLeast

### DIFF
--- a/doc/plutus/tutorials/GameModel.hs
+++ b/doc/plutus/tutorials/GameModel.hs
@@ -30,7 +30,7 @@ import Test.QuickCheck (Arbitrary, Gen, Property, arbitrary, choose, elements, f
                         shrink, tabulate, withMaxSuccess)
 
 -- START import Contract.Test
-import Plutus.Contract.Test (Wallet, minLogLevel, mockWalletPaymentPubKeyHash, w1, w2, w3)
+import Plutus.Contract.Test (Wallet, minLogLevel, mockWalletAddress, w1, w2, w3)
 -- END import Contract.Test
 
 -- START import ContractModel
@@ -71,7 +71,7 @@ import Data.Default (Default (def))
 
 -- START gameParam
 gameParam :: G.GameParam
-gameParam = G.GameParam (mockWalletPaymentPubKeyHash w1) (TimeSlot.scSlotZeroTime def)
+gameParam = G.GameParam (mockWalletAddress w1) (TimeSlot.scSlotZeroTime def)
 -- END gameParam
 
 -- * QuickCheck model
@@ -133,7 +133,7 @@ instance CM.ContractModel GameModel where
             Trace.callEndpoint @"guess" (handle $ WalletKey w)
                 G.GuessArgs
                     { G.guessArgsGameParam     = gameParam
-                    , G.guessTokenTarget       = mockWalletPaymentPubKeyHash w
+                    , G.guessTokenTarget       = mockWalletAddress w
                     , G.guessArgsOldSecret     = old
                     , G.guessArgsNewSecret     = secretArg new
                     , G.guessArgsValueTakenOut = Ada.lovelaceValueOf val
@@ -423,7 +423,7 @@ v1_model = ()
             Trace.callEndpoint @"guess" (handle $ WalletKey w)
                 G.GuessArgs
                     { G.guessArgsGameParam = gameParam
-                    , G.guessTokenTarget   = mockWalletPaymentPubKeyHash w
+                    , G.guessTokenTarget   = mockWalletAddress w
                     , G.guessArgsOldSecret = old
                     , G.guessArgsNewSecret = secretArg new
                     , G.guessArgsValueTakenOut = Ada.lovelaceValueOf val

--- a/doc/plutus/tutorials/GameModel.hs
+++ b/doc/plutus/tutorials/GameModel.hs
@@ -133,6 +133,7 @@ instance CM.ContractModel GameModel where
             Trace.callEndpoint @"guess" (handle $ WalletKey w)
                 G.GuessArgs
                     { G.guessArgsGameParam     = gameParam
+                    , G.guessTokenTarget       = mockWalletPaymentPubKeyHash w
                     , G.guessArgsOldSecret     = old
                     , G.guessArgsNewSecret     = secretArg new
                     , G.guessArgsValueTakenOut = Ada.lovelaceValueOf val
@@ -422,6 +423,7 @@ v1_model = ()
             Trace.callEndpoint @"guess" (handle $ WalletKey w)
                 G.GuessArgs
                     { G.guessArgsGameParam = gameParam
+                    , G.guessTokenTarget   = mockWalletPaymentPubKeyHash w
                     , G.guessArgsOldSecret = old
                     , G.guessArgsNewSecret = secretArg new
                     , G.guessArgsValueTakenOut = Ada.lovelaceValueOf val

--- a/playground-common/src/Schema.hs
+++ b/playground-common/src/Schema.hs
@@ -58,7 +58,7 @@ import Data.Text qualified as Text
 import Data.UUID (UUID)
 import GHC.Generics (C1, Constructor, D1, Generic, K1 (K1), M1 (M1), Rec0, Rep, S1, Selector, U1, conIsRecord, conName,
                      from, selName, (:*:) ((:*:)), (:+:) (L1, R1))
-import Ledger (Ada, AssetClass, CurrencySymbol, Interval, Language, POSIXTime, POSIXTimeRange, PaymentPubKey,
+import Ledger (Ada, Address, AssetClass, CurrencySymbol, Interval, Language, POSIXTime, POSIXTimeRange, PaymentPubKey,
                PaymentPubKeyHash, PubKey, PubKeyHash, Signature, Slot, StakePubKey, StakePubKeyHash, TokenName, TxId,
                TxOutRef, Value)
 import Ledger.Bytes (LedgerBytes)
@@ -428,14 +428,17 @@ deriving anyclass instance ToSchema ValidatorHash
 
 deriving anyclass instance ToSchema WalletNumber
 
-instance ToSchema Wallet where
-  toSchema = toSchema @WalletId
-
 deriving anyclass instance ToArgument Ada
 
 deriving anyclass instance ToArgument WalletNumber
 
 deriving anyclass instance ToArgument Slot
+
+instance ToSchema Address where
+  toSchema = FormSchemaString
+
+instance ToSchema Wallet where
+  toSchema = toSchema @WalletId
 
 instance ToArgument Wallet where
   toArgument = toArgument . getWalletId

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustProduceAtLeast.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustProduceAtLeast.hs
@@ -18,17 +18,17 @@ import Ledger.Ada qualified as Ada
 import Ledger.CardanoWallet (paymentPrivateKey)
 import Ledger.Constraints.OffChain qualified as Constraints (MkTxError, typedValidatorLookups, unspentOutputs)
 import Ledger.Constraints.OnChain.V1 qualified as Constraints (checkScriptContext)
-import Ledger.Constraints.TxConstraints qualified as Constraints (collectFromTheScript, mustPayToTheScriptWithDatumInTx,
-                                                                  mustPayWithDatumInTxToPubKey, mustProduceAtLeast)
+import Ledger.Constraints.TxConstraints qualified as Constraints (collectFromTheScript, mustPayToAddressWithDatumInTx,
+                                                                  mustPayToTheScriptWithDatumInTx, mustProduceAtLeast)
 import Ledger.Generators (someTokenValue)
 import Ledger.Tx qualified as Tx
 import Ledger.Typed.Scripts qualified as Scripts
 import Plutus.Contract as Con (Contract, ContractError (WalletContractError), Empty, awaitTxConfirmed,
                                submitTxConstraintsWith, utxosAt)
 import Plutus.Contract.Test (assertContractError, assertFailedTransaction, assertValidatedTransactionCount,
-                             changeInitialWalletValue, checkPredicateOptions, defaultCheckOptions,
-                             mockWalletPaymentPubKeyHash, w1, w6, (.&&.))
-import Plutus.Trace.Emulator qualified as Trace (EmulatorTrace, activateContractWallet, setSigningProcess, waitNSlots,
+                             changeInitialWalletValue, checkPredicateOptions, defaultCheckOptions, mockWalletAddress,
+                             w1, w6, (.&&.))
+import Plutus.Trace.Emulator qualified as Trace (EmulatorTrace, activateContractWallet, nextSlot, setSigningProcess,
                                                  walletInstanceTag)
 import Plutus.V1.Ledger.Api (Datum (Datum), ScriptContext, ValidatorHash)
 import Plutus.V1.Ledger.Scripts (ScriptError)
@@ -71,28 +71,25 @@ baseAdaValueLockedByScript = Ada.lovelaceValueOf baseLovelaceLockedByScript
 baseAdaAndTokenValueLockedByScript :: Value.Value
 baseAdaAndTokenValueLockedByScript = baseAdaValueLockedByScript <> someTokens 1
 
-w1PaymentPubKeyHash :: Ledger.PaymentPubKeyHash
-w1PaymentPubKeyHash = mockWalletPaymentPubKeyHash w1
-
-w1StakePubKeyHash :: Ledger.StakePubKeyHash
-w1StakePubKeyHash = Ledger.StakePubKeyHash $ Ledger.unPaymentPubKeyHash w1PaymentPubKeyHash -- fromJust $ stakePubKeyHash $ walletToMockWallet' w1 -- is Nothing
+w1Address :: Ledger.Address
+w1Address = mockWalletAddress w1
 
 -- | Valid contract containing all required lookups. Uses mustProduceAtLeast constraint with provided on-chain and off-chain values.
-mustProduceAtLeastContract :: Value.Value -> Value.Value -> Value.Value -> Ledger.PaymentPubKeyHash -> Contract () Empty ContractError ()
-mustProduceAtLeastContract offAmt onAmt baseScriptValue pkh = do
+mustProduceAtLeastContract :: Value.Value -> Value.Value -> Value.Value -> Ledger.Address -> Contract () Empty ContractError ()
+mustProduceAtLeastContract offAmt onAmt baseScriptValue addr = do
     let lookups1 = Constraints.typedValidatorLookups typedValidator
         tx1 = Constraints.mustPayToTheScriptWithDatumInTx onAmt baseScriptValue
     ledgerTx1 <- submitTxConstraintsWith lookups1 tx1
     awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx1
 
-    pubKeyUtxos <- utxosAt $ Ledger.pubKeyHashAddress pkh Nothing
+    pubKeyUtxos <- utxosAt addr
     scriptUtxos <- utxosAt scrAddress
     let lookups2 = Constraints.typedValidatorLookups typedValidator
             <> Constraints.unspentOutputs pubKeyUtxos
             <> Constraints.unspentOutputs scriptUtxos
         tx2 =
             Constraints.collectFromTheScript scriptUtxos ()
-            <> Constraints.mustPayWithDatumInTxToPubKey w1PaymentPubKeyHash (Datum $ PlutusTx.toBuiltinData onAmt) offAmt
+            <> Constraints.mustPayToAddressWithDatumInTx w1Address (Datum $ PlutusTx.toBuiltinData onAmt) offAmt
             <> Constraints.mustProduceAtLeast offAmt
     ledgerTx2 <- submitTxConstraintsWith @UnitTest lookups2 tx2
     awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx2
@@ -100,12 +97,16 @@ mustProduceAtLeastContract offAmt onAmt baseScriptValue pkh = do
 trace :: Contract () Empty ContractError () -> Trace.EmulatorTrace ()
 trace contract = do
     void $ Trace.activateContractWallet w1 contract
-    void $ Trace.waitNSlots 1
+    void $ Trace.nextSlot
 
 -- | Uses onchain and offchain constraint mustProduceAtLeast to spend entire ada balance locked by the script
 spendAtLeastTheScriptBalance :: TestTree
 spendAtLeastTheScriptBalance =
-    let contract = mustProduceAtLeastContract baseAdaValueLockedByScript baseAdaValueLockedByScript baseAdaValueLockedByScript $ mockWalletPaymentPubKeyHash w1
+    let contract = mustProduceAtLeastContract
+                       baseAdaValueLockedByScript
+                       baseAdaValueLockedByScript
+                       baseAdaValueLockedByScript
+                       w1Address
     in checkPredicateOptions
         defaultCheckOptions
         "Successful use of mustProduceAtLeast at script's exact balance"
@@ -116,7 +117,7 @@ spendAtLeastTheScriptBalance =
 spendLessThanScriptBalance :: TestTree
 spendLessThanScriptBalance =
     let amt = Ada.lovelaceValueOf (baseLovelaceLockedByScript - 500)
-        contract = mustProduceAtLeastContract amt amt baseAdaValueLockedByScript $ mockWalletPaymentPubKeyHash w1
+        contract = mustProduceAtLeastContract amt amt baseAdaValueLockedByScript w1Address
     in checkPredicateOptions
         defaultCheckOptions
         "Successful use of mustProduceAtLeast below script's balance"
@@ -127,7 +128,11 @@ spendLessThanScriptBalance =
 spendTokenBalanceFromScript :: TestTree
 spendTokenBalanceFromScript =
     let token = someTokens 1
-        contract = mustProduceAtLeastContract (baseAdaValueLockedByScript <> token) (baseAdaValueLockedByScript <> token) baseAdaAndTokenValueLockedByScript $ mockWalletPaymentPubKeyHash w1
+        contract = mustProduceAtLeastContract
+                       (baseAdaValueLockedByScript <> token)
+                       (baseAdaValueLockedByScript <> token)
+                       baseAdaAndTokenValueLockedByScript
+                       w1Address
         options = defaultCheckOptions
             & changeInitialWalletValue w1 (token <>)
     in checkPredicateOptions
@@ -140,7 +145,7 @@ spendTokenBalanceFromScript =
 spendMoreThanScriptBalanceWithOwnWalletAsOwnPubkeyLookup :: TestTree
 spendMoreThanScriptBalanceWithOwnWalletAsOwnPubkeyLookup =
     let amt = Ada.lovelaceValueOf (baseLovelaceLockedByScript + 5_000_000)
-        contract = mustProduceAtLeastContract amt amt baseAdaValueLockedByScript $ mockWalletPaymentPubKeyHash w1
+        contract = mustProduceAtLeastContract amt amt baseAdaValueLockedByScript w1Address
     in checkPredicateOptions
         defaultCheckOptions
         "Validation pass when mustProduceAtLeast is greater than script's balance"
@@ -153,13 +158,13 @@ spendMoreThanScriptBalanceWithOwnWalletAsOwnPubkeyLookup =
 contractErrorWhenSpendMoreThanScriptBalanceWithOtherWalletAsOwnPubkeyLookup :: TestTree
 contractErrorWhenSpendMoreThanScriptBalanceWithOtherWalletAsOwnPubkeyLookup =
     let amt = Ada.lovelaceValueOf (baseLovelaceLockedByScript + 5_000_000)
-        contract = mustProduceAtLeastContract amt amt baseAdaValueLockedByScript $ mockWalletPaymentPubKeyHash w6
+        contract = mustProduceAtLeastContract amt amt baseAdaValueLockedByScript $ mockWalletAddress w6
         options = defaultCheckOptions
             & changeInitialWalletValue w1 (const amt) -- not enough funds remain for w1 to satisfy constraint
         traceWithW6Signing = do
             Trace.setSigningProcess w1 (Just $ signPrivateKeys [paymentPrivateKey $ walletToMockWallet' w1, paymentPrivateKey $ walletToMockWallet' w6])
             void $ Trace.activateContractWallet w1 contract
-            void $ Trace.waitNSlots 1
+            Trace.nextSlot
     in checkPredicateOptions
         options
         "Fail validation when there are not enough ada in own wallet to satisfy mustProduceAtLeast constraint. Other wallet is not used."
@@ -174,7 +179,7 @@ contractErrorWhenUnableToSpendMoreThanScriptTokenBalance :: TestTree
 contractErrorWhenUnableToSpendMoreThanScriptTokenBalance =
     let offAmt = baseAdaValueLockedByScript <> someTokens 2
         onAmt  = baseAdaValueLockedByScript <> someTokens 2
-        contract = mustProduceAtLeastContract offAmt onAmt baseAdaAndTokenValueLockedByScript $ mockWalletPaymentPubKeyHash w1
+        contract = mustProduceAtLeastContract offAmt onAmt baseAdaAndTokenValueLockedByScript w1Address
         options = defaultCheckOptions
             & changeInitialWalletValue w1 (someTokens 1 <>)
     in checkPredicateOptions
@@ -190,7 +195,7 @@ phase2FailureWhenProducedAdaAmountIsNotSatisfied =
     let w1StartingBalance = 100_000_000
         offAmt = baseAdaValueLockedByScript
         onAmt  = Ada.lovelaceValueOf (baseLovelaceLockedByScript + w1StartingBalance) -- fees make this impossible to satisfy onchain
-        contract = mustProduceAtLeastContract offAmt onAmt baseAdaValueLockedByScript $ mockWalletPaymentPubKeyHash w1
+        contract = mustProduceAtLeastContract offAmt onAmt baseAdaValueLockedByScript w1Address
         options = defaultCheckOptions
             & changeInitialWalletValue w1 (const $ Ada.lovelaceValueOf w1StartingBalance)
     in checkPredicateOptions
@@ -204,7 +209,7 @@ phase2FailureWhenProducedTokenAmountIsNotSatisfied :: TestTree
 phase2FailureWhenProducedTokenAmountIsNotSatisfied =
     let offAmt = baseAdaValueLockedByScript <> someTokens 1
         onAmt  = baseAdaValueLockedByScript <> someTokens 2
-        contract = mustProduceAtLeastContract offAmt onAmt baseAdaAndTokenValueLockedByScript $ mockWalletPaymentPubKeyHash w1
+        contract = mustProduceAtLeastContract offAmt onAmt baseAdaAndTokenValueLockedByScript w1Address
         options = defaultCheckOptions
             & changeInitialWalletValue w1 (someTokens 1 <>)
     in checkPredicateOptions

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustSpendPubKeyOutput.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustSpendPubKeyOutput.hs
@@ -17,8 +17,8 @@ import Data.Set qualified as S (elemAt, elems)
 import Ledger qualified
 import Ledger.Ada qualified as Ada
 import Ledger.CardanoWallet (paymentPrivateKey)
-import Ledger.Constraints.OffChain qualified as Constraints (MkTxError (TxOutRefNotFound), ownPaymentPubKeyHash,
-                                                             typedValidatorLookups, unspentOutputs)
+import Ledger.Constraints.OffChain qualified as Constraints (MkTxError (TxOutRefNotFound), typedValidatorLookups,
+                                                             unspentOutputs)
 import Ledger.Constraints.OnChain.V1 qualified as Constraints (checkScriptContext)
 import Ledger.Constraints.TxConstraints qualified as Constraints (collectFromTheScript, mustBeSignedBy,
                                                                   mustIncludeDatumInTx, mustPayToTheScriptWithDatumInTx,
@@ -85,7 +85,6 @@ mustSpendPubKeyOutputContract' keys offChainTxOutRefs onChainTxOutRefs pkh = do
     let lookups2 = Constraints.typedValidatorLookups typedValidator
             <> Constraints.unspentOutputs pubKeyUtxos
             <> Constraints.unspentOutputs scriptUtxos
-            <> Constraints.ownPaymentPubKeyHash pkh
         tx2 =
             Constraints.collectFromTheScript scriptUtxos ()
             <> Constraints.mustIncludeDatumInTx (Datum $ PlutusTx.toBuiltinData onChainTxOutRefs)

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -112,8 +112,7 @@ import Data.Set qualified as Set
 import GHC.Generics (Generic)
 import Ledger (Redeemer (Redeemer), decoratedTxOutReferenceScript, outValue)
 import Ledger.Ada qualified as Ada
-import Ledger.Address (Address (Address), PaymentPubKey (PaymentPubKey), PaymentPubKeyHash (PaymentPubKeyHash),
-                       pubKeyHashAddress)
+import Ledger.Address (Address (Address), PaymentPubKey (PaymentPubKey), PaymentPubKeyHash (PaymentPubKeyHash))
 import Ledger.Constraints.TxConstraints (ScriptInputConstraint (ScriptInputConstraint, icRedeemer, icTxOutRef),
                                          ScriptOutputConstraint (ScriptOutputConstraint, ocDatum, ocReferenceScriptHash, ocValue),
                                          TxConstraint (MustBeSignedBy, MustIncludeDatumInTx, MustIncludeDatumInTxWithHash, MustMintValue, MustPayToAddress, MustProduceAtLeast, MustReferenceOutput, MustSatisfyAnyOf, MustSpendAtLeast, MustSpendPubKeyOutput, MustSpendScriptOutput, MustUseOutputAsCollateral, MustValidateIn),

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -56,7 +56,6 @@ module Ledger.Constraints.OffChain(
     , _DatumNotFoundInTx
     , _MintingPolicyNotFound
     , _ScriptHashNotFound
-    , _OwnPubKeyMissing
     , _TypedValidatorMissing
     , _DatumWrongHash
     , _CannotSatisfyAny
@@ -938,7 +937,6 @@ data MkTxError =
     | DeclaredOutputMismatch Value
     | MintingPolicyNotFound MintingPolicyHash
     | ScriptHashNotFound ScriptHash
-    | OwnPubKeyMissing
     | TypedValidatorMissing
     | DatumWrongHash DatumHash Datum
     | CannotSatisfyAny
@@ -963,7 +961,6 @@ instance Pretty MkTxError where
         DeclaredOutputMismatch v       -> "Discrepancy of" <+> pretty v <+> "outputs"
         MintingPolicyNotFound h        -> "No minting policy with hash" <+> pretty h <+> "was found"
         ScriptHashNotFound h           -> "No script with hash" <+> pretty h <+> "was found"
-        OwnPubKeyMissing               -> "Own public key is missing"
         TypedValidatorMissing          -> "Script instance is missing"
         DatumWrongHash h d             -> "Wrong hash for datum" <+> pretty d <> colon <+> pretty h
         CannotSatisfyAny               -> "Cannot satisfy any of the required constraints"

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -273,7 +273,7 @@ ownPaymentPubKeyHash pkh = mempty { slOwnPaymentPubKeyHash = Just pkh }
 -- ownStakingCredential skh1 <> ownStakingCredential skh2 <> ...
 --     == ownStakingCredential skh1
 -- @
-{-# DEPRECATED ownStakePubKeyHash "Shouldn't be meaningful due to change in MustSpendAtLeast and MustProduceAtLeast offchain code" #-}
+{-# DEPRECATED ownStakingCredential "Shouldn't be meaningful due to change in MustSpendAtLeast and MustProduceAtLeast offchain code" #-}
 ownStakingCredential :: StakingCredential -> ScriptLookups a
 ownStakingCredential sc = mempty { slOwnStakingCredential = Just sc }
 

--- a/plutus-ledger-constraints/src/Ledger/Constraints/TxConstraints.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/TxConstraints.hs
@@ -733,23 +733,24 @@ mustMintCurrencyWithRedeemer = mustMintCurrencyWithRedeemerAndReference Nothing
 -- information.
 mustMintCurrencyWithRedeemerAndReference
     :: forall i o
-     . (Maybe TxOutRef)
+     . Maybe TxOutRef
     -> MintingPolicyHash
     -> Redeemer
     -> TokenName
     -> Integer
     -> TxConstraints i o
-mustMintCurrencyWithRedeemerAndReference mref mph red tn a = if a == 0 then mempty else singleton $ MustMintValue mph red tn a mref
+mustMintCurrencyWithRedeemerAndReference mref mph red tn a =
+  if a == 0 then mempty else singleton $ MustMintValue mph red tn a mref
 
 {-# INLINABLE mustSpendAtLeast #-}
 -- | @mustSpendAtLeast v@ requires the sum of the transaction's inputs value to
 -- be at least @v@.
 --
--- If used in 'Ledger.Constraints.OffChain', this constraint adds the missing
--- input value with an additionnal public key output using the public key hash
--- provided in the 'Ledger.Constraints.OffChain.ScriptLookups' with
--- 'Ledger.Constraints.OffChain.ownPaymentPubKeyHash' and optionaly
--- 'Ledger.Constraints.OffChain.ownStakingCredential'.
+-- If used in 'Ledger.Constraints.OffChain', this constraint checks if
+-- at least the given value is spent in the transaction.
+-- When the transaction is created, a 'MkTxError.DeclaredInputMismatch' error
+-- is raised if it is not the case.
+>>>>>>> bfaddb8a3 (Remove offchain logic for MustProduceAtLeast and MustSpendAtLeast)
 --
 -- If used in 'Ledger.Constraints.OnChain', this constraint verifies that the
 -- sum of the transaction's inputs value to be at least @v@.
@@ -760,11 +761,10 @@ mustSpendAtLeast = singleton . MustSpendAtLeast
 -- | @mustProduceAtLeast v@ requires the sum of the transaction's outputs value to
 -- be at least @v@.
 --
--- If used in 'Ledger.Constraints.OffChain', this constraint adds the missing
--- output value with an additionnal public key output using the public key hash
--- provided in the 'Ledger.Constraints.OffChain.ScriptLookups' with
--- 'Ledger.Constraints.OffChain.ownPaymentPubKeyHash' and optionaly
--- 'Ledger.Constraints.OffChain.ownStakingCredential'.
+-- If used in 'Ledger.Constraints.OffChain', this constraint checks if
+-- at least the given value is produced in the transaction.
+-- When the transaction is created, a 'MkTxError.DeclaredOutputMismatch' error
+-- is raised if it is not the case.
 --
 -- If used in 'Ledger.Constraints.OnChain', this constraint verifies that the
 -- sum of the transaction's outputs value to be at least @v@.

--- a/plutus-ledger-constraints/src/Ledger/Constraints/TxConstraints.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/TxConstraints.hs
@@ -750,7 +750,6 @@ mustMintCurrencyWithRedeemerAndReference mref mph red tn a =
 -- at least the given value is spent in the transaction.
 -- When the transaction is created, a 'MkTxError.DeclaredInputMismatch' error
 -- is raised if it is not the case.
->>>>>>> bfaddb8a3 (Remove offchain logic for MustProduceAtLeast and MustSpendAtLeast)
 --
 -- If used in 'Ledger.Constraints.OnChain', this constraint verifies that the
 -- sum of the transaction's inputs value to be at least @v@.

--- a/plutus-ledger/src/Ledger/Address.hs
+++ b/plutus-ledger/src/Ledger/Address.hs
@@ -28,6 +28,7 @@ import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import Data.Hashable (Hashable)
 import Data.OpenApi qualified as OpenApi
 import GHC.Generics (Generic)
+import Ledger.Address.Orphans as Export ()
 import Ledger.Crypto (PubKey (PubKey), PubKeyHash (PubKeyHash), pubKeyHash, toPublicKey)
 import Ledger.Orphans ()
 import Ledger.Scripts (StakeValidatorHash (..), ValidatorHash (..))

--- a/plutus-ledger/src/Ledger/Address/Orphans.hs
+++ b/plutus-ledger/src/Ledger/Address/Orphans.hs
@@ -1,17 +1,17 @@
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DerivingVia        #-}
-{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingVia    #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Ledger.Address.Orphans where
 
 import Codec.Serialise (Serialise)
 import Data.Aeson (FromJSON, ToJSON)
 
+import Data.OpenApi (ToSchema)
 import Ledger.Credential.Orphans ()
+import Ledger.Scripts.Orphans ()
 import Plutus.V1.Ledger.Address
 
 deriving anyclass instance ToJSON Address
 deriving anyclass instance FromJSON Address
 deriving anyclass instance Serialise Address
+deriving anyclass instance ToSchema Address

--- a/plutus-ledger/src/Ledger/Credential/Orphans.hs
+++ b/plutus-ledger/src/Ledger/Credential/Orphans.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DerivingVia        #-}
-{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingVia    #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Ledger.Credential.Orphans where
 
@@ -12,6 +9,7 @@ import Ledger.Scripts.Orphans ()
 import Codec.Serialise (Serialise)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Hashable (Hashable)
+import Data.OpenApi (ToSchema)
 
 import Plutus.V1.Ledger.Credential
 
@@ -19,8 +17,10 @@ deriving anyclass instance ToJSON Credential
 deriving anyclass instance FromJSON Credential
 deriving anyclass instance Hashable Credential
 deriving anyclass instance Serialise Credential
+deriving anyclass instance ToSchema Credential
 
 deriving anyclass instance ToJSON StakingCredential
 deriving anyclass instance FromJSON StakingCredential
 deriving anyclass instance Hashable StakingCredential
 deriving anyclass instance Serialise StakingCredential
+deriving anyclass instance ToSchema StakingCredential

--- a/plutus-ledger/src/Ledger/Crypto/Orphans.hs
+++ b/plutus-ledger/src/Ledger/Crypto/Orphans.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DerivingVia        #-}
-{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingVia    #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Ledger.Crypto.Orphans where
 
@@ -12,6 +9,7 @@ import Codec.Serialise (Serialise)
 import Control.Newtype.Generics (Newtype)
 import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import Data.Hashable (Hashable)
+import Data.OpenApi (ToSchema)
 
 import Plutus.V1.Ledger.Crypto
 
@@ -22,3 +20,4 @@ deriving anyclass instance ToJSONKey PubKeyHash
 deriving anyclass instance Newtype PubKeyHash
 deriving newtype instance Serialise PubKeyHash
 deriving newtype instance Hashable PubKeyHash
+deriving anyclass instance ToSchema PubKeyHash

--- a/plutus-ledger/src/Ledger/Orphans.hs
+++ b/plutus-ledger/src/Ledger/Orphans.hs
@@ -31,13 +31,11 @@ import Ledger.Ada (Ada (Lovelace))
 import Ledger.Crypto (PrivateKey (PrivateKey, getPrivateKey), PubKey (PubKey), Signature (Signature))
 import Ledger.Scripts (Language, Versioned)
 import Ledger.Slot (Slot (Slot))
-import Plutus.V1.Ledger.Api (Address, Credential, CurrencySymbol (CurrencySymbol), DCert, Extended, Interval,
-                             LedgerBytes (LedgerBytes), LowerBound, MintingPolicy (MintingPolicy),
-                             MintingPolicyHash (MintingPolicyHash), POSIXTime (POSIXTime), PubKeyHash (PubKeyHash),
-                             Redeemer (Redeemer), RedeemerHash (RedeemerHash), Script, StakeValidator (StakeValidator),
-                             StakeValidatorHash (StakeValidatorHash), StakingCredential, TokenName (TokenName),
-                             TxId (TxId), TxOutRef, UpperBound, Validator (Validator), ValidatorHash (ValidatorHash),
-                             Value (Value), fromBytes)
+import Plutus.V1.Ledger.Api (CurrencySymbol (CurrencySymbol), DCert, Extended, Interval, LedgerBytes (LedgerBytes),
+                             LowerBound, MintingPolicy (MintingPolicy), MintingPolicyHash (MintingPolicyHash),
+                             POSIXTime (POSIXTime), Redeemer (Redeemer), RedeemerHash (RedeemerHash), Script,
+                             StakeValidator (StakeValidator), TokenName (TokenName), TxId (TxId), TxOutRef, UpperBound,
+                             Validator (Validator), Value (Value), fromBytes)
 import Plutus.V1.Ledger.Api qualified as PV1
 import Plutus.V1.Ledger.Bytes (bytes)
 import Plutus.V1.Ledger.Scripts (ScriptError, ScriptHash (..))
@@ -123,19 +121,13 @@ deriving instance OpenApi.ToSchema a => OpenApi.ToSchema (UpperBound a)
 deriving newtype instance OpenApi.ToSchema Redeemer
 deriving newtype instance OpenApi.ToSchema RedeemerHash
 deriving newtype instance OpenApi.ToSchema Value
-deriving instance OpenApi.ToSchema Address
 deriving newtype instance OpenApi.ToSchema MintingPolicy
 deriving newtype instance OpenApi.ToSchema MintingPolicyHash
 deriving newtype instance OpenApi.ToSchema CurrencySymbol
-deriving instance OpenApi.ToSchema Credential
 deriving newtype instance OpenApi.ToSchema PubKey
 deriving newtype instance OpenApi.ToSchema TokenName
-deriving instance OpenApi.ToSchema StakingCredential
 deriving newtype instance OpenApi.ToSchema StakeValidator
-deriving newtype instance OpenApi.ToSchema StakeValidatorHash
-deriving newtype instance OpenApi.ToSchema PubKeyHash
 deriving newtype instance OpenApi.ToSchema LedgerBytes
-deriving newtype instance OpenApi.ToSchema ValidatorHash
 deriving newtype instance OpenApi.ToSchema Signature
 deriving newtype instance OpenApi.ToSchema POSIXTime
 deriving newtype instance OpenApi.ToSchema DiffMilliSeconds

--- a/plutus-ledger/src/Ledger/Scripts/Orphans.hs
+++ b/plutus-ledger/src/Ledger/Scripts/Orphans.hs
@@ -64,6 +64,7 @@ deriving anyclass instance ToJSONKey StakeValidatorHash
 deriving anyclass instance FromJSONKey StakeValidatorHash
 deriving newtype instance Hashable StakeValidatorHash
 deriving newtype instance Serialise StakeValidatorHash
+deriving newtype instance OpenApi.ToSchema StakeValidatorHash
 
 deriving anyclass instance ToJSON ScriptHash
 deriving anyclass instance FromJSON ScriptHash
@@ -78,6 +79,7 @@ deriving anyclass instance ToJSONKey ValidatorHash
 deriving anyclass instance FromJSONKey ValidatorHash
 deriving newtype instance Hashable ValidatorHash
 deriving newtype instance Serialise ValidatorHash
+deriving newtype instance OpenApi.ToSchema ValidatorHash
 
 deriving newtype instance ToJSON Context
 deriving newtype instance FromJSON Context

--- a/plutus-pab-executables/test/full/Plutus/PAB/CoreSpec.hs
+++ b/plutus-pab-executables/test/full/Plutus/PAB/CoreSpec.hs
@@ -46,7 +46,7 @@ import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Extras (tshow)
-import Ledger (PaymentPubKeyHash (unPaymentPubKeyHash), getCardanoTxFee, getCardanoTxId, getCardanoTxOutRefs,
+import Ledger (Address, PaymentPubKeyHash (unPaymentPubKeyHash), getCardanoTxFee, getCardanoTxId, getCardanoTxOutRefs,
                pubKeyAddress, pubKeyHash, pubKeyHashAddress, toPubKeyHash, txId, txOutAddress, txOutRefId, txOutRefs,
                txOutputs)
 import Ledger qualified
@@ -58,7 +58,7 @@ import Ledger.Value (valueOf)
 import Plutus.ChainIndex (Depth (Depth), RollbackState (Committed, TentativelyConfirmed, Unknown),
                           TxOutState (Spent, Unspent), TxValidity (TxValid), chainConstant)
 import Plutus.Contract.State (ContractResponse (ContractResponse, hooks))
-import Plutus.Contract.Test (mockWalletPaymentPubKeyHash, w1)
+import Plutus.Contract.Test (mockWalletAddress, w1)
 import Plutus.Contracts.Currency (OneShotCurrency, SimpleMPS (SimpleMPS, amount, tokenName))
 import Plutus.Contracts.GameStateMachine qualified as Contracts.GameStateMachine
 import Plutus.Contracts.PingPong (PingPongState (Pinged, Ponged))
@@ -116,8 +116,8 @@ runScenarioWithSecondSlot sim = do
 defaultWallet :: Wallet
 defaultWallet = knownWallet 1
 
-defaultWalletPaymentPubKeyHash :: PaymentPubKeyHash
-defaultWalletPaymentPubKeyHash = CW.paymentPubKeyHash (CW.fromWalletNumber $ CW.WalletNumber 1)
+defaultWalletAddress :: Address
+defaultWalletAddress = mockWalletAddress defaultWallet
 
 activateContractTests :: TestTree
 activateContractTests =
@@ -357,7 +357,7 @@ guessingGameTest =
                             (valueOf (balance <> fees) adaSymbol adaToken)
 
               instanceId <- Simulator.activateContract defaultWallet GameStateMachine
-              let gameParam = Contracts.GameStateMachine.GameParam (mockWalletPaymentPubKeyHash defaultWallet) (TimeSlot.scSlotZeroTime def)
+              let gameParam = Contracts.GameStateMachine.GameParam (mockWalletAddress defaultWallet) (TimeSlot.scSlotZeroTime def)
 
               initialTxCounts <- Simulator.txCounts
               pubKeyHashFundsChange instanceId "Check our opening balance." 0
@@ -383,7 +383,7 @@ guessingGameTest =
                   game1Id
                   Contracts.GameStateMachine.GuessArgs
                       { Contracts.GameStateMachine.guessArgsGameParam = gameParam
-                      , Contracts.GameStateMachine.guessTokenTarget   = mockWalletPaymentPubKeyHash defaultWallet
+                      , Contracts.GameStateMachine.guessTokenTarget   = mockWalletAddress defaultWallet
                       , Contracts.GameStateMachine.guessArgsNewSecret = "wrong"
                       , Contracts.GameStateMachine.guessArgsOldSecret = "wrong"
                       , Contracts.GameStateMachine.guessArgsValueTakenOut = lovelaceValueOf lockAmount
@@ -399,7 +399,7 @@ guessingGameTest =
                   game2Id
                   Contracts.GameStateMachine.GuessArgs
                       { Contracts.GameStateMachine.guessArgsGameParam = gameParam
-                      , Contracts.GameStateMachine.guessTokenTarget   = mockWalletPaymentPubKeyHash defaultWallet
+                      , Contracts.GameStateMachine.guessTokenTarget   = mockWalletAddress defaultWallet
                       , Contracts.GameStateMachine.guessArgsNewSecret = "password"
                       , Contracts.GameStateMachine.guessArgsOldSecret = "password"
                       , Contracts.GameStateMachine.guessArgsValueTakenOut = lovelaceValueOf lockAmount

--- a/plutus-pab-executables/test/full/Plutus/PAB/CoreSpec.hs
+++ b/plutus-pab-executables/test/full/Plutus/PAB/CoreSpec.hs
@@ -383,6 +383,7 @@ guessingGameTest =
                   game1Id
                   Contracts.GameStateMachine.GuessArgs
                       { Contracts.GameStateMachine.guessArgsGameParam = gameParam
+                      , Contracts.GameStateMachine.guessTokenTarget   = mockWalletPaymentPubKeyHash defaultWallet
                       , Contracts.GameStateMachine.guessArgsNewSecret = "wrong"
                       , Contracts.GameStateMachine.guessArgsOldSecret = "wrong"
                       , Contracts.GameStateMachine.guessArgsValueTakenOut = lovelaceValueOf lockAmount
@@ -398,6 +399,7 @@ guessingGameTest =
                   game2Id
                   Contracts.GameStateMachine.GuessArgs
                       { Contracts.GameStateMachine.guessArgsGameParam = gameParam
+                      , Contracts.GameStateMachine.guessTokenTarget   = mockWalletPaymentPubKeyHash defaultWallet
                       , Contracts.GameStateMachine.guessArgsNewSecret = "password"
                       , Contracts.GameStateMachine.guessArgsOldSecret = "password"
                       , Contracts.GameStateMachine.guessArgsValueTakenOut = lovelaceValueOf lockAmount

--- a/plutus-tx-constraints/src/Ledger/Tx/Constraints/OffChain.hs
+++ b/plutus-tx-constraints/src/Ledger/Tx/Constraints/OffChain.hs
@@ -214,7 +214,6 @@ processLookupsAndConstraints lookups TxConstraints{txConstraints, txOwnOutputs} 
             -- traverse_ P.processConstraintFun txCnsFuns
             -- traverse_ P.addOwnInput txOwnInputs
             -- P.addMintingRedeemers
-            -- P.addMissingValueSpent
             traverse_ processConstraint (includeDatumConstraints sortedConstraints)
             mapReaderT (mapStateT (withExcept LedgerMkTxError)) P.updateUtxoIndex
             lift $ setValidityRange (rangeConstraints sortedConstraints)

--- a/plutus-use-cases/src/Plutus/Contracts/GameStateMachine.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/GameStateMachine.hs
@@ -60,6 +60,7 @@ import Plutus.V1.Ledger.Scripts (MintingPolicyHash)
 import PlutusTx qualified
 import PlutusTx.Prelude (Bool (False, True), BuiltinByteString, Eq, Maybe (Just, Nothing), check, sha2_256, toBuiltin,
                          traceIfFalse, ($), (&&), (-), (.), (<$>), (<>), (==), (>>))
+import Schema (ToSchema)
 
 import Plutus.Contract.Test.Coverage.Analysis
 import PlutusTx.Coverage
@@ -73,7 +74,7 @@ data GameParam = GameParam
     , gameParamStartTime :: POSIXTime
     -- ^ Starting time of the game
     } deriving (Haskell.Show, Generic)
-      deriving anyclass (ToJSON, FromJSON)
+      deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 PlutusTx.makeLift ''GameParam
 
@@ -101,7 +102,7 @@ data LockArgs =
         , lockArgsValue     :: Value
         -- ^ Value that is locked by the contract initially
         } deriving stock (Haskell.Show, Generic)
-          deriving anyclass (ToJSON, FromJSON)
+          deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 -- | Arguments for the @"guess"@ endpoint
 data GuessArgs =
@@ -117,7 +118,7 @@ data GuessArgs =
         , guessArgsValueTakenOut :: Value
         -- ^ How much to extract from the contract
         } deriving stock (Haskell.Show, Generic)
-          deriving anyclass (ToJSON, FromJSON)
+          deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 -- | The schema of the contract. It consists of the two endpoints @"lock"@
 --   and @"guess"@ with their respective argument types.

--- a/plutus-use-cases/src/Plutus/Contracts/GameStateMachine.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/GameStateMachine.hs
@@ -44,8 +44,9 @@ import Control.Monad (void)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.ByteString.Char8 qualified as C
 import GHC.Generics (Generic)
-import Ledger (POSIXTime, PaymentPubKeyHash, ScriptContext, TokenName, Value)
+import Ledger (Address, POSIXTime, ScriptContext, TokenName, Value)
 import Ledger.Ada qualified as Ada
+import Ledger.Address.Orphans ()
 import Ledger.Constraints (TxConstraints)
 import Ledger.Constraints qualified as Constraints
 import Ledger.Typed.Scripts qualified as Scripts
@@ -59,7 +60,6 @@ import Plutus.V1.Ledger.Scripts (MintingPolicyHash)
 import PlutusTx qualified
 import PlutusTx.Prelude (Bool (False, True), BuiltinByteString, Eq, Maybe (Just, Nothing), check, sha2_256, toBuiltin,
                          traceIfFalse, ($), (&&), (-), (.), (<$>), (<>), (==), (>>))
-import Schema (ToSchema)
 
 import Plutus.Contract.Test.Coverage.Analysis
 import PlutusTx.Coverage
@@ -68,12 +68,12 @@ import Prelude qualified as Haskell
 
 -- | Datatype for creating a parameterized validator.
 data GameParam = GameParam
-    { gameParamPayeePkh  :: PaymentPubKeyHash
-    -- ^ Payment public key hash of the wallet locking some funds
+    { gameParamPayeePkh  :: Address
+    -- ^ Payment address of the wallet locking some funds
     , gameParamStartTime :: POSIXTime
     -- ^ Starting time of the game
     } deriving (Haskell.Show, Generic)
-      deriving anyclass (ToJSON, FromJSON, ToSchema)
+      deriving anyclass (ToJSON, FromJSON)
 
 PlutusTx.makeLift ''GameParam
 
@@ -101,14 +101,14 @@ data LockArgs =
         , lockArgsValue     :: Value
         -- ^ Value that is locked by the contract initially
         } deriving stock (Haskell.Show, Generic)
-          deriving anyclass (ToJSON, FromJSON, ToSchema)
+          deriving anyclass (ToJSON, FromJSON)
 
 -- | Arguments for the @"guess"@ endpoint
 data GuessArgs =
     GuessArgs
         { guessArgsGameParam     :: GameParam
         -- ^ The parameters for parameterizing the validator.
-        , guessTokenTarget       :: PaymentPubKeyHash
+        , guessTokenTarget       :: Address
         -- ^ The recipient of the guess token
         , guessArgsOldSecret     :: Haskell.String
         -- ^ The guess
@@ -117,7 +117,7 @@ data GuessArgs =
         , guessArgsValueTakenOut :: Value
         -- ^ How much to extract from the contract
         } deriving stock (Haskell.Show, Generic)
-          deriving anyclass (ToJSON, FromJSON, ToSchema)
+          deriving anyclass (ToJSON, FromJSON)
 
 -- | The schema of the contract. It consists of the two endpoints @"lock"@
 --   and @"guess"@ with their respective argument types.
@@ -178,7 +178,7 @@ checkGuess (HashedString actual) (ClearString gss) = actual == sha2_256 gss
 data GameInput =
       MintToken
     -- ^ Mint the "guess" token
-    | Guess PaymentPubKeyHash ClearString HashedString Value
+    | Guess Address ClearString HashedString Value
     -- ^ Make a guess, extract the funds, and lock the remaining funds using a
     --   new secret word.
     deriving stock (Haskell.Show, Generic)
@@ -203,7 +203,7 @@ transition _ State{stateData=oldData, stateValue=oldValue} input = case (oldData
              )
     (Locked mph tn currentSecret, Guess guessTokenRecipient theGuess nextSecret takenOut)
         | checkGuess currentSecret theGuess ->
-        let constraints = Constraints.mustPayToPubKey guessTokenRecipient (token mph tn)
+        let constraints = Constraints.mustPayToAddress guessTokenRecipient (token mph tn)
                        <> Constraints.mustMintCurrency mph tn 0
             newValue = oldValue - takenOut
          in Just ( constraints

--- a/plutus-use-cases/src/Plutus/Contracts/Prism/Mirror.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Prism/Mirror.hs
@@ -72,7 +72,6 @@ createTokens authority = endpoint @"issue" $ \CredentialOwnerReference{coTokenNa
     logInfo @String "Endpoint 'issue' called"
     let pk      = Credential.unCredentialAuthority authority
         lookups = Constraints.plutusV1MintingPolicy (Credential.policy authority)
-                <> Constraints.ownPaymentPubKeyHash pk
         theToken = Credential.token Credential{credAuthority=authority,credName=coTokenName}
         constraints =
             Constraints.mustMintValue theToken
@@ -91,8 +90,7 @@ revokeToken ::
     -> Promise w s MirrorError ()
 revokeToken authority = endpoint @"revoke" $ \CredentialOwnerReference{coTokenName, coOwner} -> do
     let stateMachine = StateMachine.mkMachineClient authority (mockWalletPaymentPubKeyHash coOwner) coTokenName
-        lookups = Constraints.plutusV1MintingPolicy (Credential.policy authority) <>
-                  Constraints.ownPaymentPubKeyHash  (Credential.unCredentialAuthority authority)
+        lookups = Constraints.plutusV1MintingPolicy (Credential.policy authority)
     t <- mapError StateMachineError $ SM.mkStep stateMachine RevokeCredential
     case t of
         Left{} -> return () -- Ignore invalid transitions

--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
@@ -249,7 +249,6 @@ create us CreateParams{..} = do
 close :: forall w s. Uniswap -> CloseParams -> Contract w s Text ()
 close us CloseParams{..} = do
     ((oref1, o1, lps), (oref2, o2, lp, liquidity)) <- findUniswapFactoryAndPool us clpCoinA clpCoinB
-    pkh                                            <- Contract.ownFirstPaymentPubKeyHash
     let usInst   = uniswapInstance us
         usScript = uniswapScript us
         usDat    = Factory $ filter (/= lp) lps
@@ -264,7 +263,6 @@ close us CloseParams{..} = do
         lookups  = Constraints.typedValidatorLookups usInst        <>
                    Constraints.plutusV1OtherScript usScript                <>
                    Constraints.plutusV1MintingPolicy (liquidityPolicy us) <>
-                   Constraints.ownPaymentPubKeyHash pkh                   <>
                    Constraints.unspentOutputs (Map.singleton oref1 o1 <> Map.singleton oref2 o2)
 
         tx       = Constraints.mustPayToTheScriptWithDatumInTx usDat usVal <>
@@ -281,7 +279,6 @@ close us CloseParams{..} = do
 remove :: forall w s. Uniswap -> RemoveParams -> Contract w s Text ()
 remove us RemoveParams{..} = do
     (_, (oref, o, lp, liquidity)) <- findUniswapFactoryAndPool us rpCoinA rpCoinB
-    pkh                           <- Contract.ownFirstPaymentPubKeyHash
     when (rpDiff < 1 || rpDiff >= liquidity) $ throwError "removed liquidity must be positive and less than total liquidity"
     let usInst       = uniswapInstance us
         usScript     = uniswapScript us
@@ -300,8 +297,7 @@ remove us RemoveParams{..} = do
         lookups  = Constraints.typedValidatorLookups usInst          <>
                    Constraints.plutusV1OtherScript usScript                  <>
                    Constraints.plutusV1MintingPolicy (liquidityPolicy us)   <>
-                   Constraints.unspentOutputs (Map.singleton oref o) <>
-                   Constraints.ownPaymentPubKeyHash pkh
+                   Constraints.unspentOutputs (Map.singleton oref o)
 
         tx       = Constraints.mustPayToTheScriptWithDatumInTx dat val          <>
                    Constraints.mustMintValue (negate lVal)        <>
@@ -314,7 +310,6 @@ remove us RemoveParams{..} = do
 -- | Adds some liquidity to an existing liquidity pool in exchange for newly minted liquidity tokens.
 add :: forall w s. Uniswap -> AddParams -> Contract w s Text ()
 add us AddParams{..} = do
-    pkh                           <- Contract.ownFirstPaymentPubKeyHash
     (_, (oref, o, lp, liquidity)) <- findUniswapFactoryAndPool us apCoinA apCoinB
     when (apAmountA < 0 || apAmountB < 0) $ throwError "amounts must not be negative"
     let outVal = view decoratedTxOutValue o
@@ -340,7 +335,6 @@ add us AddParams{..} = do
         lookups  = Constraints.typedValidatorLookups usInst             <>
                    Constraints.plutusV1OtherScript usScript                     <>
                    Constraints.plutusV1MintingPolicy (liquidityPolicy us)       <>
-                   Constraints.ownPaymentPubKeyHash pkh                        <>
                    Constraints.unspentOutputs (Map.singleton oref o)
 
         tx       = Constraints.mustPayToTheScriptWithDatumInTx dat val          <>
@@ -371,7 +365,6 @@ swap us SwapParams{..} = do
         let outA = Amount $ findSwapB oldA oldB spAmountB
         when (outA == 0) $ throwError "no payout"
         return (oldA - outA, oldB + spAmountB)
-    pkh <- Contract.ownFirstPaymentPubKeyHash
 
     logInfo @String $ printf "oldA = %d, oldB = %d, old product = %d, newA = %d, newB = %d, new product = %d" oldA oldB (unAmount oldA * unAmount oldB) newA newB (unAmount newA * unAmount newB)
 
@@ -380,8 +373,7 @@ swap us SwapParams{..} = do
 
         lookups = Constraints.typedValidatorLookups inst                 <>
                   Constraints.plutusV1OtherScript (Scripts.validatorScript inst) <>
-                  Constraints.unspentOutputs (Map.singleton oref o)      <>
-                  Constraints.ownPaymentPubKeyHash pkh
+                  Constraints.unspentOutputs (Map.singleton oref o)
 
         tx      = mustSpendScriptOutput oref (Redeemer $ PlutusTx.toBuiltinData Swap) <>
                   Constraints.mustPayToTheScriptWithDatumInTx (Pool lp liquidity) val

--- a/plutus-use-cases/test/Spec/GameStateMachine.hs
+++ b/plutus-use-cases/test/Spec/GameStateMachine.hs
@@ -119,6 +119,7 @@ instance ContractModel GameModel where
         Guess w old new val -> do
             Trace.callEndpoint @"guess" (handle $ WalletKey w)
                 GuessArgs { guessArgsGameParam = gameParam
+                          , guessTokenTarget = mockWalletPaymentPubKeyHash w
                           , guessArgsOldSecret = old
                           , guessArgsNewSecret = secretArg new
                           , guessArgsValueTakenOut = Ada.lovelaceValueOf val
@@ -408,6 +409,7 @@ successTrace = do
     _ <- Trace.waitNSlots 1
     hdl2 <- Trace.activateContractWallet w2 G.contract
     Trace.callEndpoint @"guess" hdl2 GuessArgs { guessArgsGameParam = gameParam
+                                               , guessTokenTarget = mockWalletPaymentPubKeyHash w2
                                                , guessArgsOldSecret = "hello"
                                                , guessArgsNewSecret = secretArg "new secret"
                                                , guessArgsValueTakenOut = Ada.adaValueOf 3
@@ -423,6 +425,7 @@ successTrace2 = do
     _ <- Trace.waitNSlots 1
     hdl3 <- Trace.activateContractWallet w3 G.contract
     Trace.callEndpoint @"guess" hdl3 GuessArgs { guessArgsGameParam = gameParam
+                                               , guessTokenTarget = mockWalletPaymentPubKeyHash w3
                                                , guessArgsOldSecret = "new secret"
                                                , guessArgsNewSecret = secretArg "hello"
                                                , guessArgsValueTakenOut = Ada.adaValueOf 5
@@ -440,6 +443,7 @@ traceLeaveTwoAdaInScript = do
                                             }
     _ <- Trace.waitNSlots 2
     _ <- Trace.callEndpoint @"guess" hdl GuessArgs { guessArgsGameParam = gameParam
+                                                   , guessTokenTarget = mockWalletPaymentPubKeyHash w1
                                                    , guessArgsOldSecret = "hello"
                                                    , guessArgsNewSecret = secretArg "new secret"
                                                    , guessArgsValueTakenOut = Ada.adaValueOf 7
@@ -460,6 +464,7 @@ failTrace = do
     _ <- Trace.waitNSlots 1
     hdl2 <- Trace.activateContractWallet w2 G.contract
     _ <- Trace.callEndpoint @"guess" hdl2 GuessArgs { guessArgsGameParam = gameParam
+                                                    , guessTokenTarget = mockWalletPaymentPubKeyHash w2
                                                     , guessArgsOldSecret = "hola"
                                                     , guessArgsNewSecret = secretArg "new secret"
                                                     , guessArgsValueTakenOut = Ada.adaValueOf 3

--- a/plutus-use-cases/test/Spec/GameStateMachine.hs
+++ b/plutus-use-cases/test/Spec/GameStateMachine.hs
@@ -62,7 +62,7 @@ import Plutus.Trace.Emulator as Trace
 import PlutusTx.Coverage
 
 gameParam :: G.GameParam
-gameParam = G.GameParam (mockWalletPaymentPubKeyHash w1) (TimeSlot.scSlotZeroTime def)
+gameParam = G.GameParam (mockWalletAddress w1) (TimeSlot.scSlotZeroTime def)
 
 options :: CheckOptions
 options = defaultCheckOptionsContractModel & (increaseTransactionLimits . increaseTransactionLimits)
@@ -119,7 +119,7 @@ instance ContractModel GameModel where
         Guess w old new val -> do
             Trace.callEndpoint @"guess" (handle $ WalletKey w)
                 GuessArgs { guessArgsGameParam = gameParam
-                          , guessTokenTarget = mockWalletPaymentPubKeyHash w
+                          , guessTokenTarget = mockWalletAddress w
                           , guessArgsOldSecret = old
                           , guessArgsNewSecret = secretArg new
                           , guessArgsValueTakenOut = Ada.lovelaceValueOf val
@@ -409,7 +409,7 @@ successTrace = do
     _ <- Trace.waitNSlots 1
     hdl2 <- Trace.activateContractWallet w2 G.contract
     Trace.callEndpoint @"guess" hdl2 GuessArgs { guessArgsGameParam = gameParam
-                                               , guessTokenTarget = mockWalletPaymentPubKeyHash w2
+                                               , guessTokenTarget = mockWalletAddress w2
                                                , guessArgsOldSecret = "hello"
                                                , guessArgsNewSecret = secretArg "new secret"
                                                , guessArgsValueTakenOut = Ada.adaValueOf 3
@@ -425,7 +425,7 @@ successTrace2 = do
     _ <- Trace.waitNSlots 1
     hdl3 <- Trace.activateContractWallet w3 G.contract
     Trace.callEndpoint @"guess" hdl3 GuessArgs { guessArgsGameParam = gameParam
-                                               , guessTokenTarget = mockWalletPaymentPubKeyHash w3
+                                               , guessTokenTarget = mockWalletAddress w3
                                                , guessArgsOldSecret = "new secret"
                                                , guessArgsNewSecret = secretArg "hello"
                                                , guessArgsValueTakenOut = Ada.adaValueOf 5
@@ -443,7 +443,7 @@ traceLeaveTwoAdaInScript = do
                                             }
     _ <- Trace.waitNSlots 2
     _ <- Trace.callEndpoint @"guess" hdl GuessArgs { guessArgsGameParam = gameParam
-                                                   , guessTokenTarget = mockWalletPaymentPubKeyHash w1
+                                                   , guessTokenTarget = mockWalletAddress w1
                                                    , guessArgsOldSecret = "hello"
                                                    , guessArgsNewSecret = secretArg "new secret"
                                                    , guessArgsValueTakenOut = Ada.adaValueOf 7
@@ -464,7 +464,7 @@ failTrace = do
     _ <- Trace.waitNSlots 1
     hdl2 <- Trace.activateContractWallet w2 G.contract
     _ <- Trace.callEndpoint @"guess" hdl2 GuessArgs { guessArgsGameParam = gameParam
-                                                    , guessTokenTarget = mockWalletPaymentPubKeyHash w2
+                                                    , guessTokenTarget = mockWalletAddress w2
                                                     , guessArgsOldSecret = "hola"
                                                     , guessArgsNewSecret = secretArg "new secret"
                                                     , guessArgsValueTakenOut = Ada.adaValueOf 3

--- a/plutus-use-cases/test/Spec/Governance.hs
+++ b/plutus-use-cases/test/Spec/Governance.hs
@@ -75,14 +75,14 @@ lawv3 = Gov.Law "Law v3"
 
 doVoting :: Int -> Int -> Integer -> EmulatorTrace ()
 doVoting ayes nays rounds = do
-    let activate wId = (mockWalletPaymentPubKeyHash w, Gov.mkTokenName baseName wId,)
+    let activate wId = (mockWalletAddress w, Gov.mkTokenName baseName wId,)
                  <$> Trace.activateContractWallet w (Gov.contract @Gov.GovError params)
            where
                w = knownWallet wId
     namesAndHandles <- traverse activate [1..numberOfHolders]
     let handle1 = (\(_,_,h) -> h) (head namesAndHandles)
     let token2 = (\(_,t,_) -> t) (namesAndHandles !! 1)
-    let owner = mockWalletPaymentPubKeyHash w2
+    let owner = mockWalletAddress w2
     void $ Trace.callEndpoint @"new-law" handle1 lawv1
     void $ Trace.waitNSlots 10
     slotCfg <- Trace.getSlotConfig

--- a/plutus-use-cases/test/Spec/Governance.hs
+++ b/plutus-use-cases/test/Spec/Governance.hs
@@ -75,27 +75,29 @@ lawv3 = Gov.Law "Law v3"
 
 doVoting :: Int -> Int -> Integer -> EmulatorTrace ()
 doVoting ayes nays rounds = do
-    let activate w = (Gov.mkTokenName baseName w,)
-                 <$> Trace.activateContractWallet (knownWallet w)
-                                                  (Gov.contract @Gov.GovError params)
+    let activate wId = (mockWalletPaymentPubKeyHash w, Gov.mkTokenName baseName wId,)
+                 <$> Trace.activateContractWallet w (Gov.contract @Gov.GovError params)
+           where
+               w = knownWallet wId
     namesAndHandles <- traverse activate [1..numberOfHolders]
-    let handle1 = snd (head namesAndHandles)
-    let token2 = fst (namesAndHandles !! 1)
+    let handle1 = (\(_,_,h) -> h) (head namesAndHandles)
+    let token2 = (\(_,t,_) -> t) (namesAndHandles !! 1)
+    let owner = mockWalletPaymentPubKeyHash w2
     void $ Trace.callEndpoint @"new-law" handle1 lawv1
     void $ Trace.waitNSlots 10
     slotCfg <- Trace.getSlotConfig
     let votingRound (_, law) = do
             now <- view Trace.currentSlot <$> Trace.chainState
             void $ Trace.activateContractWallet w2
-                (Gov.proposalContract @Gov.GovError params
+                (Gov.proposalContract @Gov.GovError params owner
                     Gov.Proposal { Gov.newLaw = law
                                  , Gov.votingDeadline = TimeSlot.slotToEndPOSIXTime slotCfg $ now + 20
                                  , Gov.tokenName = token2
                                  })
             void $ Trace.waitNSlots 1
-            traverse_ (\(nm, hdl) -> Trace.callEndpoint @"add-vote" hdl (nm, True)  >> Trace.waitNSlots 1)
+            traverse_ (\(ow, nm, hdl) -> Trace.callEndpoint @"add-vote" hdl (ow, nm, True)  >> Trace.waitNSlots 1)
                       (take ayes namesAndHandles)
-            traverse_ (\(nm, hdl) -> Trace.callEndpoint @"add-vote" hdl (nm, False) >> Trace.waitNSlots 1)
+            traverse_ (\(ow, nm, hdl) -> Trace.callEndpoint @"add-vote" hdl (ow, nm, False) >> Trace.waitNSlots 1)
                       (take nays $ drop ayes namesAndHandles)
             Trace.waitNSlots 15
 

--- a/plutus-use-cases/test/Spec/Uniswap/Endpoints.hs
+++ b/plutus-use-cases/test/Spec/Uniswap/Endpoints.hs
@@ -49,7 +49,6 @@ data BadRemoveParams = BadRemoveParams
 badRemove :: forall w s. Uniswap -> BadRemoveParams -> Contract w s Text ()
 badRemove us BadRemoveParams{..} = do
     (_, (oref, o, lp, liquidity)) <- findUniswapFactoryAndPool us brpCoinA brpCoinB
-    pkh                           <- Contract.ownFirstPaymentPubKeyHash
     --when (brpDiff < 1 || brpDiff >= liquidity) $ throwError "removed liquidity must be positive and less than total liquidity"
     let usInst       = uniswapInstance us
         usScript     = uniswapScript us
@@ -70,8 +69,7 @@ badRemove us BadRemoveParams{..} = do
         lookups  = Constraints.typedValidatorLookups usInst          <>
                    Constraints.plutusV1OtherScript usScript                  <>
                    Constraints.plutusV1MintingPolicy (liquidityPolicy us)   <>
-                   Constraints.unspentOutputs (Map.singleton oref o) <>
-                   Constraints.ownPaymentPubKeyHash pkh
+                   Constraints.unspentOutputs (Map.singleton oref o)
 
         tx       = Constraints.mustPayToTheScriptWithDatumInTx dat val          <>
                    Constraints.mustMintValue (negate lVal)         <>

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -550,7 +550,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       0876f98e6295b06e45067896b5c4f3cee7add5e9e8a74cbc8a163824fa6e0c0e
+TxId:       b21d26970f0faa6d2a83a2cc8bbadc434aa7a468eae0cee75015d9ebc8de6311
 Fee:        Ada:      Lovelace:  178173
 Mint:       -
 Inputs:
@@ -573,7 +573,7 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  Script: 6ca1807b05f07a2017a95928ed43de36c5070b52158af5b363361dbf
+  Destination:  Script: 35aee8e38ded37d96302e4a1a36cc86a12f5b14c92a7e991df552c2d
   Value:
     Ada:      Lovelace:  8000000
 
@@ -624,6 +624,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 6ca1807b05f07a2017a95928ed43de36c5070b52158af5b363361dbf
+  Script: 35aee8e38ded37d96302e4a1a36cc86a12f5b14c92a7e991df552c2d
   Value:
     Ada:      Lovelace:  8000000

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -550,7 +550,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       9f59b11377f3a63ad8d87c5151d325d4d7801f12de4eb54b59d2f0655a7858eb
+TxId:       07035d559d6f781982029273cc1b886345fae5180c90d17bf38a597cfacec180
 Fee:        Ada:      Lovelace:  178173
 Mint:       -
 Inputs:
@@ -573,7 +573,7 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  Script: 1938da79eb53ba2ef222b3345aedc1c15ded786b701f52920f568b64
+  Destination:  Script: 00042998c7bc204466a6f5663ce1c0aa6e989a1889617d14f17f600f
   Value:
     Ada:      Lovelace:  8000000
 
@@ -624,6 +624,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 1938da79eb53ba2ef222b3345aedc1c15ded786b701f52920f568b64
+  Script: 00042998c7bc204466a6f5663ce1c0aa6e989a1889617d14f17f600f
   Value:
     Ada:      Lovelace:  8000000

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -550,7 +550,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       07035d559d6f781982029273cc1b886345fae5180c90d17bf38a597cfacec180
+TxId:       0876f98e6295b06e45067896b5c4f3cee7add5e9e8a74cbc8a163824fa6e0c0e
 Fee:        Ada:      Lovelace:  178173
 Mint:       -
 Inputs:
@@ -573,7 +573,7 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  Script: 00042998c7bc204466a6f5663ce1c0aa6e989a1889617d14f17f600f
+  Destination:  Script: 6ca1807b05f07a2017a95928ed43de36c5070b52158af5b363361dbf
   Value:
     Ada:      Lovelace:  8000000
 
@@ -624,6 +624,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 00042998c7bc204466a6f5663ce1c0aa6e989a1889617d14f17f600f
+  Script: 6ca1807b05f07a2017a95928ed43de36c5070b52158af5b363361dbf
   Value:
     Ada:      Lovelace:  8000000


### PR DESCRIPTION
Offchain use of `MustProduceAtLeast` and `MustSpendAtLeast` now checks if we have produced/spent at least the given amount when we create the Tx, and throw an error if it isn't the case. (see PLT-665 for the rationale behind this change)
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
