### PR TITLE
PLT-671 implement MustBeSignedBy for cardano TX

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Test.hs
+++ b/plutus-contract/src/Plutus/Contract/Test.hs
@@ -208,8 +208,8 @@ checkPredicateCoverage ::
     -> TracePredicate -- ^ The predicate to check
     -> EmulatorTrace ()
     -> TestTree
-checkPredicateCoverage nm cr predicate action =
-  checkPredicateCoverageOptions defaultCheckOptions nm cr predicate action
+checkPredicateCoverage =
+  checkPredicateCoverageOptions defaultCheckOptions
 
 checkPredicateCoverageOptions ::
     CheckOptions -- ^ Options to use
@@ -342,8 +342,7 @@ endpointAvailable contract inst = TracePredicate $
                 tell @(Doc Void) ("missing endpoint:" <+> fromString (symbolVal (Proxy :: Proxy l)))
                 pure False
 
-tx
-    :: forall w s e a.
+tx :: forall w s e a.
        ( Monoid w
        )
     => Contract w s e a

--- a/plutus-contract/src/Plutus/Contract/Test.hs
+++ b/plutus-contract/src/Plutus/Contract/Test.hs
@@ -208,8 +208,8 @@ checkPredicateCoverage ::
     -> TracePredicate -- ^ The predicate to check
     -> EmulatorTrace ()
     -> TestTree
-checkPredicateCoverage =
-  checkPredicateCoverageOptions defaultCheckOptions
+checkPredicateCoverage nm cr predicate action =
+  checkPredicateCoverageOptions defaultCheckOptions nm cr predicate action
 
 checkPredicateCoverageOptions ::
     CheckOptions -- ^ Options to use

--- a/plutus-contract/src/Plutus/Contract/Wallet.hs
+++ b/plutus-contract/src/Plutus/Contract/Wallet.hs
@@ -282,6 +282,7 @@ toExportTxInput networkId Plutus.TxOutRef{Plutus.txOutRefId, Plutus.txOutRefIdx}
         <*> pure otherQuantities
 
 -- TODO: Here there's hidden error of script DCert missing its redeemer - this just counts as no DCert. Don't know if bad.
+-- TODO: Refactor with getGardanoTxRedeemers once we are ceady to move to Cardano Txs
 mkRedeemers :: P.Tx -> [ExportTxRedeemer]
 mkRedeemers = map (uncurry scriptPurposeToExportRedeemer) . Map.assocs . txRedeemers
 

