### PR TITLE
Change secp256k1 loop scripts to have consistent counter value bitsizes

### DIFF
--- a/plutus-example/src/PlutusExample/PlutusVersion2/EcdsaSecp256k1Loop.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion2/EcdsaSecp256k1Loop.hs
@@ -26,14 +26,14 @@ mkValidator _datum red _txContext =
   case PlutusV2.fromBuiltinData red of
     Nothing -> P.traceError "Trace error: Invalid redeemer"
     Just (n, vkey, msg, sig) ->
-      if n < (0 :: Integer)
-      then traceError "redeemer is < 0"
+      if n < (1000000 :: Integer) -- large number ensures same bitsize for all counter values
+      then traceError "redeemer is < 1000000"
       else loop n vkey msg sig
   where
     loop i v m s
-      | i == 0 = ()
+      | i == 1000000 = ()
       | BI.verifyEcdsaSecp256k1Signature v m s = loop (pred i) v m s
-      | otherwise = P.traceError "Trace error: Ecdsa validation failed"
+      | otherwise = P.traceError "Trace error: ECDSA validation failed"
 
 validator :: PlutusV2.Validator
 validator = PlutusV2.mkValidatorScript $$(PlutusTx.compile [|| mkValidator ||])

--- a/plutus-example/src/PlutusExample/PlutusVersion2/SchnorrSecp256k1Loop.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion2/SchnorrSecp256k1Loop.hs
@@ -26,12 +26,12 @@ mkValidator _datum red _txContext =
   case PlutusV2.fromBuiltinData red of
     Nothing -> P.traceError "Trace error: Invalid redeemer"
     Just (n, vkey, msg, sig) ->
-      if n < (0 :: Integer)
-      then traceError "redeemer is < 0"
+      if n < (1000000 :: Integer) -- large number ensures same bitsize for all counter values
+      then traceError "redeemer is < 1000000"
       else loop n vkey msg sig
   where
     loop i v m s
-      | i == 0 = ()
+      | i == 1000000 = ()
       | BI.verifySchnorrSecp256k1Signature v m s = loop (pred i) v m s
       | otherwise = P.traceError "Trace error: Schnorr validation failed"
 


### PR DESCRIPTION
Two new plutus V2 scripts for looping over SECP256k1 ECDSA and Schnorr verify builtin functions.

Can use the following redeemers (cli json format) to loop 10 times. Change the `int` for number of loops:

ECDSA
```
{"constructor":0,"fields":[{"int":1000010},{"bytes":"0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"},{"bytes":"16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"},{"bytes":"5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"}]}
```

Schnorr
```
{"constructor":0,"fields":[{"int":1000010},{"bytes":"599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b"},{"bytes":"30303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030"},{"bytes":"5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a9b"}]}
```