### PR TITLE
Better computation of minAda

### DIFF
--- a/doc/plutus/tutorials/Auction.hs
+++ b/doc/plutus/tutorials/Auction.hs
@@ -217,7 +217,7 @@ instance ContractModel AuctionModel where
         where
             p    = s ^. contractState . phase
             b    = s ^. contractState . currentBid
-            validBid = choose ((b+1) /\ Ada.getLovelace Ledger.minAdaTxOutEstimated,
+            validBid = choose ((b+1) `max` Ada.getLovelace Ledger.minAdaTxOutEstimated,
                                b + Ada.getLovelace (Ada.adaOf 100))
 {- START precondition -}
     precondition s Init = s ^. contractState . phase == NotStarted

--- a/doc/plutus/tutorials/Auction.hs
+++ b/doc/plutus/tutorials/Auction.hs
@@ -217,7 +217,7 @@ instance ContractModel AuctionModel where
         where
             p    = s ^. contractState . phase
             b    = s ^. contractState . currentBid
-            validBid = choose ((b+1) `max` Ada.getLovelace Ledger.minAdaTxOut,
+            validBid = choose ((b+1) /\ Ada.getLovelace Ledger.minAdaTxOutEstimated,
                                b + Ada.getLovelace (Ada.adaOf 100))
 {- START precondition -}
     precondition s Init = s ^. contractState . phase == NotStarted
@@ -225,7 +225,7 @@ instance ContractModel AuctionModel where
       -- In order to place a bid, we need to satisfy the constraint where
       -- each tx output must have at least N Ada.
       s ^. contractState . phase /= NotStarted &&
-      bid >= Ada.getLovelace (Ledger.minAdaTxOut) &&
+      bid >= Ada.getLovelace (Ledger.minAdaTxOutEstimated) &&
       bid > s ^. contractState . currentBid
 {-END precondition -}
 {- START nextReactiveState -}
@@ -236,7 +236,7 @@ instance ContractModel AuctionModel where
         w   <- viewContractState winner
         bid <- viewContractState currentBid
         phase .= AuctionOver
-        deposit w $ Ada.toValue Ledger.minAdaTxOut <> theToken
+        deposit w $ Ada.toValue Ledger.minAdaTxOutEstimated <> theToken
         deposit w1 $ Ada.lovelaceValueOf bid
 {- END nextReactiveState -}
 
@@ -249,7 +249,7 @@ instance ContractModel AuctionModel where
         w   <- viewContractState winner
         bid <- viewContractState currentBid
         phase .= AuctionOver
-        deposit w $ Ada.toValue Ledger.minAdaTxOut <> theToken
+        deposit w $ Ada.toValue Ledger.minAdaTxOutEstimated <> theToken
         deposit w1 $ Ada.lovelaceValueOf bid
         -- NEW!!!
         w1change <- viewModelState $ balanceChange w1  -- since the start of the test
@@ -264,7 +264,7 @@ instance ContractModel AuctionModel where
         case cmd of
             Init -> do
                 phase .= Bidding
-                withdraw w1 $ Ada.toValue Ledger.minAdaTxOut <> theToken
+                withdraw w1 $ Ada.toValue Ledger.minAdaTxOutEstimated <> theToken
                 wait 3
             Bid w bid -> do
                 currentPhase <- viewContractState phase
@@ -368,8 +368,8 @@ tests =
             (assertDone seller (Trace.walletInstanceTag w1) (const True) "seller should be done"
             .&&. assertDone (buyer threadToken) (Trace.walletInstanceTag w2) (const True) "buyer should be done"
             .&&. assertAccumState (buyer threadToken) (Trace.walletInstanceTag w2) ((==) trace1FinalState ) "wallet 2 final state should be OK"
-            .&&. walletFundsChange w1 (Ada.toValue (-Ledger.minAdaTxOut) <> Ada.toValue trace1WinningBid <> inv theToken)
-            .&&. walletFundsChange w2 (Ada.toValue Ledger.minAdaTxOut <> inv (Ada.toValue trace1WinningBid) <> theToken))
+            .&&. walletFundsChange w1 (Ada.toValue (-Ledger.minAdaTxOutEstimated) <> Ada.toValue trace1WinningBid <> inv theToken)
+            .&&. walletFundsChange w2 (Ada.toValue Ledger.minAdaTxOutEstimated <> inv (Ada.toValue trace1WinningBid) <> theToken))
             auctionTrace1
         , checkPredicateOptions options "run an auction with multiple bids"
             (assertDone seller (Trace.walletInstanceTag w1) (const True) "seller should be done"
@@ -377,8 +377,8 @@ tests =
             .&&. assertDone (buyer threadToken) (Trace.walletInstanceTag w3) (const True) "3rd party should be done"
             .&&. assertAccumState (buyer threadToken) (Trace.walletInstanceTag w2) ((==) trace2FinalState) "wallet 2 final state should be OK"
             .&&. assertAccumState (buyer threadToken) (Trace.walletInstanceTag w3) ((==) trace2FinalState) "wallet 3 final state should be OK"
-            .&&. walletFundsChange w1 (Ada.toValue (-Ledger.minAdaTxOut) <> Ada.toValue trace2WinningBid <> inv theToken)
-            .&&. walletFundsChange w2 (Ada.toValue Ledger.minAdaTxOut <> inv (Ada.toValue trace2WinningBid) <> theToken)
+            .&&. walletFundsChange w1 (Ada.toValue (-Ledger.minAdaTxOutEstimated) <> Ada.toValue trace2WinningBid <> inv theToken)
+            .&&. walletFundsChange w2 (Ada.toValue Ledger.minAdaTxOutEstimated <> inv (Ada.toValue trace2WinningBid) <> theToken)
             .&&. walletFundsChange w3 mempty)
             auctionTrace2
         , testProperty "QuickCheck property" $

--- a/doc/plutus/tutorials/Escrow.hs
+++ b/doc/plutus/tutorials/Escrow.hs
@@ -20,7 +20,7 @@ import Data.Foldable (Foldable (fold))
 import Data.Map (Map)
 import Data.Map qualified as Map
 
-import Ledger (minAdaTxOut)
+import Ledger (minAdaTxOutEstimated)
 import Ledger.Ada qualified as Ada
 import Ledger.Typed.Scripts qualified as Scripts
 import Ledger.Value qualified as Value
@@ -169,14 +169,14 @@ precondition s a = case a of
     Redeem _ -> (s ^. contractState . contributions . to fold)
                 `geq`
                 (s ^. contractState . targets . to fold)
-    Pay _ v  -> Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOut
+    Pay _ v  -> Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOutEstimated
 {- END precondition2 -}
 -}
   precondition s a = case a of
     Redeem _ -> (s ^. CM.contractState . contributions . to fold) `Value.geq` (s ^. CM.contractState . targets . to fold)
     --Redeem _ -> (s ^. contractState . contributions . to fold) == (s ^. contractState . targets . to fold)
     --Refund w -> Nothing /= (s ^. contractState . contributions . at w)
-    Pay _ v  -> Ada.adaValueOf (fromInteger v) `Value.geq` Ada.toValue minAdaTxOut
+    Pay _ v  -> Ada.adaValueOf (fromInteger v) `Value.geq` Ada.toValue minAdaTxOutEstimated
 
 {- START perform -}
   perform h _ _ a = case a of

--- a/doc/plutus/tutorials/Escrow2.hs
+++ b/doc/plutus/tutorials/Escrow2.hs
@@ -24,7 +24,7 @@ import Data.Foldable (fold)
 import Data.Map (Map)
 import Data.Map qualified as Map
 