--- a/plutus-contract/src/Wallet/Emulator/Folds.hs
+++ b/plutus-contract/src/Wallet/Emulator/Folds.hs
@@ -104,7 +104,7 @@ failedTransactions phase = preMapMaybe (f >=> filterPhase phase) L.list
         f e = preview (eteEvent . chainEvent . _TxnValidationFail) e
           <|> preview (eteEvent . walletEvent' . _2 . _TxBalanceLog . _ValidationFailed) e
         filterPhase Nothing (_, i, t, v, c, l)   = Just (i, t, v, c, l)
-        filterPhase (Just p) (p', i, t, v, c, l) = if p == p' then Just (i, t, v, c, l) else Nothing
+        filterPhase (Just p) (p', i, t, v, c, l) = guard (p == p') $> (i, t, v, c, l)
 
 -- | Transactions that were validated
 validatedTransactions :: EmulatorEventFold [(TxId, CardanoTx, [Text])]

--- a/plutus-contract/src/Wallet/Emulator/Folds.hs
+++ b/plutus-contract/src/Wallet/Emulator/Folds.hs
@@ -104,7 +104,7 @@ failedTransactions phase = preMapMaybe (f >=> filterPhase phase) L.list
         f e = preview (eteEvent . chainEvent . _TxnValidationFail) e
           <|> preview (eteEvent . walletEvent' . _2 . _TxBalanceLog . _ValidationFailed) e
         filterPhase Nothing (_, i, t, v, c, l)   = Just (i, t, v, c, l)
-        filterPhase (Just p) (p', i, t, v, c, l) = guard (p == p') $> (i, t, v, c, l)
+        filterPhase (Just p) (p', i, t, v, c, l) = if p == p' then Just (i, t, v, c, l) else Nothing
 
 -- | Transactions that were validated
 validatedTransactions :: EmulatorEventFold [(TxId, CardanoTx, [Text])]

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/RequiredSigner.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/RequiredSigner.hs
@@ -166,9 +166,6 @@ mustBeSignedByTypedValidator = Scripts.mkTypedValidator @UnitTest
 -- for CardanoTx
 
 
-tag :: Trace.ContractInstanceTag
-tag = "instance 1"
-
 cardanoTxOwnWalletContract
     :: Ledger.PaymentPubKeyHash
     -> Ledger.PaymentPubKeyHash
@@ -228,4 +225,4 @@ cardanoTxOtherWalletNoSigningProcess =
         (changeInitialWalletValue w1 (const $ Ada.adaValueOf 1000) defaultCheckOptions)
         "without Trace.setSigningProcess fails phase-1 validation"
         (assertFailedTransaction (\_ err -> case err of {Ledger.CardanoLedgerValidationError msg -> Text.isInfixOf "MissingRequiredSigners" msg; _ -> False  }))
-    (void trace)
+        (void trace)

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/RequiredSigner.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/RequiredSigner.hs
@@ -231,6 +231,8 @@ cardanoTxOtherWalletNoSigningProcess =
             void $ Trace.activateContractWallet w1 $ cardanoTxOwnWalletContract w2PubKey w2PubKey
             void Trace.nextSlot
     in checkPredicateOptions
+        -- Needed to manually balance the transaction
+        -- We may remove it once PLT-321
         (changeInitialWalletValue w1 (const $ Ada.adaValueOf 1000) defaultCheckOptions)
         "without Trace.setSigningProcess fails phase-1 validation"
         (assertFailedTransaction (\_ err -> case err of {Ledger.CardanoLedgerValidationError msg -> Text.isInfixOf "MissingRequiredSigners" msg; _ -> False  }))

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/RequiredSigner.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/RequiredSigner.hs
@@ -195,7 +195,7 @@ mustReferenceOutputV2ValidatorAddress =
     PSU.V2.mkValidatorAddress mustReferenceOutputValidatorV2
 
 cardanoTxOwnWalletContract
-    :: Ledger.PaymentPubKey
+    :: Ledger.PaymentPubKeyHash
     -> Ledger.PaymentPubKeyHash
     -> Contract () EmptySchema ContractError ()
 cardanoTxOwnWalletContract pk pkh = do
@@ -209,7 +209,7 @@ cardanoTxOwnWalletContract pk pkh = do
         vh = fromJust $ Ledger.toValidatorHash mustReferenceOutputV2ValidatorAddress
         lookups1 = Constraints.unspentOutputs utxos
                <> Constraints.plutusV2OtherScript mustReferenceOutputValidatorV2
-               <> Constraints.paymentPubKey pk
+               <> Constraints.paymentPubKeyHash pk
         tx1 = Constraints.mustPayToOtherScriptWithDatumInTx
                 vh
                 (Ledger.Datum $ PlutusTx.toBuiltinData utxoRef)
@@ -240,10 +240,9 @@ cardanoTxOwnWalletContract pk pkh = do
 
 cardanoTxOwnWallet :: TestTree
 cardanoTxOwnWallet =
-    let pk  = mockWalletPaymentPubKey     w1
-        pkh = mockWalletPaymentPubKeyHash w1
+    let pkh = mockWalletPaymentPubKeyHash w1
         trace = do
-            void $ Trace.activateContractWallet w1 $ cardanoTxOwnWalletContract pk pkh
+            void $ Trace.activateContractWallet w1 $ cardanoTxOwnWalletContract pkh pkh
             void Trace.nextSlot
     in checkPredicateOptions
         (changeInitialWalletValue w1 (const $ Ada.adaValueOf 1000) defaultCheckOptions)
@@ -251,10 +250,9 @@ cardanoTxOwnWallet =
 
 cardanoTxOtherWalletNoSigningProcess :: TestTree
 cardanoTxOtherWalletNoSigningProcess =
-    let pk  = mockWalletPaymentPubKey     w2
-        pkh = mockWalletPaymentPubKeyHash w2
+    let pkh = mockWalletPaymentPubKeyHash w2
         trace = do
-            void $ Trace.activateContractWallet w1 $ cardanoTxOwnWalletContract pk pkh
+            void $ Trace.activateContractWallet w1 $ cardanoTxOwnWalletContract pkh pkh
             void Trace.nextSlot
     in checkPredicateOptions
         (changeInitialWalletValue w1 (const $ Ada.adaValueOf 1000) defaultCheckOptions)

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/RequiredSigner.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/RequiredSigner.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE TypeFamilies        #-}
 module Spec.Contract.Tx.Constraints.RequiredSigner(tests) where
 
-import Control.Lens (_Just, has)
 import Control.Monad (void)
 import Data.Void (Void)
 import Test.Tasty (TestTree, testGroup)
@@ -20,18 +19,18 @@ import Ledger qualified
 import Ledger.Ada qualified as Ada
 import Ledger.CardanoWallet qualified as CW
 import Ledger.Constraints.OffChain qualified as Constraints hiding (requiredSignatories)
-import Ledger.Constraints.OnChain.V1 qualified as Constraints
+import Ledger.Constraints.OnChain.V2 qualified as Constraints
 import Ledger.Constraints.TxConstraints qualified as Constraints
-import Ledger.Test (someAddressV2, someValidatorHashV2, someValidatorV2)
 import Ledger.Tx qualified as Tx
 import Ledger.Tx.Constraints qualified as TxCons
-import Ledger.Typed.Scripts qualified as Scripts
 import Plutus.Contract as Con
 import Plutus.Contract.Test (assertFailedTransaction, assertValidatedTransactionCount, changeInitialWalletValue,
                              checkPredicateOptions, defaultCheckOptions, mockWalletPaymentPubKeyHash, w1, w2)
 import Plutus.Script.Utils.V2.Typed.Scripts as PSU.V2
+import Plutus.Script.Utils.V2.Typed.Scripts qualified as Scripts
 import Plutus.Trace qualified as Trace
 import Plutus.V1.Ledger.Scripts (ScriptError (EvaluationError), unitDatum)
+import Plutus.V2.Ledger.Api qualified as PV2
 import PlutusTx qualified
 import Prelude
 import Wallet.Emulator.Wallet (signPrivateKeys, walletToMockWallet)
@@ -151,7 +150,7 @@ instance Scripts.ValidatorTypes UnitTest  where
     type instance RedeemerType UnitTest = Ledger.PaymentPubKeyHash
 
 {-# INLINEABLE mustBeSignedByValidator #-}
-mustBeSignedByValidator :: () -> Ledger.PaymentPubKeyHash -> Ledger.ScriptContext -> Bool
+mustBeSignedByValidator :: () -> Ledger.PaymentPubKeyHash -> PV2.ScriptContext -> Bool
 mustBeSignedByValidator _ pkh = Constraints.checkScriptContext @Void @Void (Constraints.mustBeSignedBy pkh)
 
 mustBeSignedByTypedValidator :: Scripts.TypedValidator UnitTest
@@ -174,44 +173,36 @@ cardanoTxOwnWalletContract
     :: Ledger.PaymentPubKeyHash
     -> Ledger.PaymentPubKeyHash
     -> Contract () EmptySchema ContractError ()
-cardanoTxOwnWalletContract pk pkh = do
+cardanoTxOwnWalletContract paymentPubKey signedPubKey = do
     let mkTx lookups constraints = either (error . show) id $ TxCons.mkTx @UnitTest def lookups constraints
 
     utxos <- ownUtxos
-    myAddr <- ownAddress
     let get3 (a:b:c:_) = (a, b, c)
         get3 _         = error "Spec.Contract.TxConstraints.get3: not enough inputs"
         ((utxoRef, utxo), (utxoRefForBalance1, _), (utxoRefForBalance2, _)) = get3 $ M.toList utxos
-        lookups1 = Constraints.unspentOutputs utxos
-               <> Constraints.typedValidatorLookups mustBeSignedByTypedValidator
-               <> Constraints.plutusV2OtherScript someValidatorV2
-               <> Constraints.paymentPubKeyHash pk
-        tx1 = Constraints.mustPayToOtherScriptWithDatumInTx
-                someValidatorHashV2
-                (Ledger.Datum $ PlutusTx.toBuiltinData utxoRef)
-                (Ada.adaValueOf 5)
+        lookups1 = Constraints.typedValidatorLookups mustBeSignedByTypedValidator
+                <> Constraints.unspentOutputs utxos
+        tx1 = Constraints.mustPayToTheScriptWithDatumInTx
+                ()
+                (Ada.lovelaceValueOf 25_000_000)
           <> Constraints.mustSpendPubKeyOutput utxoRefForBalance1
           <> Constraints.mustUseOutputAsCollateral utxoRefForBalance1
-          <> Constraints.mustPayToAddressWithReferenceValidator
-                myAddr
-                someValidatorHashV2
-                Nothing
-                (Ada.adaValueOf 30)
-    submitTxConfirmed $ mkTx lookups1 tx1
+    ledgerTx1 <- submitTxConstraintsWith lookups1 tx1
+    awaitTxConfirmed $ Tx.getCardanoTxId ledgerTx1
 
     -- Trying to unlock the Ada in the script address
-    scriptUtxos <- utxosAt someAddressV2
+    scriptUtxos <- utxosAt (Ledger.scriptHashAddress $ Scripts.validatorHash mustBeSignedByTypedValidator)
     utxos' <- ownUtxos
-    let
-        scriptUtxo = fst . head . M.toList $ scriptUtxos
-        refScriptUtxo = head . M.keys . M.filter (has $ Tx.decoratedTxOutReferenceScript . _Just) $ utxos'
-        lookups2 = Constraints.unspentOutputs (M.singleton utxoRef utxo <> scriptUtxos <> utxos')
-          <> Constraints.typedValidatorLookups mustBeSignedByTypedValidator
-        tx2 = Constraints.mustReferenceOutput utxoRef
-          <> Constraints.mustSpendScriptOutputWithReference scriptUtxo Ledger.unitRedeemer refScriptUtxo
-          <> Constraints.mustSpendPubKeyOutput utxoRefForBalance2
-          <> Constraints.mustUseOutputAsCollateral utxoRefForBalance2
-          <> Constraints.mustBeSignedBy pkh
+    let lookups2 =
+            Constraints.typedValidatorLookups mustBeSignedByTypedValidator
+            <> Constraints.unspentOutputs (M.singleton utxoRef utxo <> scriptUtxos <> utxos')
+            <> Constraints.paymentPubKeyHash paymentPubKey
+        tx2 =
+            Constraints.collectFromTheScript utxos signedPubKey
+            <> Constraints.mustIncludeDatumInTx unitDatum
+            <> Constraints.mustUseOutputAsCollateral utxoRefForBalance2
+            <> Constraints.mustSpendPubKeyOutput utxoRefForBalance2
+            <> Constraints.mustBeSignedBy signedPubKey
     logInfo @String $ "Required Signatories: " ++ show (Constraints.requiredSignatories tx2)
     submitTxConfirmed $ mkTx lookups2 tx2
 

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -291,13 +291,8 @@ data UnbalancedTx
         -- Simply refers to  'slTxOutputs' of 'ScriptLookups'.
         }
     | UnbalancedCardanoTx
-        { unBalancedCardanoBuildTx        :: C.CardanoBuildTx
-        , unBalancedTxRequiredSignatories :: Set PaymentPubKeyHash
-        -- ^ These are all the payment public keys that should be used to request the
-        -- signatories from the user's wallet. The signatories are what is required to
-        -- sign the transaction before submitting it to the blockchain. Transaction
-        -- validation will fail if the transaction is not signed by the required wallet.
-        , unBalancedTxUtxoIndex           :: Map TxOutRef TxOut
+        { unBalancedCardanoBuildTx :: C.CardanoBuildTx
+        , unBalancedTxUtxoIndex    :: Map TxOutRef TxOut
         -- ^ Utxo lookups that are used for adding inputs to the 'UnbalancedTx'.
         -- Simply refers to  'slTxOutputs' of 'ScriptLookups'.
         }
@@ -325,10 +320,9 @@ instance Pretty UnbalancedTx where
         , hang 2 $ vsep $ "Requires signatures:" : (pretty <$> Set.toList rs)
         , hang 2 $ vsep $ "Utxo index:" : (pretty <$> Map.toList utxo)
         ]
-    pretty (UnbalancedCardanoTx utx rs utxo) =
+    pretty (UnbalancedCardanoTx utx utxo) =
         vsep
         [ hang 2 $ vsep ["Tx (cardano-api Representation):", pretty utx]
-        , hang 2 $ vsep $ "Requires signatures:" : (pretty <$> Set.toList rs)
         , hang 2 $ vsep $ "Utxo index:" : (pretty <$> Map.toList utxo)
         ]
 

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -35,6 +35,7 @@ module Ledger.Constraints.OffChain(
     , ownPaymentPubKeyHash
     , ownStakingCredential
     , paymentPubKey
+    , paymentPubKeyHash
     -- * Constraints resolution
     , SomeLookupsAndConstraints(..)
     , UnbalancedTx(..)
@@ -249,7 +250,12 @@ otherData dt =
 -- | A script lookups value with a payment public key
 paymentPubKey :: PaymentPubKey -> ScriptLookups a
 paymentPubKey (PaymentPubKey pk) =
-    mempty { slPaymentPubKeyHashes = Set.singleton (PaymentPubKeyHash $ pubKeyHash pk) }
+   paymentPubKeyHash (PaymentPubKeyHash $ pubKeyHash pk)
+
+-- | A script lookups value with a payment public key
+paymentPubKeyHash :: PaymentPubKeyHash -> ScriptLookups a
+paymentPubKeyHash pkh =
+    mempty { slPaymentPubKeyHashes = Set.singleton pkh }
 
 -- | A script lookups value with a payment public key hash.
 --

--- a/plutus-ledger/src/Ledger/Tx.hs
+++ b/plutus-ledger/src/Ledger/Tx.hs
@@ -53,6 +53,7 @@ module Ledger.Tx
     , getCardanoTxCollateralInputs
     , getCardanoTxOutRefs
     , getCardanoTxOutputs
+    , getCardanoTxRedeemers
     , getCardanoTxSpentOutputs
     , getCardanoTxProducedOutputs
     , getCardanoTxReturnCollateral

--- a/plutus-ledger/src/Ledger/Validation.hs
+++ b/plutus-ledger/src/Ledger/Validation.hs
@@ -304,7 +304,7 @@ makeTransactionBody
   -> Either CardanoLedgerError (C.Api.TxBody C.Api.BabbageEra)
 makeTransactionBody params utxo txBodyContent = do
   txTmp <- first Right $ makeSignedTransaction [] <$> P.makeTransactionBody (Just $ emulatorPParams params) mempty txBodyContent
-  exUnits <- bimap Left id $ (Map.map snd) <$> getTxExUnitsWithLogs params utxo txTmp
+  exUnits <- first Left $ Map.map snd <$> getTxExUnitsWithLogs params utxo txTmp
   first Right $ P.makeTransactionBody (Just $ emulatorPParams params) exUnits txBodyContent
 
 

--- a/plutus-tx-constraints/src/Ledger/Tx/Constraints.hs
+++ b/plutus-tx-constraints/src/Ledger/Tx/Constraints.hs
@@ -79,6 +79,7 @@ module Ledger.Tx.Constraints(
     , OC.plutusV2OtherScript
     , OC.otherData
     , OC.paymentPubKey
+    , OC.paymentPubKeyHash
     , OC.ownPaymentPubKeyHash
     , OC.ownStakingCredential
     -- * Deprecated

--- a/plutus-tx-constraints/src/Ledger/Tx/Constraints/OffChain.hs
+++ b/plutus-tx-constraints/src/Ledger/Tx/Constraints/OffChain.hs
@@ -34,6 +34,7 @@ module Ledger.Tx.Constraints.OffChain(
     , P.ownPaymentPubKeyHash
     , P.ownStakingCredential
     , P.paymentPubKey
+    , P.paymentPubKeyHash
     -- * Constraints resolution
     , P.SomeLookupsAndConstraints(..)
     , UnbalancedTx(..)

--- a/plutus-tx-constraints/src/Ledger/Tx/Constraints/OffChain.hs
+++ b/plutus-tx-constraints/src/Ledger/Tx/Constraints/OffChain.hs
@@ -61,6 +61,7 @@ import Data.Aeson (FromJSON, ToJSON)
 import Data.Bifunctor (first)
 import Data.Either (partitionEithers)
 import Data.Foldable (traverse_)
+import Data.Set qualified as Set
 import GHC.Generics (Generic)
 import Ledger (POSIXTimeRange, Params (..), networkIdL, pProtocolParams)
 import Ledger.Constraints qualified as P
@@ -278,7 +279,8 @@ processConstraint = \case
             $ guard $ is Tx._PublicKeyDecoratedTxOut txout
         txIn <- throwLeft ToCardanoError $ C.toCardanoTxIn txo
         unbalancedTx . tx . txIns <>= [(txIn, C.BuildTxWith (C.KeyWitness C.KeyWitnessForSpending))]
-
+    P.MustBeSignedBy pk ->
+        unbalancedTx . P.requiredSignatories %= Set.insert pk
     P.MustSpendScriptOutput txo redeemer mref -> do
         txout <- lookupTxOutRef txo
         mkWitness <- case mref of


### PR DESCRIPTION
Implementation details:

As we put the required signatures directly in the Tx, we don't need `unbalancedRequiredSignatories` in the unbalanced cardano Tx, so it's now removed.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
