### PR TITLE
Drop hw-aeson fork

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -166,16 +166,6 @@ source-repository-package
     location: https://github.com/input-output-hk/quickcheck-dynamic
     tag: c272906361471d684440f76c297e29ab760f6a1e
 
--- TODO This is a compatibility shim to make it easier for our library dependencies to
--- be compatible with both aeson 1 & 2.  Once downstream projects are all upgraded to
--- work with aeson-2, library dependencies will need to be updated to no longer use
--- this compatibility shim and have bounds to indicate they work with aeson-2 only.
--- After this, the dependency to hw-aeson can be dropped.
-source-repository-package
-    type: git
-    location: https://github.com/sevanspowell/hw-aeson
-    tag: b5ef03a7d7443fcd6217ed88c335f0c411a05408
-
 -- Should follow cardano-wallet.
 source-repository-package
     type: git


### PR DESCRIPTION
I should have notices this earlier. It looks like we don't need this and everything supports aeson 2 (and have for a while).