-import Ledger (minAdaTxOut)
+import Ledger (minAdaTxOutEstimated)
 import Ledger.Ada qualified as Ada
 import Ledger.Value qualified as Value
 import Plutus.Contract (Contract, selectList)
@@ -130,7 +130,7 @@ instance CM.ContractModel EscrowModel where
 {- START tightprecondition -}
   precondition s a = case a of
     Init tgts-> currentPhase == Initial
-             && and [Ada.adaValueOf (fromInteger n) `geq` Ada.toValue minAdaTxOut | (w,n) <- tgts]
+             && and [Ada.adaValueOf (fromInteger n) `geq` Ada.toValue minAdaTxOutEstimated | (w,n) <- tgts]
     ...
 {- END tightprecondition -}
 -}
@@ -140,7 +140,7 @@ instance CM.ContractModel EscrowModel where
     Redeem _ -> currentPhase == Running
              && (s ^. CM.contractState . contributions . to fold) `Value.geq` (s ^. CM.contractState . targets . to fold)
     Pay _ v  -> currentPhase == Running
-             && Ada.adaValueOf (fromInteger v) `Value.geq` Ada.toValue minAdaTxOut
+             && Ada.adaValueOf (fromInteger v) `Value.geq` Ada.toValue minAdaTxOutEstimated
     where currentPhase = s ^. CM.contractState . phase
 
 {-

--- a/doc/plutus/tutorials/Escrow4.hs
+++ b/doc/plutus/tutorials/Escrow4.hs
@@ -24,7 +24,7 @@ import Data.Foldable (fold)
 import Data.Map (Map)
 import Data.Map qualified as Map
 
-import Ledger (POSIXTime (POSIXTime), Slot (Slot, getSlot), minAdaTxOut)
+import Ledger (POSIXTime (POSIXTime), Slot (Slot, getSlot), minAdaTxOutEstimated)
 import Ledger.Ada qualified as Ada
 import Ledger.Value qualified as Value
 import Plutus.Contract (Contract, selectList)
@@ -132,11 +132,11 @@ instance CM.ContractModel EscrowModel where
   precondition s a = case a of
     Init s tgts -> currentPhase == Initial
                 && s > 1
-                && and [Ada.adaValueOf (fromInteger n) `Value.geq` Ada.toValue minAdaTxOut | (_,n) <- tgts]
+                && and [Ada.adaValueOf (fromInteger n) `Value.geq` Ada.toValue minAdaTxOutEstimated | (_,n) <- tgts]
     Redeem _    -> currentPhase == Running
                 && fold (s ^. CM.contractState . contributions) `Value.geq` fold (s ^. CM.contractState . targets)
     Pay _ v     -> currentPhase == Running
-                && Ada.adaValueOf (fromInteger v) `Value.geq` Ada.toValue minAdaTxOut
+                && Ada.adaValueOf (fromInteger v) `Value.geq` Ada.toValue minAdaTxOutEstimated
     Refund w    -> currentPhase == Refunding           -- NEW!!!
                 && w `Map.member` (s ^. CM.contractState . contributions)
     where currentPhase = s ^. CM.contractState . phase

--- a/doc/plutus/tutorials/Escrow5.hs
+++ b/doc/plutus/tutorials/Escrow5.hs
@@ -24,7 +24,7 @@ import Data.Foldable (fold)
 import Data.Map (Map)
 import Data.Map qualified as Map
 
-import Ledger (POSIXTime (POSIXTime), Slot (Slot, getSlot), minAdaTxOut)
+import Ledger (POSIXTime (POSIXTime), Slot (Slot, getSlot), minAdaTxOutEstimated)
 import Ledger.Ada qualified as Ada
 import Ledger.Value qualified as Value
 import Plutus.Contract (Contract, selectList)
@@ -115,11 +115,11 @@ instance CM.ContractModel EscrowModel where
   precondition s a = case a of
     Init s tgts -> currentPhase == Initial
                 && s > 1
-                && and [Ada.adaValueOf (fromInteger n) `Value.geq` Ada.toValue minAdaTxOut | (_,n) <- tgts]
+                && and [Ada.adaValueOf (fromInteger n) `Value.geq` Ada.toValue minAdaTxOutEstimated | (_,n) <- tgts]
     Redeem _    -> currentPhase == Running
                 && fold (s ^. CM.contractState . contributions) `Value.geq` fold (s ^. CM.contractState . targets)
     Pay _ v     -> currentPhase == Running
-                && Ada.adaValueOf (fromInteger v) `Value.geq` Ada.toValue minAdaTxOut
+                && Ada.adaValueOf (fromInteger v) `Value.geq` Ada.toValue minAdaTxOutEstimated
     Refund w    -> currentPhase == Refunding
                 && w `Map.member` (s ^. CM.contractState . contributions)
     where currentPhase = s ^. CM.contractState . phase

--- a/doc/plutus/tutorials/Escrow6.hs
+++ b/doc/plutus/tutorials/Escrow6.hs
@@ -32,7 +32,7 @@ import Data.Foldable (fold)
 import Data.Map (Map)
 import Data.Map qualified as Map
 
-import Ledger (POSIXTime (POSIXTime), Slot (Slot, getSlot), minAdaTxOut)
+import Ledger (POSIXTime (POSIXTime), Slot (Slot, getSlot), minAdaTxOutEstimated)
 import Ledger.Ada qualified as Ada
 import Ledger.Value qualified as Value
 import Plutus.Contract (Contract, selectList)
@@ -127,11 +127,11 @@ instance CM.ContractModel EscrowModel where
   precondition s a = case a of
     Init s tgts -> currentPhase == Initial
                 && s > 1
-                && and [Ada.adaValueOf (fromInteger n) `Value.geq` Ada.toValue minAdaTxOut | (_,n) <- tgts]
+                && and [Ada.adaValueOf (fromInteger n) `Value.geq` Ada.toValue minAdaTxOutEstimated | (_,n) <- tgts]
     Redeem _    -> currentPhase == Running
                 && fold (s ^. CM.contractState . contributions) `Value.geq` fold (s ^. CM.contractState . targets)
     Pay _ v     -> currentPhase == Running
-                && Ada.adaValueOf (fromInteger v) `Value.geq` Ada.toValue minAdaTxOut
+                && Ada.adaValueOf (fromInteger v) `Value.geq` Ada.toValue minAdaTxOutEstimated
     Refund w    -> currentPhase == Refunding
                 && w `Map.member` (s ^. CM.contractState . contributions)
     where currentPhase = s ^. CM.contractState . phase

--- a/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
+++ b/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
@@ -307,7 +307,7 @@ handleAdjustUnbalancedTx =
     RequestHandler $ \utx ->
         surroundDebug @Text "handleAdjustUnbalancedTx" $ do
             params <- Wallet.Effects.getClientParams
-            forM (adjustUnbalancedTx params utx) $ \(missingAdaCosts, adjusted) -> do
+            forM (adjustUnbalancedTx (emulatorPParams params) utx) $ \(missingAdaCosts, adjusted) -> do
                 logDebug $ AdjustingUnbalancedTx missingAdaCosts
                 pure adjusted
 

--- a/plutus-contract/src/Wallet/API.hs
+++ b/plutus-contract/src/Wallet/API.hs
@@ -132,7 +132,8 @@ payToAddress params range v addr = do
     utx <- either (throwError . PaymentMkTxError)
                   pure
                   (Constraints.mkTxWithParams @Void params mempty constraints)
-    (missingAdaCosts, adjustedUtx) <- either (throwError . ToCardanoError) pure (adjustUnbalancedTx params utx)
+    (missingAdaCosts, adjustedUtx) <- either (throwError . ToCardanoError) pure
+                                        (adjustUnbalancedTx (emulatorPParams params) utx)
     logDebug $ AdjustingUnbalancedTx missingAdaCosts
     unless (utx == adjustedUtx) $
       logWarn @Text $ "Wallet.API.payToPublicKeyHash: "

--- a/plutus-contract/src/Wallet/Emulator/MultiAgent.hs
+++ b/plutus-contract/src/Wallet/Emulator/MultiAgent.hs
@@ -312,7 +312,7 @@ emulatorStateInitialDist params mp = do
         mMinAdaTxOut = do
           let k = fst $ head $ Map.toList mp
           emptyTxOut <- toCardanoTxOut (pNetworkId params) $ mkOutput k mempty
-          pure $ minAdaTxOut params (TxOut emptyTxOut)
+          pure $ minAdaTxOut (emulatorPParams params) (TxOut emptyTxOut)
         -- See [Creating wallets with multiple outputs]
         mkOutputs minAda (key, vl) = mkOutput key <$> splitInto10 vl minAda
         splitInto10 vl minAda = if count <= 1

--- a/plutus-contract/src/Wallet/Emulator/MultiAgent.hs
+++ b/plutus-contract/src/Wallet/Emulator/MultiAgent.hs
@@ -35,12 +35,12 @@ import Data.Text.Extras (tshow)
 import GHC.Generics (Generic)
 import Prettyprinter (Pretty (pretty), colon, (<+>))
 
-import Cardano.Api (NetworkId)
 import Data.Foldable (fold)
-import Ledger hiding (to, value)
+import Ledger hiding (minAdaTxOut, to, value)
 import Ledger.Ada qualified as Ada
 import Ledger.AddressMap qualified as AM
 import Ledger.CardanoWallet qualified as CW
+import Ledger.Constraints.OffChain (adjustTxOut)
 import Ledger.Index qualified as Index
 import Ledger.Tx.CardanoAPI (toCardanoTxOut)
 import Ledger.Validation qualified as Validation
@@ -295,9 +295,10 @@ we create 10 Ada-only outputs per wallet here.
 
 -- | Initialise the emulator state with a single pending transaction that
 --   creates the initial distribution of funds to public key addresses.
-emulatorStateInitialDist :: NetworkId -> Map PaymentPubKeyHash Value -> Either ToCardanoError EmulatorState
-emulatorStateInitialDist networkId mp = do
-    outs <- traverse (toCardanoTxOut networkId) $ Map.toList mp >>= mkOutputs
+emulatorStateInitialDist :: Params -> Map PaymentPubKeyHash Value -> Either ToCardanoError EmulatorState
+emulatorStateInitialDist params mp = do
+    minAdaTxOut <- mMinAdaTxOut
+    outs <- traverse (toCardanoTxOut $ pNetworkId params) $ Map.toList mp >>= mkOutputs minAdaTxOut
     let tx = mempty
            { txOutputs = TxOut <$> outs
            , txMint = fold mp
@@ -307,13 +308,23 @@ emulatorStateInitialDist networkId mp = do
         cTx = Validation.fromPlutusTxSigned def cUtxoIndex tx CW.knownPaymentKeys
     pure $ emulatorStatePool [cTx]
     where
+        -- we start with an empty TxOut and we adjust it to be sure that the containted Adas fit the size
+        -- of the TxOut
+        mMinAdaTxOut = do
+          let k = fst $ head $ Map.toList mp
+          emptyTxOut <- toCardanoTxOut (pNetworkId params) $ mkOutput k mempty
+          Ada.fromValue . txOutValue . snd <$> adjustTxOut params (TxOut emptyTxOut)
         -- See [Creating wallets with multiple outputs]
-        mkOutputs (key, vl) = mkOutput key <$> splitInto10 vl
-        splitInto10 vl = if count <= 1 then [vl] else replicate (fromIntegral count) (Ada.toValue (ada `div` count)) ++ remainder
+        mkOutputs minAda (key, vl) = mkOutput key <$> splitInto10 vl minAda
+        splitInto10 vl minAda = if count <= 1
+            then [vl]
+            else replicate (fromIntegral count) (Ada.toValue (ada `div` count)) ++ remainder
             where
-                ada = if Value.isAdaOnlyValue vl then Ada.fromValue vl else Ada.fromValue vl - minAdaTxOut
+                ada = if Value.isAdaOnlyValue vl
+                    then Ada.fromValue vl
+                    else Ada.fromValue vl - minAda
                 -- Make sure we don't make the outputs too small
-                count = min 10 $ ada `div` minAdaTxOut
+                count = min 10 $ ada `div` minAda
                 remainder = [ vl <> Ada.toValue (-ada) | not (Value.isAdaOnlyValue vl) ]
         mkOutput key vl = V2.pubKeyHashTxOut vl (unPaymentPubKeyHash key)
 

--- a/plutus-contract/src/Wallet/Emulator/Stream.hs
+++ b/plutus-contract/src/Wallet/Emulator/Stream.hs
@@ -166,11 +166,10 @@ instance Default EmulatorConfig where
 
 initialState :: EmulatorConfig -> EM.EmulatorState
 initialState EmulatorConfig{..} = let
-    networkId = pNetworkId _params
     withInitialWalletValues = either
           (error . ("Cannot build the initial state: " <>) . show)
           id
-          . EM.emulatorStateInitialDist networkId . Map.mapKeys EM.mockWalletPaymentPubKeyHash
+          . EM.emulatorStateInitialDist _params . Map.mapKeys EM.mockWalletPaymentPubKeyHash
     signTx = onCardanoTx
           (\t -> Validation.fromPlutusTxSigned _params cUtxoIndex t CW.knownPaymentKeys)
           CardanoApiTx

--- a/plutus-contract/src/Wallet/Emulator/Stream.hs
+++ b/plutus-contract/src/Wallet/Emulator/Stream.hs
@@ -54,7 +54,7 @@ import Streaming (Stream)
 import Streaming qualified as S
 import Streaming.Prelude (Of)
 import Streaming.Prelude qualified as S
-import Wallet.API (Params (pNetworkId), WalletAPIError)
+import Wallet.API (Params, WalletAPIError)
 import Wallet.Emulator (EmulatorEvent, EmulatorEvent')
 import Wallet.Emulator qualified as EM
 import Wallet.Emulator.Chain (ChainControlEffect, ChainEffect, _SlotAdd)

--- a/plutus-contract/src/Wallet/Emulator/Wallet.hs
+++ b/plutus-contract/src/Wallet/Emulator/Wallet.hs
@@ -507,7 +507,7 @@ calculateTxChanges addr utxos (neg, pos) = do
               $ toCardanoTxOut (pNetworkId params) $ PV2.TxOut addr pos PV2.NoOutputDatum Nothing
             (missing, extraTxOut) <-
                 either (throwError . WAPI.ToCardanoError) pure
-                $ U.adjustTxOut params txOut
+                $ U.adjustTxOut (emulatorPParams params) txOut
             let missingValue = Ada.toValue (fold missing)
             -- Add the missing ada to both sides to keep the balance.
             pure (neg <> missingValue, pos <> missingValue, Just extraTxOut)

--- a/plutus-contract/src/Wallet/Emulator/Wallet.hs
+++ b/plutus-contract/src/Wallet/Emulator/Wallet.hs
@@ -525,7 +525,7 @@ calculateTxChanges addr utxos (neg, pos) = do
             -- We have change so we need an extra output, if we didn't have that yet,
             -- first make one with an estimated minimal amount of ada
             -- which then will calculate a more exact set of inputs
-            then calculateTxChanges addr utxos (neg <> Ada.toValue Ledger.minAdaTxOut, Ada.toValue Ledger.minAdaTxOut)
+            then calculateTxChanges addr utxos (neg <> Ada.toValue Ledger.minAdaTxOutEstimated, Ada.toValue Ledger.minAdaTxOutEstimated)
             -- Else recalculate with the change added to both sides
             -- Ideally this creates the same inputs and outputs and then the change will be zero
             -- But possibly the minimal Ada increases and then we also want to compute a new set of inputs

--- a/plutus-contract/test/Spec/Balancing.hs
+++ b/plutus-contract/test/Spec/Balancing.hs
@@ -56,7 +56,7 @@ balanceTxnMinAda =
                     L.Constraints.mustPayToOtherScriptWithDatumInTx
                         vHash
                         unitDatum
-                        (Value.scale 100 ff <> Ada.toValue Ledger.minAdaTxOut)
+                        (Value.scale 100 ff <> Ada.toValue Ledger.minAdaTxOutEstimated)
                  <> L.Constraints.mustIncludeDatumInTx unitDatum
             utx1 <- mkTxConstraints @Void mempty constraints1
             submitTxConfirmed utx1
@@ -105,7 +105,7 @@ balanceTxnMinAda2 =
               =<< mkTx mempty
                        (payToWallet w2 ( vA 1
                                       <> vB 1
-                                      <> Value.scale 2 (Ada.toValue Ledger.minAdaTxOut)
+                                      <> Value.scale 2 (Ada.toValue Ledger.minAdaTxOutEstimated)
                                        ))
             -- Make sure there is a UTxO with 1 B and datum () at the script
             submitTxConfirmed
@@ -153,7 +153,7 @@ balanceTxnNoExtraOutput =
             let val = vL 200
                 lookups = L.Constraints.plutusV1MintingPolicy coinMintingPolicy
                 constraints = L.Constraints.mustMintValue val
-                    <> L.Constraints.mustPayToPubKey pkh (val <> Ada.toValue Ledger.minAdaTxOut)
+                    <> L.Constraints.mustPayToPubKey pkh (val <> Ada.toValue Ledger.minAdaTxOutEstimated)
 
             tx <- submitUnbalancedTx =<< mkTx lookups constraints
             tell [length $ Ledger.getCardanoTxOutRefs tx]
@@ -207,7 +207,7 @@ balanceCardanoTx =
             pkh <- Con.ownFirstPaymentPubKeyHash
             utxos <- Con.ownUtxos
 
-            let constraints = Tx.Constraints.mustPayToPubKey pkh (Ada.toValue Ledger.minAdaTxOut)
+            let constraints = Tx.Constraints.mustPayToPubKey pkh (Ada.toValue Ledger.minAdaTxOutEstimated)
                     <> Tx.Constraints.mustSpendPubKeyOutput (fst . head . Map.toList $ utxos)
                 lookups = Tx.Constraints.unspentOutputs utxos
 

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/TimeValidity.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/TimeValidity.hs
@@ -121,7 +121,7 @@ contractCardano f p = do
     logInfo @String $ "now: " ++ show now
     let utxoRef = fst $ head' $ Map.toList utxos
         lookups = Tx.Constraints.unspentOutputs utxos
-        tx  =  Tx.Constraints.mustPayToPubKey pkh (Ada.toValue Ledger.minAdaTxOut)
+        tx  =  Tx.Constraints.mustPayToPubKey pkh (Ada.toValue Ledger.minAdaTxOutEstimated)
             <> Tx.Constraints.mustSpendPubKeyOutput utxoRef
             <> Tx.Constraints.mustValidateIn (f now)
     void $ waitNSlots 2

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -569,10 +569,10 @@ adjustUnbalancedTx params = alaf Compose (tx . Tx.outputs . traverse) (adjustTxO
 adjustTxOut :: Params -> TxOut -> Either Tx.ToCardanoError ([Ada.Ada], TxOut)
 adjustTxOut params txOut = do
     -- Increasing the ada amount can also increase the size in bytes, so start with a rough estimated amount of ada
-    withMinAdaValue <- C.toCardanoTxOutValue $ txOutValue txOut <> Ada.toValue minAdaTxOut
+    withMinAdaValue <- C.toCardanoTxOutValue $ txOutValue txOut \/ Ada.toValue (minAdaTxOut params txOut)
     let txOutEstimate = txOut & outValue .~ withMinAdaValue
-        minAdaTxOut' = evaluateMinLovelaceOutput params (fromPlutusTxOut txOutEstimate)
-        missingLovelace = minAdaTxOut' - Ada.fromValue (txOutValue txOut)
+        minAdaTxOutEstimated' = evaluateMinLovelaceOutput params (fromPlutusTxOut txOutEstimate)
+        missingLovelace = minAdaTxOutEstimated' - Ada.fromValue (txOutValue txOut)
     if missingLovelace > 0
     then do
       adjustedLovelace <- C.toCardanoTxOutValue $ txOutValue txOut <> Ada.toValue missingLovelace

--- a/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs
@@ -123,7 +123,7 @@ import Ledger.Constraints.TxConstraints (ScriptInputConstraint (ScriptInputConst
 import Ledger.Crypto (pubKeyHash)
 import Ledger.Index (minAdaTxOut)
 import Ledger.Orphans ()
-import Ledger.Params (Params (pNetworkId, pSlotConfig))
+import Ledger.Params (PParams, Params (pNetworkId, pSlotConfig))
 import Ledger.TimeSlot (posixTimeRangeToContainedSlotRange)
 import Ledger.Tx (DecoratedTxOut, Language (PlutusV1, PlutusV2), ReferenceScript, TxOut (TxOut), TxOutRef,
                   Versioned (Versioned), txOutValue)
@@ -131,7 +131,6 @@ import Ledger.Tx qualified as Tx
 import Ledger.Tx.CardanoAPI qualified as C
 import Ledger.Typed.Scripts (Any, ConnectionError (UnknownRef), TypedValidator (tvValidator, tvValidatorHash),
                              ValidatorTypes (DatumType, RedeemerType), validatorAddress)
-import Ledger.Validation (evaluateMinLovelaceOutput, fromPlutusTxOut)
 import Plutus.Script.Utils.Scripts qualified as P
 import Plutus.Script.Utils.V2.Typed.Scripts qualified as Typed
 import Plutus.V1.Ledger.Api (Datum (Datum), DatumHash, StakingCredential, Validator (getValidator), Value,
@@ -561,17 +560,17 @@ mkTxWithParams params lookups txc = mkSomeTx params [SomeLookupsAndConstraints l
 
 -- | Each transaction output should contain a minimum amount of Ada (this is a
 -- restriction on the real Cardano network).
-adjustUnbalancedTx :: Params -> UnbalancedTx -> Either Tx.ToCardanoError ([Ada.Ada], UnbalancedTx)
+adjustUnbalancedTx :: PParams -> UnbalancedTx -> Either Tx.ToCardanoError ([Ada.Ada], UnbalancedTx)
 adjustUnbalancedTx params = alaf Compose (tx . Tx.outputs . traverse) (adjustTxOut params)
 
 -- | Adjust a single transaction output so it contains at least the minimum amount of Ada
 -- and return the adjustment (if any) and the updated TxOut.
-adjustTxOut :: Params -> TxOut -> Either Tx.ToCardanoError ([Ada.Ada], TxOut)
+adjustTxOut :: PParams -> TxOut -> Either Tx.ToCardanoError ([Ada.Ada], TxOut)
 adjustTxOut params txOut = do
     -- Increasing the ada amount can also increase the size in bytes, so start with a rough estimated amount of ada
     withMinAdaValue <- C.toCardanoTxOutValue $ txOutValue txOut \/ Ada.toValue (minAdaTxOut params txOut)
     let txOutEstimate = txOut & outValue .~ withMinAdaValue
-        minAdaTxOutEstimated' = evaluateMinLovelaceOutput params (fromPlutusTxOut txOutEstimate)
+        minAdaTxOutEstimated' = minAdaTxOut params txOutEstimate
         missingLovelace = minAdaTxOutEstimated' - Ada.fromValue (txOutValue txOut)
     if missingLovelace > 0
     then do

--- a/plutus-ledger-constraints/test/Spec.hs
+++ b/plutus-ledger-constraints/test/Spec.hs
@@ -135,7 +135,7 @@ mustPayToPubKeyAddressStakePubKeyNotNothingProp = property $ do
     [x,y] <- Hedgehog.forAllWith (const "A known key") $ take 2 <$> Gen.shuffle Gen.knownXPrvs
     let pkh = xprvToPaymentPubKeyHash x
         sc = xprvToStakingCredential y
-        txE = Constraints.mkTxWithParams @Void def mempty (Constraints.mustPayToPubKeyAddress pkh sc (Ada.toValue Ledger.minAdaTxOut))
+        txE = Constraints.mkTxWithParams @Void def mempty (Constraints.mustPayToPubKeyAddress pkh sc (Ada.toValue Ledger.minAdaTxOutEstimated))
     case txE of
       Left err -> do
           Hedgehog.annotateShow err
@@ -151,7 +151,7 @@ mustPayToOtherScriptAddressStakeValidatorHashNotNothingProp :: Property
 mustPayToOtherScriptAddressStakeValidatorHashNotNothingProp = property $ do
     pkh <- forAll $ Ledger.paymentPubKeyHash <$> Gen.element Gen.knownPaymentPublicKeys
     let sc = stakeValidatorHashCredential $ Ledger.StakeValidatorHash $ examplePlutusScriptAlwaysSucceedsHash WitCtxStake
-        txE = Constraints.mkTxWithParams @Void def mempty (Constraints.mustPayToOtherScriptAddressWithDatumHash alwaysSucceedValidatorHash sc Ledger.unitDatum (Ada.toValue Ledger.minAdaTxOut))
+        txE = Constraints.mkTxWithParams @Void def mempty (Constraints.mustPayToOtherScriptAddressWithDatumHash alwaysSucceedValidatorHash sc Ledger.unitDatum (Ada.toValue Ledger.minAdaTxOutEstimated))
     case txE of
       Left err -> do
           Hedgehog.annotateShow err

--- a/plutus-ledger/changelog.d/20221128_103738_nicolas.biri_minAdaTxOut.md
+++ b/plutus-ledger/changelog.d/20221128_103738_nicolas.biri_minAdaTxOut.md
@@ -12,7 +12,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 -->
 ### Added
 
-- `minAdaTxOut`, computes the minimum amount of Ada requires for a `TxOut` more
+- `minAdaTxOut`, computes the minimum amount of Ada required for a `TxOut` more
   precisely, by taking the params and the `TxOut`.
 
 ### Changed

--- a/plutus-ledger/changelog.d/20221128_103738_nicolas.biri_minAdaTxOut.md
+++ b/plutus-ledger/changelog.d/20221128_103738_nicolas.biri_minAdaTxOut.md
@@ -1,0 +1,39 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+### Added
+
+- `minAdaTxOut`, computes the minimum amount of Ada requires for a `TxOut` more
+  precisely, by taking the params and the `TxOut`.
+
+### Changed
+
+- `minAdaTxOut` is now renamed `minAdaTxOutEstimated`.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/plutus-ledger/src/Ledger/Generators.hs
+++ b/plutus-ledger/src/Ledger/Generators.hs
@@ -88,8 +88,8 @@ import Ledger (Ada, AssetClass, CardanoTx (EmulatorTx), CurrencySymbol, Datum, I
                TxInType (ConsumePublicKeyAddress, ConsumeSimpleScriptAddress, ScriptAddress), TxInput (TxInput),
                TxInputType (TxConsumePublicKeyAddress, TxConsumeSimpleScriptAddress, TxScriptAddress), TxOut,
                TxOutRef (TxOutRef), ValidationErrorInPhase, Validator, Value, Versioned, addCardanoTxSignature,
-               addMintingPolicy, getValidator, maxFee, minAdaTxOut, pubKeyTxOut, scriptHash, txData, txOutValue,
-               txScripts, validatorHash)
+               addMintingPolicy, getValidator, maxFee, minAdaTxOutEstimated, pubKeyTxOut, scriptHash, txData,
+               txOutValue, txScripts, validatorHash)
 import Ledger.Ada qualified as Ada
 import Ledger.CardanoWallet qualified as CW
 import Ledger.Index.Internal qualified as Index (UtxoIndex (UtxoIndex))
@@ -249,7 +249,7 @@ genValidTransactionSpending' g ins totalVal = do
                     -- If there is a minted value, we look for a value in the
                     -- splitted values which can be associated with it.
                     let outValForMint =
-                          maybe mempty id $ List.find (\v -> v >= Ledger.minAdaTxOut)
+                          maybe mempty id $ List.find (\v -> v >= Ledger.minAdaTxOutEstimated)
                                           $ List.sort splitOutVals
                     Ada.toValue outValForMint <> mv : fmap Ada.toValue (List.delete outValForMint splitOutVals)
                 txOutputs = either (error . ("Cannot create outputs: " <>) . show) id
@@ -467,7 +467,7 @@ splitVal mx init' = go 0 0 [] where
             if v + c == init'
             then pure $ v : l
             else go (succ i) (v + c) (v : l)
-    minAda = fromIntegral $ Ada.getLovelace $ Ledger.minAdaTxOut + Ledger.maxFee
+    minAda = fromIntegral $ Ada.getLovelace $ Ledger.minAdaTxOutEstimated + Ledger.maxFee
 
 knownXPrvs :: [Crypto.XPrv]
 knownXPrvs = unPaymentPrivateKey <$> CW.knownPaymentPrivateKeys

--- a/plutus-ledger/src/Ledger/Index.hs
+++ b/plutus-ledger/src/Ledger/Index.hs
@@ -99,7 +99,6 @@ the blockchain.
 -- | Exact computation of the mimimum Ada required for a given TxOut.
 -- TODO: Should be moved to cardano-api-extended once created
 minAdaTxOut :: PParams -> TxOut -> Ada
-
 minAdaTxOut params txOut = let
   toAda = lovelaceOf . C.Ledger.unCoin
   initialValue = txOutValue txOut

--- a/plutus-ledger/src/Ledger/Validation.hs
+++ b/plutus-ledger/src/Ledger/Validation.hs
@@ -303,8 +303,8 @@ makeTransactionBody
   -> P.CardanoBuildTx
   -> Either CardanoLedgerError (C.Api.TxBody C.Api.BabbageEra)
 makeTransactionBody params utxo txBodyContent = do
-  txTmp <- first Right $ makeSignedTransaction [] <$> P.makeTransactionBody (Just $ emulatorPParams params) mempty txBodyContent
-  exUnits <- first Left $ Map.map snd <$> getTxExUnitsWithLogs params utxo txTmp
+  txTmp <- bimap Right (makeSignedTransaction []) $ P.makeTransactionBody (Just $ emulatorPParams params) mempty txBodyContent
+  exUnits <- bimap Left (Map.map snd) $ getTxExUnitsWithLogs params utxo txTmp
   first Right $ P.makeTransactionBody (Just $ emulatorPParams params) exUnits txBodyContent
 
 

--- a/plutus-ledger/src/Ledger/Validation.hs
+++ b/plutus-ledger/src/Ledger/Validation.hs
@@ -16,7 +16,6 @@ module Ledger.Validation(
   EmulatorEra,
   CardanoLedgerError,
   initialState,
-  evaluateMinLovelaceOutput,
   getRequiredSigners,
   hasValidationErrors,
   makeTransactionBody,
@@ -84,7 +83,6 @@ import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import Data.Text qualified as Text
 import GHC.Records (HasField (..))
-import Ledger.Ada qualified as P
 import Ledger.Address qualified as P
 import Ledger.Crypto qualified as Crypto
 import Ledger.Index.Internal qualified as P
@@ -307,12 +305,6 @@ makeTransactionBody params utxo txBodyContent = do
   exUnits <- bimap Left (Map.map snd) $ getTxExUnitsWithLogs params utxo txTmp
   first Right $ P.makeTransactionBody (Just $ emulatorPParams params) exUnits txBodyContent
 
-
-evaluateMinLovelaceOutput :: P.Params -> TxOut EmulatorEra -> P.Ada
-evaluateMinLovelaceOutput params = toPlutusValue . C.Ledger.evaluateMinLovelaceOutput (emulatorPParams params)
-  where
-    toPlutusValue :: Coin -> P.Ada
-    toPlutusValue (Coin c) = P.lovelaceOf c
 
 fromPlutusTxSigned'
   :: P.Params

--- a/plutus-ledger/test/Spec.hs
+++ b/plutus-ledger/test/Spec.hs
@@ -119,7 +119,7 @@ splitVal = property $ do
 
 splitValMinAda :: Property
 splitValMinAda = property $ do
-    let minAda = Ada.getLovelace $ Ledger.minAdaTxOut + Ledger.maxFee
+    let minAda = Ada.getLovelace $ Ledger.minAdaTxOutEstimated + Ledger.maxFee
     i <- forAll $ Gen.integral $ Range.linear minAda (100_000_000 :: Integer)
     n <- forAll $ Gen.integral $ Range.linear 1 100
     vs <- forAll $ Gen.splitVal n i

--- a/plutus-pab-executables/test/full/Plutus/PAB/CoreSpec.hs
+++ b/plutus-pab-executables/test/full/Plutus/PAB/CoreSpec.hs
@@ -204,7 +204,7 @@ waitForTxStatusChangeTest = runScenarioWithSecondSlot $ do
 
   -- We create a new transaction to trigger a block creation in order to
   -- increment the block number.
-  void $ Simulator.payToPaymentPublicKeyHash w1 pk1 (Ada.toValue Ledger.minAdaTxOut)
+  void $ Simulator.payToPaymentPublicKeyHash w1 pk1 (Ada.toValue Ledger.minAdaTxOutEstimated)
   Simulator.waitNSlots 1
   txStatus' <- Simulator.waitForTxStatusChange (getCardanoTxId tx)
   assertEqual "tx should be tentatively confirmed of depth 2"
@@ -214,7 +214,7 @@ waitForTxStatusChangeTest = runScenarioWithSecondSlot $ do
   -- We create `n` more blocks to test whether the tx status is committed.
   let (Depth n) = chainConstant
   replicateM_ (n - 1) $ do
-    void $ Simulator.payToPaymentPublicKeyHash w1 pk1 (Ada.toValue Ledger.minAdaTxOut)
+    void $ Simulator.payToPaymentPublicKeyHash w1 pk1 (Ada.toValue Ledger.minAdaTxOutEstimated)
     Simulator.waitNSlots 1
 
   txStatus'' <- Simulator.waitForTxStatusChange (getCardanoTxId tx)
@@ -255,7 +255,7 @@ waitForTxOutStatusChangeTest = runScenarioWithSecondSlot $ do
 
   -- We create a new transaction to trigger a block creation in order to
   -- increment the block number.
-  tx2 <- Simulator.payToPaymentPublicKeyHash w1 pk1 (Ada.toValue Ledger.minAdaTxOut)
+  tx2 <- Simulator.payToPaymentPublicKeyHash w1 pk1 (Ada.toValue Ledger.minAdaTxOutEstimated)
   Simulator.waitNSlots 1
   txOutStatus1' <- Simulator.waitForTxOutStatusChange txOutRef1
   assertEqual "tx output 1 should be tentatively confirmed of depth 1"
@@ -269,7 +269,7 @@ waitForTxOutStatusChangeTest = runScenarioWithSecondSlot $ do
   -- We create `n` more blocks to test whether the tx status is committed.
   let (Depth n) = chainConstant
   replicateM_ n $ do
-    void $ Simulator.payToPaymentPublicKeyHash w1 pk1 (Ada.toValue Ledger.minAdaTxOut)
+    void $ Simulator.payToPaymentPublicKeyHash w1 pk1 (Ada.toValue Ledger.minAdaTxOutEstimated)
     Simulator.waitNSlots 1
 
   txOutStatus1'' <- Simulator.waitForTxOutStatusChange txOutRef1

--- a/plutus-pab-executables/tx-inject/Main.hs
+++ b/plutus-pab-executables/tx-inject/Main.hs
@@ -18,6 +18,7 @@ import Control.Lens hiding (ix)
 import Control.Monad (forever)
 import Control.Monad.IO.Class (liftIO)
 import Control.RateLimit (rateLimitExecution)
+import Data.Default (Default (def))
 import Data.Map qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -35,7 +36,7 @@ import Text.Pretty.Simple (pPrint)
 import Cardano.Node.Types (PABServerConfig (..))
 import Cardano.Protocol.Socket.Mock.Client (TxSendHandle (..), queueTx, runTxSender)
 import Data.Either (fromRight)
-import Ledger (testnet)
+import Ledger (Params (pNetworkId), testnet)
 import Ledger.Ada qualified as Ada
 import Ledger.Blockchain (OnChainTx (..))
 import Ledger.Index (UtxoIndex (..), insertBlock)
@@ -76,7 +77,7 @@ initialUtxoIndex config =
                    (repeat (Ada.adaValueOf 1000_000_000))
       initialTxs =
         view (chainState . txPool) $ fromRight (error "cannot initialize chain state") $
-        emulatorStateInitialDist testnet $
+        emulatorStateInitialDist (def {pNetworkId = testnet}) $
         Map.mapKeys mockWalletPaymentPubKeyHash dist
   in insertBlock (map Valid initialTxs) (UtxoIndex Map.empty)
 

--- a/plutus-pab/src/Cardano/Node/Types.hs
+++ b/plutus-pab/src/Cardano/Node/Types.hs
@@ -78,7 +78,7 @@ import Wallet.Emulator.MultiAgent qualified as MultiAgent
 
 import Cardano.Api.NetworkId.Extra (NetworkIdWrapper (unNetworkIdWrapper), testnetNetworkId)
 import Cardano.BM.Tracing (toObject)
-import Ledger.Params (testnet)
+import Ledger.Params (pNetworkId, testnet)
 import Plutus.PAB.Arbitrary ()
 
 -- Configuration ------------------------------------------------------------------------------------------------------
@@ -256,7 +256,7 @@ initialAppState wallets = do
 initialChainState :: MonadIO m => Trace.InitialDistribution -> m MockNodeServerChainState
 initialChainState =
     fromEmulatorChainState . view EM.chainState . fromRight (error "Can't initialise chain state") .
-    MultiAgent.emulatorStateInitialDist testnet . Map.mapKeys EM.mockWalletPaymentPubKeyHash
+    MultiAgent.emulatorStateInitialDist (def {pNetworkId = testnet}) . Map.mapKeys EM.mockWalletPaymentPubKeyHash
 
 -- Effects -------------------------------------------------------------------------------------------------------------
 

--- a/plutus-tx-constraints/test/Spec.hs
+++ b/plutus-tx-constraints/test/Spec.hs
@@ -85,7 +85,7 @@ mustPayToPubKeyAddressStakePubKeyNotNothingProp :: Property
 mustPayToPubKeyAddressStakePubKeyNotNothingProp = property $ do
     pkh <- forAll $ Ledger.paymentPubKeyHash <$> Gen.element Gen.knownPaymentPublicKeys
     let sc = stakePubKeyHashCredential $ StakePubKeyHash $ Ledger.pubKeyHash $ Ledger.PubKey "00000000000000000000000000000000000000000000000000000000"
-        txE = mkTx @Void def mempty (Constraints.mustPayToPubKeyAddress pkh sc (Ada.toValue Ledger.minAdaTxOut))
+        txE = mkTx @Void def mempty (Constraints.mustPayToPubKeyAddress pkh sc (Ada.toValue Ledger.minAdaTxOutEstimated))
     case txE of
         Left err -> do
             Hedgehog.annotateShow err

--- a/plutus-use-cases/test/Spec/Auction.hs
+++ b/plutus-use-cases/test/Spec/Auction.hs
@@ -275,7 +275,7 @@ instance ContractModel AuctionModel where
     shrinkAction _ (Bid w v) = [ Bid w v' | v' <- shrink v ]
 
     monitoring _ (Bid _ bid) =
-      classify (Ada.lovelaceOf bid == Ada.adaOf 100 - (Ledger.minAdaTxOut <> Ledger.maxFee))
+      classify (Ada.lovelaceOf bid == Ada.adaOf 100 - (Ledger.minAdaTxOutEstimated <> Ledger.maxFee))
         "Maximum bid reached"
     monitoring _ _ = id
 

--- a/plutus-use-cases/test/Spec/Crowdfunding.hs
+++ b/plutus-use-cases/test/Spec/Crowdfunding.hs
@@ -282,7 +282,7 @@ instance ContractModel CrowdfundingModel where
     CContribute w v -> w `notElem` Map.keys (s ^. contractState . contributions)
                     && w /= (s ^. contractState . ownerWallet)
                     && s ^. currentSlot < s ^. contractState . endSlot
-                    && Ada.fromValue v >= Ledger.minAdaTxOut
+                    && Ada.fromValue v >= Ledger.minAdaTxOutEstimated
     CStart          -> Prelude.not (s ^. contractState . ownerOnline || s ^. contractState . ownerContractDone)
 
   -- To generate a random test case we need to know how to generate a random

--- a/plutus-use-cases/test/Spec/Escrow.hs
+++ b/plutus-use-cases/test/Spec/Escrow.hs
@@ -26,7 +26,7 @@ import Data.Foldable
 import Data.Map (Map)
 import Data.Map qualified as Map
 
-import Ledger (Slot (..), minAdaTxOut)
+import Ledger (Slot (..), minAdaTxOutEstimated)
 import Ledger.Ada qualified as Ada
 import Ledger.Time (POSIXTime)
 import Ledger.TimeSlot qualified as TimeSlot
@@ -126,7 +126,7 @@ instance ContractModel EscrowModel where
     Refund w -> s ^. currentSlot >= s ^. contractState . refundSlot
              && Nothing /= (s ^. contractState . contributions . at w)
     Pay _ v -> s ^. currentSlot + 1 < s ^. contractState . refundSlot
-            && Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOut
+            && Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOutEstimated
     BadRefund w w' -> s ^. currentSlot < s ^. contractState . refundSlot - 2  -- why -2?
                    || w /= w'
 

--- a/plutus-use-cases/test/Spec/SimpleEscrow.hs
+++ b/plutus-use-cases/test/Spec/SimpleEscrow.hs
@@ -75,7 +75,7 @@ tests = testGroup "simple-escrow"
             void $ Trace.waitNSlots 100
             void $ Trace.callEndpoint @"refund" hdl2 params
     , checkPredicateOptions options "can't redeem if you can't pay"
-        ( walletFundsChange w1 (Ada.toValue (-Ledger.minAdaTxOut) <> token1 (-10))
+        ( walletFundsChange w1 (Ada.toValue (-Ledger.minAdaTxOutEstimated) <> token1 (-10))
           .&&. walletFundsChange w2 mempty
         )
         $ do

--- a/plutus-use-cases/test/Spec/Tutorial/Escrow.hs
+++ b/plutus-use-cases/test/Spec/Tutorial/Escrow.hs
@@ -23,7 +23,7 @@ import Data.List (sortBy)
 import Data.Map (Map)
 import Data.Map qualified as Map
 
-import Ledger (minAdaTxOut)
+import Ledger (minAdaTxOutEstimated)
 import Ledger.Ada qualified as Ada
 import Ledger.Value
 import Plutus.Contract hiding (currentSlot)
@@ -116,14 +116,14 @@ instance ContractModel EscrowModel where
 
   precondition s a = case a of
     Init tgts-> currentPhase == Initial
-             && and [Ada.adaValueOf (fromInteger n) `geq` Ada.toValue minAdaTxOut | (_,n) <- tgts]
+             && and [Ada.adaValueOf (fromInteger n) `geq` Ada.toValue minAdaTxOutEstimated | (_,n) <- tgts]
 --             && and [Ada.adaValueOf (fromInteger n) `gt` Ada.toValue 0 | (_,n) <- tgts]
     Redeem _ -> currentPhase == Running
              && (s ^. contractState . contributions . to fold) `geq` (s ^. contractState . targets . to fold)
 --             && (s ^. contractState . contributions . to fold) == (s ^. contractState . targets . to fold)
     Refund w -> Nothing /= (s ^. contractState . contributions . at w)
     Pay _ v  -> currentPhase == Running
-            && Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOut
+            && Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOutEstimated
             -- disallow payments that take us over the targets
             -- && ((s ^. contractState . contributions . to fold) <> Ada.adaValueOf (fromInteger v)) `leq` (s ^. contractState . targets . to fold)
     where currentPhase = s ^. contractState . phase

--- a/plutus-use-cases/test/Spec/Tutorial/Escrow1.hs
+++ b/plutus-use-cases/test/Spec/Tutorial/Escrow1.hs
@@ -22,7 +22,7 @@ import Data.Foldable
 import Data.Map (Map)
 import Data.Map qualified as Map
 
-import Ledger (minAdaTxOut)
+import Ledger (minAdaTxOutEstimated)
 import Ledger.Ada qualified as Ada
 import Ledger.Value
 import Plutus.Contract
@@ -85,7 +85,7 @@ instance ContractModel EscrowModel where
 
   precondition s a = case a of
     Redeem _ -> (s ^. contractState . contributions . to fold) `geq` (s ^. contractState . targets . to fold)
-    Pay _ v  -> Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOut
+    Pay _ v  -> Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOutEstimated
 
   perform h _ _ a = case a of
     Pay w v        -> do

--- a/plutus-use-cases/test/Spec/Tutorial/Escrow2.hs
+++ b/plutus-use-cases/test/Spec/Tutorial/Escrow2.hs
@@ -23,7 +23,7 @@ import Data.Foldable
 import Data.Map (Map)
 import Data.Map qualified as Map
 
-import Ledger (minAdaTxOut)
+import Ledger (minAdaTxOutEstimated)
 import Ledger.Ada qualified as Ada
 import Ledger.Value
 import Plutus.Contract
@@ -96,7 +96,7 @@ instance ContractModel EscrowModel where
     Redeem _ -> currentPhase == Running
              && (s ^. contractState . contributions . to fold) `geq` (s ^. contractState . targets . to fold)
     Pay _ v  -> currentPhase == Running
-             && Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOut
+             && Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOutEstimated
     where currentPhase = s ^. contractState . phase
 
 

--- a/plutus-use-cases/test/Spec/Tutorial/Escrow4.hs
+++ b/plutus-use-cases/test/Spec/Tutorial/Escrow4.hs
@@ -24,7 +24,7 @@ import Data.Foldable
 import Data.Map (Map)
 import Data.Map qualified as Map
 
-import Ledger (Slot (..), minAdaTxOut)
+import Ledger (Slot (..), minAdaTxOutEstimated)
 import Ledger.Ada qualified as Ada
 import Ledger.TimeSlot (SlotConfig (..))
 import Ledger.Value (Value, geq)
@@ -111,11 +111,11 @@ instance ContractModel EscrowModel where
   precondition s a = case a of
     Init s tgts -> currentPhase == Initial
                 && s > 1
-                && and [Ada.adaValueOf (fromInteger n) `geq` Ada.toValue minAdaTxOut | (_,n) <- tgts]
+                && and [Ada.adaValueOf (fromInteger n) `geq` Ada.toValue minAdaTxOutEstimated | (_,n) <- tgts]
     Redeem _    -> currentPhase == Running
                 && fold (s ^. contractState . contributions) `geq` fold (s ^. contractState . targets)
     Pay _ v     -> currentPhase == Running
-                && Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOut
+                && Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOutEstimated
     Refund w    -> currentPhase == Refunding
                 && w `Map.member` (s ^. contractState . contributions)
     where currentPhase = s ^. contractState . phase

--- a/plutus-use-cases/test/Spec/Tutorial/Escrow5.hs
+++ b/plutus-use-cases/test/Spec/Tutorial/Escrow5.hs
@@ -25,7 +25,7 @@ import Data.Foldable
 import Data.Map (Map)
 import Data.Map qualified as Map
 
-import Ledger (Slot (..), minAdaTxOut)
+import Ledger (Slot (..), minAdaTxOutEstimated)
 import Ledger.Ada qualified as Ada
 import Ledger.TimeSlot (SlotConfig (..))
 import Ledger.Value (Value, geq)
@@ -113,11 +113,11 @@ instance ContractModel EscrowModel where
   precondition s a = case a of
     Init s tgts -> currentPhase == Initial
                 && s > 1
-                && and [Ada.adaValueOf (fromInteger n) `geq` Ada.toValue minAdaTxOut | (_,n) <- tgts]
+                && and [Ada.adaValueOf (fromInteger n) `geq` Ada.toValue minAdaTxOutEstimated | (_,n) <- tgts]
     Redeem _    -> currentPhase == Running
                 && fold (s ^. contractState . contributions) `geq` fold (s ^. contractState . targets)
     Pay _ v     -> currentPhase == Running
-                && Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOut
+                && Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOutEstimated
     Refund w    -> currentPhase == Refunding
                 && w `Map.member` (s ^. contractState . contributions)
     where currentPhase = s ^. contractState . phase

--- a/plutus-use-cases/test/Spec/Tutorial/Escrow6.hs
+++ b/plutus-use-cases/test/Spec/Tutorial/Escrow6.hs
@@ -26,7 +26,7 @@ import Data.Foldable
 import Data.Map (Map)
 import Data.Map qualified as Map
 
-import Ledger (Slot (..), minAdaTxOut)
+import Ledger (Slot (..), minAdaTxOutEstimated)
 import Ledger.Ada qualified as Ada
 import Ledger.TimeSlot (SlotConfig (..))
 import Ledger.Value (Value, geq)
@@ -115,11 +115,11 @@ instance ContractModel EscrowModel where
   precondition s a = case a of
     Init s tgts -> currentPhase == Initial
                 && s > 1
-                && and [Ada.adaValueOf (fromInteger n) `geq` Ada.toValue minAdaTxOut | (_,n) <- tgts]
+                && and [Ada.adaValueOf (fromInteger n) `geq` Ada.toValue minAdaTxOutEstimated | (_,n) <- tgts]
     Redeem _    -> currentPhase == Running
                 && fold (s ^. contractState . contributions) `geq` fold (s ^. contractState . targets)
     Pay _ v     -> currentPhase == Running
-                && Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOut
+                && Ada.adaValueOf (fromInteger v) `geq` Ada.toValue minAdaTxOutEstimated
     Refund w    -> currentPhase == Refunding
                 && w `Map.member` (s ^. contractState . contributions)
     where currentPhase = s ^. contractState . phase

--- a/plutus-use-cases/test/Spec/Vesting.hs
+++ b/plutus-use-cases/test/Spec/Vesting.hs
@@ -120,8 +120,8 @@ instance ContractModel VestingModel where
     when ( enoughValueLeft slot s v
          && v `leq` amount
          && mockWalletPaymentPubKeyHash w == vestingOwner params
-         && Ada.fromValue v >= Ledger.minAdaTxOut
-         && (Ada.fromValue newAmount == 0 || Ada.fromValue newAmount >= Ledger.minAdaTxOut)) $ do
+         && Ada.fromValue v >= Ledger.minAdaTxOutEstimated
+         && (Ada.fromValue newAmount == 0 || Ada.fromValue newAmount >= Ledger.minAdaTxOutEstimated)) $ do
       deposit w v
       vestedAmount .= newAmount
     wait 2
@@ -135,8 +135,8 @@ instance ContractModel VestingModel where
 
   precondition s (Retrieve w v) = enoughValueLeft slot (s ^. contractState) v
                                 && mockWalletPaymentPubKeyHash w == vestingOwner params
-                                && Ada.fromValue v >= Ledger.minAdaTxOut
-                                && (Ada.fromValue newAmount == 0 || Ada.fromValue newAmount >= Ledger.minAdaTxOut)
+                                && Ada.fromValue v >= Ledger.minAdaTxOutEstimated
+                                && (Ada.fromValue newAmount == 0 || Ada.fromValue newAmount >= Ledger.minAdaTxOutEstimated)
     where
       slot   = s ^. currentSlot
       amount = s ^. contractState . vestedAmount
@@ -145,7 +145,7 @@ instance ContractModel VestingModel where
   arbitraryAction s = frequency [ (1, Vest <$> genWallet)
                                 , (1, Retrieve <$> genWallet
                                                <*> (Ada.lovelaceValueOf
-                                                   <$> choose (Ada.getLovelace Ledger.minAdaTxOut, valueOf amount Ada.adaSymbol Ada.adaToken)
+                                                   <$> choose (Ada.getLovelace Ledger.minAdaTxOutEstimated, valueOf amount Ada.adaSymbol Ada.adaToken)
                                                    )
                                   )
                                 ]
@@ -183,7 +183,7 @@ genWallet :: Gen Wallet
 genWallet = elements wallets
 
 shrinkValue :: Value -> [Value]
-shrinkValue v = Ada.lovelaceValueOf <$> filter (\val -> val >= Ada.getLovelace Ledger.minAdaTxOut) (shrink (valueOf v Ada.adaSymbol Ada.adaToken))
+shrinkValue v = Ada.lovelaceValueOf <$> filter (\val -> val >= Ada.getLovelace Ledger.minAdaTxOutEstimated) (shrink (valueOf v Ada.adaSymbol Ada.adaToken))
 
 prop_Vesting :: Actions VestingModel -> Property
 prop_Vesting = propRunActions_


### PR DESCRIPTION
Done:

- rename `minAdaTxOut` into `minAdaTxOutEstimated`
- add a function `minAdaTxOut`, which provides a more precise computation, taking `PParams` and a `TxOut`.
- add a comment to explain why we can't always compute `minAdaTxOut` precisely and thus why we keep `minAdaTxOutEstimated`
- use `minAdaTxOut` in `adjustTx` and `emulatorStateInitialDist`.

We can't remove much `minAdaTxOutEstimated` as most of the time we don't have access to the `TxOut` for which we want to compute the minimum Ada.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [x] Important changes are reflected in changelog.d of the affected packages
- PR
    - [x] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
