### PR TITLE
mkUntyped* functions work with PlutusV1 and PlutusV2

### DIFF
--- a/doc/plutus/tutorials/BasicApps.hs
+++ b/doc/plutus/tutorials/BasicApps.hs
@@ -66,7 +66,7 @@ splitValidator :: Scripts.TypedValidator Split
 splitValidator = Scripts.mkTypedValidator @Split
     $$(PlutusTx.compile [|| validateSplit ||])
     $$(PlutusTx.compile [|| wrap ||]) where
-        wrap = Scripts.mkUntypedValidator @SplitData @()
+        wrap = Scripts.mkUntypedValidator @ScriptContext @SplitData @()
 
 -- BLOCK4
 

--- a/plutus-contract/src/Plutus/Contract/StateMachine/ThreadToken.hs
+++ b/plutus-contract/src/Plutus/Contract/StateMachine/ThreadToken.hs
@@ -28,7 +28,6 @@ import Ledger.Value (TokenName (..), Value (..))
 import Ledger.Value qualified as Value
 import Plutus.Contract.StateMachine.MintingPolarity (MintingPolarity (..))
 import Plutus.Script.Utils.Typed (ScriptContextV1, mkUntypedMintingPolicy)
-import Plutus.Script.Utils.V1.Typed.Scripts qualified as Scripts
 import Plutus.V1.Ledger.Contexts qualified as V
 import PlutusTx qualified
 import Prelude qualified as Haskell

--- a/plutus-contract/src/Plutus/Contract/StateMachine/ThreadToken.hs
+++ b/plutus-contract/src/Plutus/Contract/StateMachine/ThreadToken.hs
@@ -27,6 +27,7 @@ import Ledger.Scripts
 import Ledger.Value (TokenName (..), Value (..))
 import Ledger.Value qualified as Value
 import Plutus.Contract.StateMachine.MintingPolarity (MintingPolarity (..))
+import Plutus.Script.Utils.Typed (ScriptContextV1, mkUntypedMintingPolicy)
 import Plutus.Script.Utils.V1.Typed.Scripts qualified as Scripts
 import Plutus.V1.Ledger.Contexts qualified as V
 import PlutusTx qualified
@@ -67,7 +68,7 @@ checkPolicy (TxOutRef refHash refIdx) (vHash, mintingPolarity) ctx@V.ScriptConte
 
 curPolicy :: TxOutRef -> MintingPolicy
 curPolicy outRef = mkMintingPolicyScript $
-    $$(PlutusTx.compile [|| \r -> Scripts.mkUntypedMintingPolicy (checkPolicy r) ||])
+    $$(PlutusTx.compile [|| \r -> mkUntypedMintingPolicy @ScriptContextV1 (checkPolicy r) ||])
         `PlutusTx.applyCode`
             PlutusTx.liftCode outRef
 

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustMint.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustMint.hs
@@ -132,7 +132,7 @@ mustReferenceOutputV2Validator :: PV2.Validator
 mustReferenceOutputV2Validator = PV2.mkValidatorScript
     $$(PlutusTx.compile [|| wrap ||])
  where
-     wrap = PV2.mkUntypedValidator mkMustReferenceOutputV2Validator
+     wrap = Scripts.mkUntypedValidator mkMustReferenceOutputV2Validator
 
 mustReferenceOutputV2ValidatorAddress :: Address
 mustReferenceOutputV2ValidatorAddress =

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustMint.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustMint.hs
@@ -39,7 +39,6 @@ import Plutus.Script.Utils.V1.Scripts qualified as PSU.V1
 import Plutus.Script.Utils.V2.Address qualified as PV2
 import Plutus.Script.Utils.V2.Scripts qualified as PSU.V2
 import Plutus.Script.Utils.V2.Typed.Scripts qualified as PV2
-import Plutus.Script.Utils.V2.Typed.Scripts.MonetaryPolicies qualified as MPS2
 import Plutus.Trace qualified as Trace
 import Plutus.V1.Ledger.Api (Address, MintingPolicyHash (MintingPolicyHash), Redeemer, TxOutRef)
 import Plutus.V1.Ledger.Scripts (ScriptError (EvaluationError))
@@ -403,7 +402,7 @@ mustMintPolicy = Ledger.mkMintingPolicyScript $$(PlutusTx.compile [||wrap||])
 mustMintPolicyV2 :: Scripts.MintingPolicy
 mustMintPolicyV2 = PV2.mkMintingPolicyScript $$(PlutusTx.compile [||wrap||])
     where
-        wrap = MPS2.mkUntypedMintingPolicy mkMustMintPolicyV2
+        wrap = Scripts.mkUntypedMintingPolicy mkMustMintPolicyV2
 
 mustMintPolicyHash :: Ledger.MintingPolicyHash
 mustMintPolicyHash = PSU.V1.mintingPolicyHash mustMintPolicy

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToOtherScript.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToOtherScript.hs
@@ -28,7 +28,6 @@ import Ledger.Typed.Scripts qualified as Scripts
 import Plutus.Contract as Con
 import Plutus.Contract.Test (assertContractError, assertFailedTransaction, assertValidatedTransactionCount,
                              changeInitialWalletValue, checkPredicateOptions, defaultCheckOptions, emulatorConfig, w1)
-import Plutus.Script.Utils.Typed qualified as Typed
 import Plutus.Script.Utils.V1.Generators (alwaysSucceedValidatorHash)
 import Plutus.Script.Utils.V1.Scripts qualified as PSU.V1
 import Plutus.Script.Utils.V2.Scripts qualified as PSU.V2

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToOtherScript.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToOtherScript.hs
@@ -28,10 +28,10 @@ import Ledger.Typed.Scripts qualified as Scripts
 import Plutus.Contract as Con
 import Plutus.Contract.Test (assertContractError, assertFailedTransaction, assertValidatedTransactionCount,
                              changeInitialWalletValue, checkPredicateOptions, defaultCheckOptions, emulatorConfig, w1)
+import Plutus.Script.Utils.Typed qualified as Typed
 import Plutus.Script.Utils.V1.Generators (alwaysSucceedValidatorHash)
 import Plutus.Script.Utils.V1.Scripts qualified as PSU.V1
 import Plutus.Script.Utils.V2.Scripts qualified as PSU.V2
-import Plutus.Script.Utils.V2.Typed.Scripts qualified as V2.Scripts
 import Plutus.Trace qualified as Trace
 import Plutus.V1.Ledger.Value qualified as Value
 import PlutusTx qualified
@@ -445,7 +445,7 @@ mustPayToOtherScriptPolicyV2 :: Ledger.MintingPolicy
 mustPayToOtherScriptPolicyV2 = Ledger.mkMintingPolicyScript $$(PlutusTx.compile [||wrap||])
     where
         checkedMkMustPayToOtherScriptPolicy = mkMustPayToOtherScriptPolicy V2.Constraints.checkScriptContext
-        wrap = V2.Scripts.mkUntypedMintingPolicy checkedMkMustPayToOtherScriptPolicy
+        wrap = Scripts.mkUntypedMintingPolicy checkedMkMustPayToOtherScriptPolicy
 
 mustPayToOtherScriptPolicy :: PSU.Language -> Ledger.MintingPolicy
 mustPayToOtherScriptPolicy = \case

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToPubKeyAddress.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToPubKeyAddress.hs
@@ -28,7 +28,6 @@ import Plutus.Contract.Test (assertFailedTransaction, assertValidatedTransaction
                              defaultCheckOptions, emulatorConfig, mockWalletPaymentPubKeyHash, w1, w2)
 import Plutus.Script.Utils.V1.Scripts qualified as PSU.V1
 import Plutus.Script.Utils.V2.Scripts qualified as PSU.V2
-import Plutus.Script.Utils.V2.Typed.Scripts qualified as V2.Scripts
 import Plutus.Trace qualified as Trace
 import Plutus.V1.Ledger.Value qualified as Value
 import PlutusTx qualified

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToPubKeyAddress.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustPayToPubKeyAddress.hs
@@ -341,7 +341,7 @@ mustPayToPubKeyAddressPolicyV2 :: Ledger.MintingPolicy
 mustPayToPubKeyAddressPolicyV2 = Ledger.mkMintingPolicyScript $$(PlutusTx.compile [||wrap||])
     where
         checkedMkMustPayToPubKeyAddressPolicy = mkMustPayToPubKeyAddressPolicy V2.Constraints.checkScriptContext
-        wrap = V2.Scripts.mkUntypedMintingPolicy checkedMkMustPayToPubKeyAddressPolicy
+        wrap = Scripts.mkUntypedMintingPolicy checkedMkMustPayToPubKeyAddressPolicy
 
 languageContextV1 :: LanguageContext
 languageContextV1 = LanguageContext

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustReferenceOutput.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustReferenceOutput.hs
@@ -271,7 +271,7 @@ mustReferenceOutputPolicyV2 :: L.MintingPolicy
 mustReferenceOutputPolicyV2 = L.mkMintingPolicyScript $$(PlutusTx.compile [||wrap||])
     where
         checkedMkMustPayToOtherScriptPolicy = mkMustReferenceOutputPolicy Cons.V2.checkScriptContext
-        wrap = V2.Scripts.mkUntypedMintingPolicy checkedMkMustPayToOtherScriptPolicy
+        wrap = Scripts.mkUntypedMintingPolicy checkedMkMustPayToOtherScriptPolicy
 data Script a where
    MustReferenceOutputPolicy :: Script L.MintingPolicy
 

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustReferenceOutput.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustReferenceOutput.hs
@@ -42,8 +42,6 @@ import Plutus.Script.Utils.Typed (Any)
 import Plutus.Script.Utils.V1.Address qualified as PSU.V1
 import Plutus.Script.Utils.V1.Typed.Scripts qualified as PSU.V1
 import Plutus.Script.Utils.V2.Address qualified as PSU.V2
-import Plutus.Script.Utils.V2.Typed.Scripts qualified as PSU.V2
-import Plutus.Script.Utils.V2.Typed.Scripts qualified as V2.Scripts
 import Plutus.Trace qualified as Trace
 import Plutus.V1.Ledger.Api qualified as PV1
 import Plutus.V1.Ledger.Value qualified as Value

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustReferenceOutput.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustReferenceOutput.hs
@@ -366,7 +366,7 @@ mustReferenceOutputV2Validator :: PV2.Validator
 mustReferenceOutputV2Validator = PV2.mkValidatorScript
     $$(PlutusTx.compile [|| wrap ||])
  where
-     wrap = PSU.V2.mkUntypedValidator mkMustReferenceOutputV2Validator
+     wrap = Scripts.mkUntypedValidator mkMustReferenceOutputV2Validator
 
 mustReferenceOutputV2ValidatorAddress :: L.Address
 mustReferenceOutputV2ValidatorAddress =

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustSatisfyAnyOf.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustSatisfyAnyOf.hs
@@ -45,7 +45,6 @@ import Plutus.Contract.Test (assertFailedTransaction, assertValidatedTransaction
 import Plutus.Script.Utils.V1.Generators (alwaysSucceedPolicyVersioned, someTokenValue)
 import Plutus.Script.Utils.V1.Scripts qualified as PSU.V1
 import Plutus.Script.Utils.V2.Scripts qualified as PSU.V2
-import Plutus.Script.Utils.V2.Typed.Scripts qualified as V2.Scripts
 import Plutus.Trace.Emulator qualified as Trace (EmulatorTrace, activateContractWallet, params, waitNSlots)
 import Plutus.V1.Ledger.Api (to)
 import Plutus.V1.Ledger.Value

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustSatisfyAnyOf.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustSatisfyAnyOf.hs
@@ -296,7 +296,7 @@ mustSatisfyAnyOfPolicyV2 :: L.MintingPolicy
 mustSatisfyAnyOfPolicyV2 = L.mkMintingPolicyScript $$(PlutusTx.compile [||wrap||])
     where
         checkedMkMustPayToOtherScriptPolicy = mkMustSatisfyAnyOfPolicy Cons.V2.checkScriptContext
-        wrap = V2.Scripts.mkUntypedMintingPolicy checkedMkMustPayToOtherScriptPolicy
+        wrap = Scripts.mkUntypedMintingPolicy checkedMkMustPayToOtherScriptPolicy
 
 data LanguageContext
    = LanguageContext

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustSpendScriptOutput.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustSpendScriptOutput.hs
@@ -54,12 +54,12 @@ import Plutus.Contract.Test (assertContractError, assertFailedTransaction, asser
 import Plutus.Script.Utils.Scripts (Language (..))
 import Plutus.Script.Utils.Scripts qualified as PSU
 import Plutus.Script.Utils.Typed (Any)
+import Plutus.Script.Utils.Typed qualified as Typed
 import Plutus.Script.Utils.V1.Address qualified as PSU.V1
 import Plutus.Script.Utils.V1.Scripts qualified as PSU.V1
 import Plutus.Script.Utils.V1.Typed.Scripts as PSU.V1
 import Plutus.Script.Utils.V2.Address qualified as PSU.V2
 import Plutus.Script.Utils.V2.Scripts qualified as PSU.V2
-import Plutus.Script.Utils.V2.Typed.Scripts as PSU.V2
 import Plutus.Trace qualified as Trace
 import Plutus.V1.Ledger.Api qualified as PV1
 import Plutus.V1.Ledger.Scripts (ScriptError, unitRedeemer)
@@ -703,7 +703,7 @@ mustSpendScriptOutputPolicyV1 :: PV1.MintingPolicy
 mustSpendScriptOutputPolicyV1 = PV1.mkMintingPolicyScript $$(PlutusTx.compile [||wrap||])
     where
         mkMustSpendScriptOutputPolicyV1 = mkMustSpendScriptOutputPolicy Cons.V1.checkScriptContext
-        wrap = PSU.V1.mkUntypedMintingPolicy mkMustSpendScriptOutputPolicyV1
+        wrap = Typed.mkUntypedMintingPolicy mkMustSpendScriptOutputPolicyV1
 
 {-# INLINEABLE mustSpendScriptOutputWithMatchingDatumAndValuePolicyV1 #-}
 mustSpendScriptOutputWithMatchingDatumAndValuePolicyV1 :: PV1.MintingPolicy
@@ -711,14 +711,14 @@ mustSpendScriptOutputWithMatchingDatumAndValuePolicyV1 = PV1.mkMintingPolicyScri
     where
         mkMustSpendScriptOutputWithMatchingDatumAndValuePolicyV1
             = mkMustSpendScriptOutputWithMatchingDatumAndValuePolicy Cons.V1.checkScriptContext
-        wrap = PSU.V1.mkUntypedMintingPolicy mkMustSpendScriptOutputWithMatchingDatumAndValuePolicyV1
+        wrap = Typed.mkUntypedMintingPolicy mkMustSpendScriptOutputWithMatchingDatumAndValuePolicyV1
 
 {-# INLINEABLE mustSpendScriptOutputWithReferencePolicyV1 #-}
 mustSpendScriptOutputWithReferencePolicyV1 :: PV1.MintingPolicy
 mustSpendScriptOutputWithReferencePolicyV1 = PV1.mkMintingPolicyScript $$(PlutusTx.compile [||wrap||])
     where
         mkMustSpendScriptOutputPolicyV1 = mkMustSpendScriptOutputWithReferencePolicy Cons.V1.checkScriptContext
-        wrap = PSU.V1.mkUntypedMintingPolicy mkMustSpendScriptOutputPolicyV1
+        wrap = Typed.mkUntypedMintingPolicy mkMustSpendScriptOutputPolicyV1
 
 {-# INLINABLE mustReferenceOutputValidatorV1 #-}
 mustReferenceOutputValidatorV1 :: PV1.Validator
@@ -726,7 +726,7 @@ mustReferenceOutputValidatorV1 = PV2.mkValidatorScript
     $$(PlutusTx.compile [|| wrap ||])
  where
      mkMustReferenceOutputV1Validator = mkMustReferenceOutputValidator Cons.V1.checkScriptContext
-     wrap = PSU.V1.mkUntypedValidator mkMustReferenceOutputV1Validator
+     wrap = Typed.mkUntypedValidator mkMustReferenceOutputV1Validator
 
 
 {-
@@ -738,7 +738,7 @@ mustSpendScriptOutputPolicyV2 :: PV2.MintingPolicy
 mustSpendScriptOutputPolicyV2 = PV2.mkMintingPolicyScript $$(PlutusTx.compile [||wrap||])
     where
         mkMustSpendScriptOutputPolicyV2 = mkMustSpendScriptOutputPolicy Cons.V2.checkScriptContext
-        wrap = PSU.V2.mkUntypedMintingPolicy mkMustSpendScriptOutputPolicyV2
+        wrap = Typed.mkUntypedMintingPolicy mkMustSpendScriptOutputPolicyV2
 
 {-# INLINEABLE mustSpendScriptOutputWithDataLengthPolicyV2 #-}
 mustSpendScriptOutputWithDataLengthPolicyV2 :: PV2.MintingPolicy
@@ -747,7 +747,7 @@ mustSpendScriptOutputWithDataLengthPolicyV2 = PV2.mkMintingPolicyScript $$(Plutu
         mkMustSpendScriptOutputWithDataLengthPolicyV2 (constraintParams, len) ctx =
             mkMustSpendScriptOutputPolicy Cons.V2.checkScriptContext constraintParams ctx
             P.&& P.length (PV2.txInfoData (PV2.scriptContextTxInfo ctx)) P.== len
-        wrap = PSU.V2.mkUntypedMintingPolicy mkMustSpendScriptOutputWithDataLengthPolicyV2
+        wrap = Typed.mkUntypedMintingPolicy mkMustSpendScriptOutputWithDataLengthPolicyV2
 
 {-# INLINEABLE mustSpendScriptOutputWithMatchingDatumAndValuePolicyV2 #-}
 mustSpendScriptOutputWithMatchingDatumAndValuePolicyV2 :: PV2.MintingPolicy
@@ -755,14 +755,14 @@ mustSpendScriptOutputWithMatchingDatumAndValuePolicyV2 = PV2.mkMintingPolicyScri
     where
         mkMustSpendScriptOutputWithMatchingDatumAndValuePolicyV2 =
             mkMustSpendScriptOutputWithMatchingDatumAndValuePolicy Cons.V2.checkScriptContext
-        wrap = PSU.V2.mkUntypedMintingPolicy mkMustSpendScriptOutputWithMatchingDatumAndValuePolicyV2
+        wrap = Typed.mkUntypedMintingPolicy mkMustSpendScriptOutputWithMatchingDatumAndValuePolicyV2
 
 {-# INLINEABLE mustSpendScriptOutputWithReferencePolicyV2 #-}
 mustSpendScriptOutputWithReferencePolicyV2 :: PV2.MintingPolicy
 mustSpendScriptOutputWithReferencePolicyV2 = PV2.mkMintingPolicyScript $$(PlutusTx.compile [||wrap||])
     where
         mkMustSpendScriptOutputPolicyV2 = mkMustSpendScriptOutputWithReferencePolicy Cons.V2.checkScriptContext
-        wrap = PSU.V2.mkUntypedMintingPolicy mkMustSpendScriptOutputPolicyV2
+        wrap = Typed.mkUntypedMintingPolicy mkMustSpendScriptOutputPolicyV2
 
 {-# INLINABLE mustReferenceOutputValidatorV2 #-}
 mustReferenceOutputValidatorV2 :: PV2.Validator
@@ -770,7 +770,7 @@ mustReferenceOutputValidatorV2 = PV2.mkValidatorScript
     $$(PlutusTx.compile [|| wrap ||])
  where
      mkMustReferenceOutputV2Validator = mkMustReferenceOutputValidator Cons.V2.checkScriptContext
-     wrap = PSU.V2.mkUntypedValidator mkMustReferenceOutputV2Validator
+     wrap = Typed.mkUntypedValidator mkMustReferenceOutputV2Validator
 
 
 -- plutus-tx-constraints tests

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustUseOutputAsCollateral.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustUseOutputAsCollateral.hs
@@ -281,7 +281,7 @@ mustUseOutputAsCollateralPolicyV2 :: L.MintingPolicy
 mustUseOutputAsCollateralPolicyV2 = L.mkMintingPolicyScript $$(PlutusTx.compile [||wrap||])
     where
         checkedMkMustUseOutputAsCollateralPolicy = mkMustUseOutputAsCollateralPolicy V2.Cons.checkScriptContext
-        wrap = V2.Scripts.mkUntypedMintingPolicy checkedMkMustUseOutputAsCollateralPolicy
+        wrap = Scripts.mkUntypedMintingPolicy checkedMkMustUseOutputAsCollateralPolicy
 
 mustUseOutputAsCollateralPolicy :: PSU.Language -> L.MintingPolicy
 mustUseOutputAsCollateralPolicy = \case

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/MustUseOutputAsCollateral.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/MustUseOutputAsCollateral.hs
@@ -39,7 +39,6 @@ import Plutus.Contract.Test (assertUnbalancedTx, assertValidatedTransactionCount
 import Plutus.Script.Utils.Typed (Any)
 import Plutus.Script.Utils.V1.Scripts qualified as PSU.V1
 import Plutus.Script.Utils.V2.Scripts qualified as PSU.V2
-import Plutus.Script.Utils.V2.Typed.Scripts qualified as V2.Scripts
 import Plutus.Trace.Emulator qualified as Trace (EmulatorTrace, activateContractWallet, nextSlot, params,
                                                  setSigningProcess, walletInstanceTag)
 import Plutus.V1.Ledger.Value qualified as Value

--- a/plutus-contract/test/Spec/Contract/Tx/Constraints/RequiredSigner.hs
+++ b/plutus-contract/test/Spec/Contract/Tx/Constraints/RequiredSigner.hs
@@ -26,7 +26,7 @@ import Ledger.Tx.Constraints qualified as TxCons
 import Plutus.Contract as Con
 import Plutus.Contract.Test (assertFailedTransaction, assertValidatedTransactionCount, changeInitialWalletValue,
                              checkPredicateOptions, defaultCheckOptions, mockWalletPaymentPubKeyHash, w1, w2)
-import Plutus.Script.Utils.V2.Typed.Scripts as PSU.V2
+import Plutus.Script.Utils.Typed qualified as Scripts
 import Plutus.Script.Utils.V2.Typed.Scripts qualified as Scripts
 import Plutus.Trace qualified as Trace
 import Plutus.V1.Ledger.Scripts (ScriptError (EvaluationError), unitDatum)

--- a/plutus-contract/test/Spec/ThreadToken.hs
+++ b/plutus-contract/test/Spec/ThreadToken.hs
@@ -18,6 +18,7 @@ import Plutus.Contract (Contract, EmptySchema, logError, mapError)
 import Plutus.Contract.StateMachine (StateMachine, StateMachineClient, ThreadToken, mkStateMachine, stateData)
 import Plutus.Contract.StateMachine qualified as SM
 import Plutus.Contract.Test
+import Plutus.Script.Utils.Typed (ScriptContextV1)
 import Plutus.Script.Utils.V1.Typed.Scripts qualified as Scripts
 import Plutus.Trace (EmulatorTrace, activateContractWallet)
 import Plutus.Trace qualified as Trace
@@ -59,7 +60,7 @@ typedValidator threadToken =
     $$(PlutusTx.compile [||wrap||])
  where
   validator c = SM.mkValidator (stateMachine c)
-  wrap = Scripts.mkUntypedValidator @State @Input
+  wrap = Scripts.mkUntypedValidator @ScriptContextV1 @State @Input
 
 stateMachineClient :: ThreadToken -> StateMachineClient State Input
 stateMachineClient threadToken =

--- a/plutus-example/src/PlutusExample/PlutusVersion1/AlwaysSucceeds.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion1/AlwaysSucceeds.hs
@@ -15,7 +15,7 @@ import Codec.Serialise
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Short qualified as SBS
 
-import Plutus.V1.Ledger.Scripts qualified as Plutus
+import Plutus.V1.Ledger.Api qualified as Plutus
 import PlutusTx qualified
 import PlutusTx.Prelude hiding (Semigroup (..), unless, (.))
 

--- a/plutus-example/src/PlutusExample/PlutusVersion1/CustomDatumRedeemerGuess.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion1/CustomDatumRedeemerGuess.hs
@@ -19,7 +19,7 @@ import Codec.Serialise
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Short qualified as SBS
 
-import Plutus.Script.Utils.V1.Typed.Scripts qualified as Scripts
+import Plutus.Script.Utils.Typed qualified as Scripts
 import Plutus.V1.Ledger.Contexts (ScriptContext)
 import Plutus.V1.Ledger.Scripts qualified as Plutus
 import PlutusTx qualified

--- a/plutus-example/src/PlutusExample/PlutusVersion1/CustomDatumRedeemerGuess.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion1/CustomDatumRedeemerGuess.hs
@@ -20,8 +20,8 @@ import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Short qualified as SBS
 
 import Plutus.Script.Utils.Typed qualified as Scripts
+import Plutus.V1.Ledger.Api qualified as Plutus
 import Plutus.V1.Ledger.Contexts (ScriptContext)
-import Plutus.V1.Ledger.Scripts qualified as Plutus
 import PlutusTx qualified
 import PlutusTx.Prelude hiding (Semigroup ((<>)), unless, (.))
 

--- a/plutus-example/src/PlutusExample/PlutusVersion1/DatumRedeemerGuess.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion1/DatumRedeemerGuess.hs
@@ -18,7 +18,7 @@ import Codec.Serialise
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Short qualified as SBS
 
-import Plutus.V1.Ledger.Scripts qualified as Plutus
+import Plutus.V1.Ledger.Api qualified as Plutus
 import PlutusTx (toBuiltinData)
 import PlutusTx qualified
 import PlutusTx.Prelude hiding (Semigroup (..), unless, (.))

--- a/plutus-example/src/PlutusExample/PlutusVersion1/MintingScript.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion1/MintingScript.hs
@@ -19,9 +19,8 @@ import Data.ByteString.Lazy qualified as LB
 import Data.ByteString.Short qualified as SBS
 
 import Plutus.Script.Utils.Typed qualified as Scripts
-import Plutus.Script.Utils.V1.Typed.Scripts qualified as Scripts
-import Plutus.V1.Ledger.Contexts (ScriptContext)
-import Plutus.V1.Ledger.Scripts (Script, Validator (Validator), mkMintingPolicyScript, unMintingPolicyScript)
+import Plutus.V1.Ledger.Api (MintingPolicy, Script, ScriptContext, Validator (Validator), mkMintingPolicyScript,
+                             unMintingPolicyScript)
 import PlutusTx qualified
 import PlutusTx.Prelude hiding (Semigroup (..), unless, (.))
 
@@ -31,7 +30,7 @@ import PlutusTx.Prelude hiding (Semigroup (..), unless, (.))
 mkPolicy :: BuiltinData -> ScriptContext -> Bool
 mkPolicy _redeemer _ctx = True
 
-policy :: Scripts.MintingPolicy
+policy :: MintingPolicy
 policy = mkMintingPolicyScript $$(PlutusTx.compile [|| wrap ||])
  where
      wrap = Scripts.mkUntypedMintingPolicy mkPolicy

--- a/plutus-example/src/PlutusExample/PlutusVersion1/MintingScript.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion1/MintingScript.hs
@@ -18,6 +18,7 @@ import Codec.Serialise
 import Data.ByteString.Lazy qualified as LB
 import Data.ByteString.Short qualified as SBS
 
+import Plutus.Script.Utils.Typed qualified as Scripts
 import Plutus.Script.Utils.V1.Typed.Scripts qualified as Scripts
 import Plutus.V1.Ledger.Contexts (ScriptContext)
 import Plutus.V1.Ledger.Scripts (Script, Validator (Validator), mkMintingPolicyScript, unMintingPolicyScript)

--- a/plutus-example/src/PlutusExample/PlutusVersion1/RedeemerContextScripts.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion1/RedeemerContextScripts.hs
@@ -29,7 +29,6 @@ import Data.ByteString.Short qualified as SBS
 
 import Plutus.Script.Utils.Typed as Scripts
 import Plutus.V1.Ledger.Api qualified as Plutus
-import Plutus.V1.Ledger.Scripts as Scripts
 import PlutusTx qualified
 import PlutusTx.AssocMap qualified as AMap
 import PlutusTx.Prelude hiding (Semigroup (..), unless, (.))
@@ -172,7 +171,7 @@ mkPolicy (PV1CustomRedeemer _ _ minted txValidRange _fee _ _ signatories mPurpos
    txInfo :: Plutus.TxInfo
    txInfo = Plutus.scriptContextTxInfo scriptContext
 
-mintingScriptContextTextPolicy :: Scripts.MintingPolicy
+mintingScriptContextTextPolicy :: Plutus.MintingPolicy
 mintingScriptContextTextPolicy = Plutus.mkMintingPolicyScript
            $$(PlutusTx.compile [|| wrap ||])
  where

--- a/plutus-example/src/PlutusExample/PlutusVersion1/RedeemerContextScripts.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion1/RedeemerContextScripts.hs
@@ -27,8 +27,7 @@ import Codec.Serialise
 import Data.ByteString.Lazy qualified as LB
 import Data.ByteString.Short qualified as SBS
 
-import Plutus.Script.Utils.V1.Typed.Scripts.MonetaryPolicies as Scripts
-import Plutus.Script.Utils.V1.Typed.Scripts.Validators as Scripts
+import Plutus.Script.Utils.Typed as Scripts
 import Plutus.V1.Ledger.Api qualified as Plutus
 import Plutus.V1.Ledger.Scripts as Scripts
 import PlutusTx qualified

--- a/plutus-example/src/PlutusExample/PlutusVersion1/Sum.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion1/Sum.hs
@@ -19,7 +19,8 @@ import Codec.Serialise
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Short qualified as SBS
 
-import Plutus.Script.Utils.V1.Typed.Scripts qualified as Scripts
+import Plutus.Script.Utils.Typed qualified as Scripts
+import Plutus.V1.Ledger.Api (ScriptContext)
 import Plutus.V1.Ledger.Scripts qualified as Plutus
 import PlutusTx qualified
 import PlutusTx.Prelude hiding (Semigroup (..), unless, (.))
@@ -32,9 +33,9 @@ smartSum a = loop a 0
     then acc
     else loop (n - 1) (n + acc)
 
--- | The validation function (DataValue -> RedeemerValue -> ScriptContext -> Bool)
+-- | The validation function
 {-# INLINABLE validateSum #-}
-validateSum :: Integer -> Integer -> x -> Bool
+validateSum :: Integer -> Integer -> ScriptContext -> Bool
 validateSum n s _ = isGoodSum n s
 
 {-# INLINABLE isGoodSum #-}

--- a/plutus-example/src/PlutusExample/PlutusVersion2/MintingScript.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion2/MintingScript.hs
@@ -19,7 +19,7 @@ import Codec.Serialise
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Short qualified as SBS
 
-import Plutus.Script.Utils.V2.Typed.Scripts.MonetaryPolicies as V2
+import Plutus.Script.Utils.Typed as Scripts
 import Plutus.V2.Ledger.Api qualified as V2
 import Plutus.V2.Ledger.Contexts as V2
 import PlutusTx qualified
@@ -35,7 +35,7 @@ mkPolicy _redeemer _ctx = True
 policy :: V2.MintingPolicy
 policy = V2.mkMintingPolicyScript $$(PlutusTx.compile [|| wrap ||])
  where
-  wrap = V2.mkUntypedMintingPolicy mkPolicy
+  wrap = Scripts.mkUntypedMintingPolicy mkPolicy
 
 plutusScript :: V2.Script
 plutusScript =

--- a/plutus-example/src/PlutusExample/PlutusVersion2/RedeemerContextEquivalence.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion2/RedeemerContextEquivalence.hs
@@ -23,8 +23,7 @@ import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Short qualified as SBS
 
 
-import Plutus.Script.Utils.V2.Typed.Scripts.MonetaryPolicies as V2
-import Plutus.Script.Utils.V2.Typed.Scripts.Validators as V2
+import Plutus.Script.Utils.Typed as Scripts
 import Plutus.V2.Ledger.Api qualified as V2
 import Plutus.V2.Ledger.Contexts as V2
 import PlutusTx qualified
@@ -144,7 +143,7 @@ validator :: V2.Validator
 validator = V2.mkValidatorScript
     $$(PlutusTx.compile [|| wrap ||])
   where
-    wrap = V2.mkUntypedValidator mkValidator
+    wrap = Scripts.mkUntypedValidator mkValidator
 
 v2ScriptContextEquivalencePlutusScript :: V2.Script
 v2ScriptContextEquivalencePlutusScript = V2.unValidatorScript validator
@@ -182,7 +181,7 @@ mkMintEquivalenceValidator redeemer scriptContext =
 policy :: V2.MintingPolicy
 policy = V2.mkMintingPolicyScript $$(PlutusTx.compile [|| wrap ||])
  where
-  wrap = V2.mkUntypedMintingPolicy mkMintEquivalenceValidator
+  wrap = Scripts.mkUntypedMintingPolicy mkMintEquivalenceValidator
 
 plutusMintEquivScript :: V2.Script
 plutusMintEquivScript =

--- a/plutus-example/src/PlutusExample/PlutusVersion2/RequireRedeemer.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion2/RequireRedeemer.hs
@@ -14,7 +14,7 @@ import Codec.Serialise
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Short qualified as SBS
 
-import Plutus.Script.Utils.V2.Typed.Scripts.Validators as Scripts
+import Plutus.Script.Utils.Typed as Scripts
 import Plutus.V2.Ledger.Api qualified as Plutus
 import Plutus.V2.Ledger.Contexts as V2
 import PlutusTx qualified

--- a/plutus-example/src/PlutusExample/PlutusVersion2/StakeScript.hs
+++ b/plutus-example/src/PlutusExample/PlutusVersion2/StakeScript.hs
@@ -19,7 +19,7 @@ import Codec.Serialise
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Short qualified as SBS
 
-import Plutus.Script.Utils.V2.Typed.Scripts.StakeValidators as V2
+import Plutus.Script.Utils.Typed as Scripts
 import Plutus.V2.Ledger.Api qualified as V2
 import Plutus.V2.Ledger.Contexts as V2
 import PlutusTx qualified
@@ -35,7 +35,7 @@ mkPolicy _redeemer _ctx = True
 policy :: V2.StakeValidator
 policy = V2.mkStakeValidatorScript $$(PlutusTx.compile [|| wrap ||])
  where
-  wrap = V2.mkUntypedStakeValidator mkPolicy
+  wrap = Scripts.mkUntypedStakeValidator mkPolicy
 
 plutusScript :: V2.Script
 plutusScript =

--- a/plutus-ledger-constraints/test/Spec.hs
+++ b/plutus-ledger-constraints/test/Spec.hs
@@ -42,6 +42,7 @@ import Ledger.Test (asRedeemer)
 import Ledger.Tx (Tx (txCollateralInputs, txOutputs), TxOut (TxOut), txOutAddress)
 import Ledger.Value (CurrencySymbol, Value (Value))
 import Ledger.Value qualified as Value
+import Plutus.Script.Utils.Typed qualified as Scripts
 import Plutus.Script.Utils.V2.Generators qualified as Gen
 import Plutus.Script.Utils.V2.Scripts qualified as Ledger
 import Plutus.Script.Utils.V2.Typed.Scripts qualified as Scripts

--- a/plutus-ledger/src/Ledger/Test.hs
+++ b/plutus-ledger/src/Ledger/Test.hs
@@ -10,9 +10,7 @@ import Ledger qualified
 import Ledger.Typed.Scripts qualified as Scripts
 import Plutus.Script.Utils.Typed as PSU
 import Plutus.Script.Utils.V1.Scripts qualified as PV1
-import Plutus.Script.Utils.V1.Typed.Scripts.MonetaryPolicies qualified as MPS1
 import Plutus.Script.Utils.V2.Scripts qualified as PV2
-import Plutus.Script.Utils.V2.Typed.Scripts.MonetaryPolicies qualified as MPS2
 import Plutus.V1.Ledger.Api (Address, Validator)
 import Plutus.V1.Ledger.Api qualified as PV1
 import Plutus.V1.Ledger.Value qualified as Value
@@ -57,14 +55,14 @@ mkPolicyV2 _ _ = True
 
 coinMintingPolicy :: Ledger.MintingPolicy
 coinMintingPolicy = Ledger.mkMintingPolicyScript
-    $$(PlutusTx.compile [|| MPS1.mkUntypedMintingPolicy mkPolicy ||])
+    $$(PlutusTx.compile [|| PSU.mkUntypedMintingPolicy mkPolicy ||])
 
 coinMintingPolicyHash :: Ledger.MintingPolicyHash
 coinMintingPolicyHash = PV1.mintingPolicyHash coinMintingPolicy
 
 coinMintingPolicyV2 :: Ledger.MintingPolicy
 coinMintingPolicyV2 = Ledger.mkMintingPolicyScript
-    $$(PlutusTx.compile [|| MPS2.mkUntypedMintingPolicy mkPolicyV2 ||])
+    $$(PlutusTx.compile [|| PSU.mkUntypedMintingPolicy mkPolicyV2 ||])
 
 coinMintingPolicyHashV2 :: Ledger.MintingPolicyHash
 coinMintingPolicyHashV2 = PV2.mintingPolicyHash coinMintingPolicyV2

--- a/plutus-ledger/src/Ledger/Typed/Scripts.hs
+++ b/plutus-ledger/src/Ledger/Typed/Scripts.hs
@@ -15,8 +15,6 @@ module Ledger.Typed.Scripts
   , PV1.ValidatorType
   , PV1.mkTypedValidator
   , PV1.mkTypedValidatorParam
-  , PV1.mkUntypedMintingPolicy
-  , PV1.mkUntypedValidator
   ) where
 
 import Ledger.Typed.Scripts.Orphans as Export ()

--- a/plutus-script-utils/changelog.d/20221130_102114_nicolas.biri_mkUntyped.rst
+++ b/plutus-script-utils/changelog.d/20221130_102114_nicolas.biri_mkUntyped.rst
@@ -1,0 +1,43 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+Removed
+-------
+
+- `mkUntypedMintingPolicyV1` replaced by a version agnostic function
+- `mkUntypedMintingPolicyV2` replaced by a version agnostic function
+- `mkUntypedStakeValidatorV1` replaced by a version agnostic function
+- `mkUntypedStakeValidatorV2` replaced by a version agnostic function
+- `mkUntypedValidatorV1` replaced by a version agnostic function
+- `mkUntypedValidatorV2` replaced by a version agnostic function
+
+
+Added
+-----
+
+- `Plutus.Script.Utils.Typed.ScriptContext` a type class that allow the creation
+  of an untyped minting policy, stake validator or validator.
+- an instance of `Plutus.Script.Utils.Typed.ScriptContext` for the `ScriptContext` of `PlutusV1`
+- an instance of `Plutus.Script.Utils.Typed.ScriptContext` for the `ScriptContext` of `PlutusV2`
+
+.. Changed
+.. -------
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ----------
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. -----
+..
+.. - A bullet item for the Fixed category.
+..
+.. Security
+.. --------
+..
+.. - A bullet item for the Security category.
+..

--- a/plutus-script-utils/changelog.d/20221130_102114_nicolas.biri_mkUntyped.rst
+++ b/plutus-script-utils/changelog.d/20221130_102114_nicolas.biri_mkUntyped.rst
@@ -18,8 +18,8 @@ Added
 
 - `Plutus.Script.Utils.Typed.ScriptContext` a type class that allow the creation
   of an untyped minting policy, stake validator or validator.
-- an instance of `Plutus.Script.Utils.Typed.ScriptContext` for the `ScriptContext` of `PlutusV1`
-- an instance of `Plutus.Script.Utils.Typed.ScriptContext` for the `ScriptContext` of `PlutusV2`
+- an instance of `Plutus.Script.Utils.Typed.ScriptContext` for `Plutus. ledger.V1.Ledger.Context.ScriptContext`
+- an instance of `Plutus.Script.Utils.Typed.ScriptContext` for `Plutus. ledger.V2.Ledger.Context.ScriptContext`
 
 .. Changed
 .. -------

--- a/plutus-script-utils/src/Plutus/Script/Utils/Typed.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/Typed.hs
@@ -22,7 +22,7 @@ module Plutus.Script.Utils.Typed (
   , Any
   , Language (PlutusV1, PlutusV2)
   , Versioned (Versioned, unversioned, version)
-  , ScriptContext(mkUntypedValidator, mkUntypedStakeValidator, mkUntypedMintingPolicy)
+  , IsScriptContext(mkUntypedValidator, mkUntypedStakeValidator, mkUntypedMintingPolicy)
   , ScriptContextV1
   , ScriptContextV2
 ) where
@@ -120,7 +120,7 @@ vForwardingMintingPolicy = tvForwardingMPS
 forwardingMintingPolicyHash :: TypedValidator a -> PV1.MintingPolicyHash
 forwardingMintingPolicyHash = tvForwardingMPSHash
 
-class PV1.UnsafeFromData a => ScriptContext a where
+class PV1.UnsafeFromData sc => IsScriptContext sc where
     {-# INLINABLE mkUntypedValidator #-}
     -- | Converts a custom datum and redeemer from a validator function to an
     -- untyped validator function. See Note [Scripts returning Bool].
@@ -171,7 +171,7 @@ class PV1.UnsafeFromData a => ScriptContext a where
     mkUntypedValidator
         :: forall d r
         . (PV1.UnsafeFromData d, PV1.UnsafeFromData r)
-        => (d -> r -> a -> Bool)
+        => (d -> r -> sc -> Bool)
         -> UntypedValidator
     -- We can use unsafeFromBuiltinData here as we would fail immediately anyway if parsing failed
     mkUntypedValidator f d r p =
@@ -202,7 +202,7 @@ class PV1.UnsafeFromData a => ScriptContext a where
     -- @
     mkUntypedStakeValidator
         :: PV1.UnsafeFromData r
-        => (r -> a -> Bool)
+        => (r -> sc -> Bool)
         -> UntypedStakeValidator
     mkUntypedStakeValidator f r p =
         check $ f (PV1.unsafeFromBuiltinData r) (PV1.unsafeFromBuiltinData p)
@@ -232,7 +232,7 @@ class PV1.UnsafeFromData a => ScriptContext a where
     -- @
     mkUntypedMintingPolicy
         :: PV1.UnsafeFromData r
-        => (r -> a -> Bool)
+        => (r -> sc -> Bool)
         -> UntypedMintingPolicy
     -- We can use unsafeFromBuiltinData here as we would fail immediately anyway if parsing failed
     mkUntypedMintingPolicy f r p =
@@ -242,6 +242,6 @@ class PV1.UnsafeFromData a => ScriptContext a where
 type ScriptContextV1 = PV1.ScriptContext
 type ScriptContextV2 = PV2.ScriptContext
 
-instance ScriptContext PV1.ScriptContext where
+instance IsScriptContext PV1.ScriptContext where
 
-instance ScriptContext PV2.ScriptContext where
+instance IsScriptContext PV2.ScriptContext where

--- a/plutus-script-utils/src/Plutus/Script/Utils/Typed.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/Typed.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE TypeFamilies       #-}
 module Plutus.Script.Utils.Typed (
   UntypedValidator
+  , UntypedMintingPolicy
+  , UntypedStakeValidator
   ---
   , ValidatorTypes (..)
   , TypedValidator (..)
@@ -23,9 +25,6 @@ module Plutus.Script.Utils.Typed (
   , ScriptContext(mkUntypedValidator, mkUntypedStakeValidator, mkUntypedMintingPolicy)
   , ScriptContextV1
   , ScriptContextV2
-  , UntypedMintingPolicy
-  , UntypedStakeValidator
-  , UntypedValidator
 ) where
 
 import Cardano.Ledger.Alonzo.Language (Language (PlutusV1, PlutusV2))

--- a/plutus-script-utils/src/Plutus/Script/Utils/V1/Typed/Scripts/MonetaryPolicies.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V1/Typed/Scripts/MonetaryPolicies.hs
@@ -11,56 +11,21 @@
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 
 module Plutus.Script.Utils.V1.Typed.Scripts.MonetaryPolicies
-    ( UntypedMintingPolicy
-    , mkUntypedMintingPolicy
-    , mkForwardingMintingPolicy
+    ( mkForwardingMintingPolicy
     , forwardToValidator
     ) where
 
+import Plutus.Script.Utils.Typed (mkUntypedMintingPolicy)
 import Plutus.V1.Ledger.Api (Address (Address, addressCredential), Credential (ScriptCredential), MintingPolicy,
                              ValidatorHash, mkMintingPolicyScript)
 import Plutus.V1.Ledger.Contexts (ScriptContext (ScriptContext, scriptContextPurpose, scriptContextTxInfo),
                                   ScriptPurpose (Minting), TxInfo (TxInfo, txInfoInputs))
 import Plutus.V1.Ledger.Contexts qualified as PV1
 import Plutus.V1.Ledger.Tx (TxOut (TxOut, txOutAddress))
-import PlutusTx (UnsafeFromData (unsafeFromBuiltinData))
 import PlutusTx qualified
-import PlutusTx.Prelude (Bool (False), BuiltinData, any, check, ($), (.), (==))
-
-type UntypedMintingPolicy = BuiltinData -> BuiltinData -> ()
+import PlutusTx.Prelude (Bool (False), any, ($), (.), (==))
 
 -- TODO: we should add a TypedMintingPolicy interface here
-
-{-# INLINABLE mkUntypedMintingPolicy #-}
--- | Converts a custom redeemer from a minting policy function to an
--- untyped minting policy function. See Note [Scripts returning Bool].
---
--- Here's an example of how this function can be used:
---
--- @
---   import PlutusTx qualified
---   import Plutus.V1.Ledger.Scripts qualified as Plutus
---   import Plutus.Script.Utils.V1.Scripts (mkUntypedMintingPolicy)
---
---   newtype MyCustomRedeemer = MyCustomRedeemer Integer
---   PlutusTx.unstableMakeIsData ''MyCustomRedeemer
---
---   mkMintingPolicy :: MyCustomRedeemer -> ScriptContext -> Bool
---   mkMintingPolicy _ _ = True
---
---   validator :: Plutus.Validator
---   validator = Plutus.mkMintingPolicyScript
---       $$(PlutusTx.compile [|| wrap ||])
---    where
---       wrap = mkUntypedMintingPolicy mkMintingPolicy
--- @
-mkUntypedMintingPolicy
-    :: UnsafeFromData r
-    => (r -> PV1.ScriptContext -> Bool)
-    -> UntypedMintingPolicy
--- We can use unsafeFromBuiltinData here as we would fail immediately anyway if parsing failed
-mkUntypedMintingPolicy f r p =
-    check $ f (unsafeFromBuiltinData r) (unsafeFromBuiltinData p)
 
 -- | A minting policy that checks whether the validator script was run
 --   in the minting transaction.

--- a/plutus-script-utils/src/Plutus/Script/Utils/V1/Typed/Scripts/StakeValidators.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V1/Typed/Scripts/StakeValidators.hs
@@ -10,55 +10,21 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module Plutus.Script.Utils.V1.Typed.Scripts.StakeValidators
-    ( UntypedStakeValidator
-    , mkUntypedStakeValidator
-    , mkForwardingStakeValidator
+    ( mkForwardingStakeValidator
     , forwardToValidator
     ) where
 
+import Plutus.Script.Utils.Typed (mkUntypedStakeValidator)
 import Plutus.V1.Ledger.Api (Address (Address, addressCredential), Credential (ScriptCredential), StakeValidator,
                              ValidatorHash, mkStakeValidatorScript)
 import Plutus.V1.Ledger.Contexts (ScriptContext (ScriptContext, scriptContextPurpose, scriptContextTxInfo),
                                   ScriptPurpose (Certifying, Rewarding), TxInfo (TxInfo, txInfoInputs))
 import Plutus.V1.Ledger.Contexts qualified as PV1
 import Plutus.V1.Ledger.Tx (TxOut (TxOut, txOutAddress))
-import PlutusTx (UnsafeFromData (unsafeFromBuiltinData))
 import PlutusTx qualified
-import PlutusTx.Prelude (Bool (False), BuiltinData, any, check, ($), (.), (==))
-
-type UntypedStakeValidator = BuiltinData -> BuiltinData -> ()
+import PlutusTx.Prelude (Bool (False), BuiltinData, any, ($), (.), (==))
 
 -- TODO: we should add a TypedStakeValidator interface here
-
-{-# INLINABLE mkUntypedStakeValidator #-}
--- | Converts a custom redeemer from a stake validator function to an
--- untyped stake validator function. See Note [Scripts returning Bool].
---
--- Here's an example of how this function can be used:
---
--- @
---   import PlutusTx qualified
---   import Plutus.V1.Ledger.Scripts qualified as Plutus
---   import Plutus.Script.Utils.V1.Scripts (mkUntypedStakeValidator)
---
---   newtype MyCustomRedeemer = MyCustomRedeemer Integer
---   PlutusTx.unstableMakeIsData ''MyCustomRedeemer
---
---   mkStakeValidator :: MyCustomRedeemer -> ScriptContext -> Bool
---   mkStakeValidator _ _ = True
---
---   validator :: Plutus.Validator
---   validator = Plutus.mkStakeValidatorScript
---       $$(PlutusTx.compile [|| wrap ||])
---    where
---       wrap = mkUntypedStakeValidator mkStakeValidator
--- @
-mkUntypedStakeValidator
-    :: UnsafeFromData r
-    => (r -> PV1.ScriptContext -> Bool)
-    -> UntypedStakeValidator
--- We can use unsafeFromBuiltinData here as we would fail immediately anyway if parsing failed
-mkUntypedStakeValidator f r p = check $ f (unsafeFromBuiltinData r) (unsafeFromBuiltinData p)
 
 -- | A stake validator that checks whether the validator script was run
 --   in the right transaction.

--- a/plutus-script-utils/src/Plutus/Script/Utils/V1/Typed/Scripts/StakeValidators.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V1/Typed/Scripts/StakeValidators.hs
@@ -22,7 +22,7 @@ import Plutus.V1.Ledger.Contexts (ScriptContext (ScriptContext, scriptContextPur
 import Plutus.V1.Ledger.Contexts qualified as PV1
 import Plutus.V1.Ledger.Tx (TxOut (TxOut, txOutAddress))
 import PlutusTx qualified
-import PlutusTx.Prelude (Bool (False), BuiltinData, any, ($), (.), (==))
+import PlutusTx.Prelude (Bool (False), any, ($), (.), (==))
 
 -- TODO: we should add a TypedStakeValidator interface here
 

--- a/plutus-script-utils/src/Plutus/Script/Utils/V2/Typed/Scripts/MonetaryPolicies.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V2/Typed/Scripts/MonetaryPolicies.hs
@@ -11,55 +11,21 @@
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 
 module Plutus.Script.Utils.V2.Typed.Scripts.MonetaryPolicies
-    ( UntypedMintingPolicy
-    , mkUntypedMintingPolicy
-    , mkForwardingMintingPolicy
+    ( mkForwardingMintingPolicy
     , forwardToValidator
     ) where
 
-import Plutus.Script.Utils.V1.Typed.Scripts.MonetaryPolicies (UntypedMintingPolicy)
+import Plutus.Script.Utils.Typed (mkUntypedMintingPolicy)
 import Plutus.V2.Ledger.Api (Address (Address, addressCredential), Credential (ScriptCredential), MintingPolicy,
                              ValidatorHash, mkMintingPolicyScript)
 import Plutus.V2.Ledger.Contexts (ScriptContext (ScriptContext, scriptContextPurpose, scriptContextTxInfo),
                                   ScriptPurpose (Minting), TxInfo (TxInfo, txInfoInputs))
 import Plutus.V2.Ledger.Contexts qualified as PV2
 import Plutus.V2.Ledger.Tx (TxOut (TxOut, txOutAddress))
-import PlutusTx (UnsafeFromData (unsafeFromBuiltinData))
 import PlutusTx qualified
-import PlutusTx.Prelude (Bool (False), any, check, ($), (.), (==))
+import PlutusTx.Prelude (Bool (False), any, ($), (.), (==))
 
 -- TODO: we should add a TypedMintingPolicy interface here
-
-{-# INLINABLE mkUntypedMintingPolicy #-}
--- | Converts a custom redeemer from a minting policy function to an
--- untyped minting policy function. See Note [Scripts returning Bool].
---
--- Here's an example of how this function can be used:
---
--- @
---   import PlutusTx qualified
---   import Plutus.V2.Ledger.Scripts qualified as Plutus
---   import Plutus.Script.Utils.V2.Scripts (mkUntypedMintingPolicy)
---
---   newtype MyCustomRedeemer = MyCustomRedeemer Integer
---   PlutusTx.unstableMakeIsData ''MyCustomRedeemer
---
---   mkMintingPolicy :: MyCustomRedeemer -> ScriptContext -> Bool
---   mkMintingPolicy _ _ = True
---
---   validator :: Plutus.Validator
---   validator = Plutus.mkMintingPolicyScript
---       $$(PlutusTx.compile [|| wrap ||])
---    where
---       wrap = mkUntypedMintingPolicy mkMintingPolicy
--- @
-mkUntypedMintingPolicy
-    :: UnsafeFromData r
-    => (r -> PV2.ScriptContext -> Bool)
-    -> UntypedMintingPolicy
--- We can use unsafeFromBuiltinData here as we would fail immediately anyway if parsing failed
-mkUntypedMintingPolicy f r p =
-    check $ f (unsafeFromBuiltinData r) (unsafeFromBuiltinData p)
 
 -- | A minting policy that checks whether the validator script was run
 --   in the minting transaction.

--- a/plutus-script-utils/src/Plutus/Script/Utils/V2/Typed/Scripts/StakeValidators.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V2/Typed/Scripts/StakeValidators.hs
@@ -10,54 +10,21 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module Plutus.Script.Utils.V2.Typed.Scripts.StakeValidators
-    ( UntypedStakeValidator
-    , mkUntypedStakeValidator
-    , mkForwardingStakeValidator
+    ( mkForwardingStakeValidator
     , forwardToValidator
     ) where
 
-import Plutus.Script.Utils.V1.Typed.Scripts.StakeValidators (UntypedStakeValidator)
+import Plutus.Script.Utils.Typed (mkUntypedStakeValidator)
 import Plutus.V2.Ledger.Api (Address (Address, addressCredential), Credential (ScriptCredential), StakeValidator,
                              ValidatorHash, mkStakeValidatorScript)
 import Plutus.V2.Ledger.Contexts (ScriptContext (ScriptContext, scriptContextPurpose, scriptContextTxInfo),
                                   ScriptPurpose (Certifying, Rewarding), TxInfo (TxInfo, txInfoInputs))
 import Plutus.V2.Ledger.Contexts qualified as PV2
 import Plutus.V2.Ledger.Tx (TxOut (TxOut, txOutAddress))
-import PlutusTx (UnsafeFromData (unsafeFromBuiltinData))
 import PlutusTx qualified
-import PlutusTx.Prelude (Bool (False), any, check, ($), (.), (==))
+import PlutusTx.Prelude (Bool (False), any, ($), (.), (==))
 
 -- TODO: we should add a TypedStakeValidator interface here
-
-{-# INLINABLE mkUntypedStakeValidator #-}
--- | Converts a custom redeemer from a stake validator function to an
--- untyped stake validator function. See Note [Scripts returning Bool].
---
--- Here's an example of how this function can be used:
---
--- @
---   import PlutusTx qualified
---   import Plutus.V2.Ledger.Scripts qualified as Plutus
---   import Plutus.Script.Utils.V2.Scripts (mkUntypedStakeValidator)
---
---   newtype MyCustomRedeemer = MyCustomRedeemer Integer
---   PlutusTx.unstableMakeIsData ''MyCustomRedeemer
---
---   mkStakeValidator :: MyCustomRedeemer -> ScriptContext -> Bool
---   mkStakeValidator _ _ = True
---
---   validator :: Plutus.Validator
---   validator = Plutus.mkStakeValidatorScript
---       $$(PlutusTx.compile [|| wrap ||])
---    where
---       wrap = mkUntypedStakeValidator mkStakeValidator
--- @
-mkUntypedStakeValidator
-    :: UnsafeFromData r
-    => (r -> PV2.ScriptContext -> Bool)
-    -> UntypedStakeValidator
--- We can use unsafeFromBuiltinData here as we would fail immediately anyway if parsing failed
-mkUntypedStakeValidator f r p = check $ f (unsafeFromBuiltinData r) (unsafeFromBuiltinData p)
 
 -- | A stake validator that checks whether the validator script was run
 --   in the right transaction.

--- a/plutus-script-utils/src/Plutus/Script/Utils/V2/Typed/Scripts/Validators.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V2/Typed/Scripts/Validators.hs
@@ -9,7 +9,6 @@
 
 module Plutus.Script.Utils.V2.Typed.Scripts.Validators
     ( UntypedValidator
-    , mkUntypedValidator
     ---
     , ValidatorTypes (..)
     , ValidatorType
@@ -32,8 +31,8 @@ import Plutus.Script.Utils.Scripts (Language (PlutusV2), Versioned (Versioned))
 import Plutus.Script.Utils.Typed (DatumType, RedeemerType,
                                   TypedValidator (TypedValidator, tvForwardingMPS, tvForwardingMPSHash, tvValidator, tvValidatorHash),
                                   UntypedValidator, ValidatorTypes, forwardingMintingPolicy,
-                                  forwardingMintingPolicyHash, generalise, mkUntypedValidator, vForwardingMintingPolicy,
-                                  vValidatorScript, validatorAddress, validatorHash, validatorScript)
+                                  forwardingMintingPolicyHash, generalise, vForwardingMintingPolicy, vValidatorScript,
+                                  validatorAddress, validatorHash, validatorScript)
 import Plutus.Script.Utils.V2.Scripts qualified as Scripts
 import Plutus.Script.Utils.V2.Typed.Scripts.MonetaryPolicies qualified as MPS
 import Plutus.V2.Ledger.Api qualified as PV2

--- a/plutus-script-utils/src/Plutus/Script/Utils/V2/Typed/Scripts/Validators.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V2/Typed/Scripts/Validators.hs
@@ -32,70 +32,13 @@ import Plutus.Script.Utils.Scripts (Language (PlutusV2), Versioned (Versioned))
 import Plutus.Script.Utils.Typed (DatumType, RedeemerType,
                                   TypedValidator (TypedValidator, tvForwardingMPS, tvForwardingMPSHash, tvValidator, tvValidatorHash),
                                   UntypedValidator, ValidatorTypes, forwardingMintingPolicy,
-                                  forwardingMintingPolicyHash, generalise, vForwardingMintingPolicy, vValidatorScript,
-                                  validatorAddress, validatorHash, validatorScript)
+                                  forwardingMintingPolicyHash, generalise, mkUntypedValidator, vForwardingMintingPolicy,
+                                  vValidatorScript, validatorAddress, validatorHash, validatorScript)
 import Plutus.Script.Utils.V2.Scripts qualified as Scripts
 import Plutus.Script.Utils.V2.Typed.Scripts.MonetaryPolicies qualified as MPS
 import Plutus.V2.Ledger.Api qualified as PV2
 import PlutusCore.Default (DefaultUni)
-import PlutusTx (CompiledCode, Lift, UnsafeFromData (unsafeFromBuiltinData), applyCode, liftCode)
-import PlutusTx.Prelude (check)
-
-{-# INLINABLE mkUntypedValidator #-}
--- | Converts a custom datum and redeemer from a validator function to an
--- untyped validator function. See Note [Scripts returning Bool].
---
--- Here's an example of how this function can be used:
---
--- @
---   import PlutusTx qualified
---   import Plutus.V2.Ledger.Scripts qualified as Plutus
---   import Plutus.Script.Utils.V2.Scripts (mkUntypedValidator)
---
---   newtype MyCustomDatum = MyCustomDatum Integer
---   PlutusTx.unstableMakeIsData ''MyCustomDatum
---   newtype MyCustomRedeemer = MyCustomRedeemer Integer
---   PlutusTx.unstableMakeIsData ''MyCustomRedeemer
---
---   mkValidator :: MyCustomDatum -> MyCustomRedeemer -> Plutus.ScriptContext -> Bool
---   mkValidator _ _ _ = True
---
---   validator :: Plutus.Validator
---   validator = Plutus.mkValidatorScript
---       $$(PlutusTx.compile [|| wrap ||])
---    where
---       wrap = mkUntypedValidator mkValidator
--- @
---
--- Here's an example using a parameterized validator:
---
--- @
---   import PlutusTx qualified
---   import Plutus.V2.Ledger.Scripts qualified as Plutus
---   import Plutus.Script.Utils.V2.Scripts (mkUntypedValidator)
---
---   newtype MyCustomDatum = MyCustomDatum Integer
---   PlutusTx.unstableMakeIsData ''MyCustomDatum
---   newtype MyCustomRedeemer = MyCustomRedeemer Integer
---   PlutusTx.unstableMakeIsData ''MyCustomRedeemer
---
---   mkValidator :: Int -> MyCustomDatum -> MyCustomRedeemer -> Plutus.ScriptContext -> Bool
---   mkValidator _ _ _ _ = True
---
---   validator :: Int -> Plutus.Validator
---   validator i = Plutus.mkValidatorScript
---       $$(PlutusTx.compile [|| wrap . mkValidator ||]) `PlutusTx.applyCode` PlutusTx.liftCode i
---    where
---       wrap = mkUntypedValidator
--- @
-mkUntypedValidator
-    :: forall d r
-    . (UnsafeFromData d, UnsafeFromData r)
-    => (d -> r -> PV2.ScriptContext -> Bool)
-    -> UntypedValidator
--- We can use unsafeFromBuiltinData here as we would fail immediately anyway if parsing failed
-mkUntypedValidator f d r p =
-    check $ f (unsafeFromBuiltinData d) (unsafeFromBuiltinData r) (unsafeFromBuiltinData p)
+import PlutusTx (CompiledCode, Lift, applyCode, liftCode)
 
 -- | The type of validators for the given connection type.
 type ValidatorType (a :: Type) = DatumType a -> RedeemerType a -> PV2.ScriptContext -> Bool

--- a/plutus-use-cases/src/Plutus/Contracts/Future.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Future.hs
@@ -317,7 +317,7 @@ typedValidator future ftos =
                 `PlutusTx.applyCode`
                     PlutusTx.liftCode ftos
         validatorParam f g = SM.mkValidator (futureStateMachine f g)
-        wrap = Scripts.mkUntypedValidator @FutureState @FutureAction
+        wrap = Scripts.mkUntypedValidator @Scripts.ScriptContextV1 @FutureState @FutureAction
 
     in Scripts.mkTypedValidator @(SM.StateMachine FutureState FutureAction)
         val

--- a/plutus-use-cases/src/Plutus/Contracts/Game.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Game.hs
@@ -54,6 +54,7 @@ import Ledger.Typed.Scripts qualified as Scripts
 import Playground.Contract (ToSchema)
 import Plutus.Contract (AsContractError, Contract, Endpoint, Promise, adjustUnbalancedTx, endpoint, fundsAtAddressGeq,
                         logInfo, mkTxConstraints, selectList, type (.\/), yieldUnbalancedTx)
+import Plutus.Script.Utils.Typed (ScriptContextV1)
 import Plutus.Script.Utils.V1.Address (mkValidatorAddress)
 import Plutus.V1.Ledger.Scripts (Datum (Datum), Validator)
 import PlutusTx qualified
@@ -104,7 +105,7 @@ gameInstance :: GameParam -> Scripts.TypedValidator Game
 gameInstance = Scripts.mkTypedValidatorParam @Game
     $$(PlutusTx.compile [|| mkValidator ||])
     $$(PlutusTx.compile [|| wrap ||]) where
-        wrap = Scripts.mkUntypedValidator @HashedString @ClearString
+        wrap = Scripts.mkUntypedValidator @ScriptContextV1 @HashedString @ClearString
 
 -- | The validation function (Datum -> Redeemer -> ScriptContext -> Bool)
 --

--- a/plutus-use-cases/src/Plutus/Contracts/PingPong.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/PingPong.hs
@@ -40,6 +40,7 @@ import GHC.Generics (Generic)
 import Ledger.Ada qualified as Ada
 import Ledger.Constraints (TxConstraints)
 import Ledger.Typed.Scripts qualified as Scripts
+import Plutus.Script.Utils.Typed (ScriptContextV1)
 import PlutusTx qualified
 import PlutusTx.Prelude hiding (Applicative (..), check)
 
@@ -106,7 +107,7 @@ typedValidator = Scripts.mkTypedValidator @(SM.StateMachine PingPongState Input)
     $$(PlutusTx.compile [|| mkValidator ||])
     $$(PlutusTx.compile [|| wrap ||])
     where
-        wrap = Scripts.mkUntypedValidator @PingPongState @Input
+        wrap = Scripts.mkUntypedValidator @ScriptContextV1 @PingPongState @Input
 
 machineInstance :: SM.StateMachineInstance PingPongState Input
 machineInstance = SM.StateMachineInstance machine typedValidator

--- a/plutus-use-cases/src/Plutus/Contracts/Prism/Credential.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Prism/Credential.hs
@@ -23,8 +23,8 @@ import Ledger.Address (PaymentPubKeyHash (unPaymentPubKeyHash))
 import Ledger.Value (TokenName, Value)
 import Ledger.Value qualified as Value
 import Plutus.Contracts.TokenAccount (Account (..))
+import Plutus.Script.Utils.Typed qualified as Scripts
 import Plutus.Script.Utils.V1.Scripts (mintingPolicyHash)
-import Plutus.Script.Utils.V1.Typed.Scripts qualified as Scripts
 import Plutus.V1.Ledger.Api (ScriptContext (..))
 import Plutus.V1.Ledger.Contexts (txSignedBy)
 import Plutus.V1.Ledger.Scripts qualified as Scripts

--- a/plutus-use-cases/src/Plutus/Contracts/Prism/STO.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Prism/STO.hs
@@ -34,8 +34,8 @@ import Ledger.Ada (Ada (Lovelace), fromValue)
 import Ledger.Address (PaymentPubKeyHash (unPaymentPubKeyHash))
 import Ledger.Value (TokenName, Value)
 import Ledger.Value qualified as Value
+import Plutus.Script.Utils.Typed qualified as Scripts
 import Plutus.Script.Utils.V1.Scripts qualified as Scripts
-import Plutus.Script.Utils.V1.Typed.Scripts qualified as Scripts
 import Plutus.V1.Ledger.Api (ScriptContext (..), ScriptPurpose (..))
 import Plutus.V1.Ledger.Contexts qualified as Validation
 import Plutus.V1.Ledger.Scripts qualified as Scripts

--- a/plutus-use-cases/src/Plutus/Contracts/Prism/StateMachine.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Prism/StateMachine.hs
@@ -89,7 +89,7 @@ typedValidator ::
 typedValidator credentialData =
     let val = $$(PlutusTx.compile [|| validator ||]) `PlutusTx.applyCode` PlutusTx.liftCode credentialData
         validator d = StateMachine.mkValidator (credentialStateMachine d)
-        wrap = Scripts.mkUntypedValidator @IDState @IDAction
+        wrap = Scripts.mkUntypedValidator @Scripts.ScriptContextV1 @IDState @IDAction
     in Scripts.mkTypedValidator @(StateMachine IDState IDAction) val $$(PlutusTx.compile [|| wrap ||])
 
 machineClient ::

--- a/plutus-use-cases/src/Plutus/Contracts/SimpleEscrow.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/SimpleEscrow.hs
@@ -30,6 +30,7 @@ import Ledger.Constraints qualified as Constraints
 import Ledger.Interval (after, before)
 import Ledger.Interval qualified as Interval
 import Ledger.Tx qualified as Tx
+import Ledger.Typed.Scripts (ScriptContextV1)
 import Ledger.Typed.Scripts qualified as Scripts
 import Ledger.Value (Value, geq)
 import Plutus.V1.Ledger.Api (ScriptContext (..), TxInfo (..))
@@ -99,7 +100,7 @@ escrowInstance = Scripts.mkTypedValidator @Escrow
     $$(PlutusTx.compile [|| validate ||])
     $$(PlutusTx.compile [|| wrap ||])
       where
-        wrap = Scripts.mkUntypedValidator @EscrowParams @Action
+        wrap = Scripts.mkUntypedValidator @ScriptContextV1 @EscrowParams @Action
 
 {-# INLINABLE validate #-}
 validate :: EscrowParams -> Action -> ScriptContext -> Bool

--- a/plutus-use-cases/src/Plutus/Contracts/Stablecoin.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Stablecoin.hs
@@ -367,7 +367,7 @@ typedValidator :: Stablecoin -> Scripts.TypedValidator (StateMachine BankState I
 typedValidator stablecoin =
     let val = $$(PlutusTx.compile [|| validator ||]) `PlutusTx.applyCode` PlutusTx.liftCode stablecoin
         validator d = SM.mkValidator (stablecoinStateMachine d)
-        wrap = Scripts.mkUntypedValidator @BankState @Input
+        wrap = Scripts.mkUntypedValidator @Scripts.ScriptContextV1 @BankState @Input
     in Scripts.mkTypedValidator @(StateMachine BankState Input) val $$(PlutusTx.compile [|| wrap ||])
 
 machineClient ::

--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
@@ -109,7 +109,7 @@ uniswapInstance us = Scripts.mkTypedValidator @Uniswapping
     c :: Coin PoolState
     c = poolStateCoin us
 
-    wrap = Scripts.mkUntypedValidator @UniswapDatum @UniswapAction
+    wrap = Scripts.mkUntypedValidator @Scripts.ScriptContextV1 @UniswapDatum @UniswapAction
 
 uniswapScript :: Uniswap -> Validator
 uniswapScript = Scripts.validatorScript . uniswapInstance

--- a/plutus-use-cases/test/Spec/Game.hs
+++ b/plutus-use-cases/test/Spec/Game.hs
@@ -75,12 +75,12 @@ successTrace = do
                                             , lockArgsValue = Ada.adaValueOf 8
                                             }
     -- One slot for sending the Ada to the script.
-    _ <- Trace.waitNSlots 1
+    void $ Trace.nextSlot
     hdl2 <- Trace.activateContractWallet w2 $ G.contract @Text
     Trace.callEndpoint @"guess" hdl2 GuessArgs { guessArgsGameParam = gameParam
                                                , guessArgsSecret = "hello"
                                                }
-    void $ Trace.waitNSlots 1
+    void $ Trace.nextSlot
 
 -- | Wallet 1 locks some funds, and Wallet 2 makes a wrong guess.
 failTrace :: EmulatorTrace ()
@@ -90,9 +90,9 @@ failTrace = do
                                             , lockArgsSecret = "hello"
                                             , lockArgsValue = Ada.adaValueOf 8
                                             }
-    _ <- Trace.waitNSlots 1
+    void $ Trace.nextSlot
     hdl2 <- Trace.activateContractWallet w2 $ G.contract @Text
     _ <- Trace.callEndpoint @"guess" hdl2 GuessArgs { guessArgsGameParam = gameParam
                                                     , guessArgsSecret = "hola"
                                                     }
-    void $ Trace.waitNSlots 1
+    void $ Trace.nextSlot

--- a/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
@@ -25,13 +25,13 @@ Slot 1: 00000000-0000-4000-8000-000000000003 {Wallet W[4]}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",2500000)])])"
 Slot 1: W[2]: Balancing an unbalanced transaction:
                 Tx:
-                  Tx 34be799d6bf634018fb6a20dfa075fc7624321310b84251ab99bc26b8661d641:
+                  Tx 8c4cabfa33d78b0d7d4a5377934ee0554c46fe3f5fdfaac2f7ca11ca7ade01ca:
                     {inputs:
                     reference inputs:
                     collateral inputs:
                     outputs:
                       - Value (Map [(,Map [("",10000000)])]) addressed to
-                        ScriptCredential: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450 (no staking credential)
+                        ScriptCredential: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1 (no staking credential)
                         with datum hash 77ab184b7537cd4b1dc3730f6a8a76a3d3aad1642fae9d769aa5dae40be38b51
                     mint: Value (Map [])
                     fee: Value (Map [])
@@ -44,7 +44,7 @@ Slot 1: W[2]: Balancing an unbalanced transaction:
                 Requires signatures:
                 Utxo index:
 Slot 1: W[2]: Finished balancing:
-                Tx f22ad19506e8360e3fa3deb52c23cd9df14b78639828a18762ed99493c14cdfe:
+                Tx 5bbba5a7381f485a38b6fdba2bfc1657a22fe78a9fa6b9a603c64ae4320d4535:
                   {inputs:
                      - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!20
 
@@ -54,7 +54,7 @@ Slot 1: W[2]: Finished balancing:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",10000000)])]) addressed to
-                      ScriptCredential: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450 (no staking credential)
+                      ScriptCredential: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1 (no staking credential)
                       with datum hash 77ab184b7537cd4b1dc3730f6a8a76a3d3aad1642fae9d769aa5dae40be38b51
                     - Value (Map [(,Map [("",9823763)])]) addressed to
                       PubKeyCredential: 80a4f45b56b88d1139da23bc4c3c75ec6d32943c087f250b86193ca7 (no staking credential)
@@ -65,18 +65,18 @@ Slot 1: W[2]: Finished balancing:
                     ( 77ab184b7537cd4b1dc3730f6a8a76a3d3aad1642fae9d769aa5dae40be38b51
                     , "\128\164\244[V\184\141\DC19\218#\188L<u\236m2\148<\b\DEL%\v\134\EM<\167" )
                   redeemers:}
-Slot 1: W[2]: Signing tx: f22ad19506e8360e3fa3deb52c23cd9df14b78639828a18762ed99493c14cdfe
-Slot 1: W[2]: Submitting tx: f22ad19506e8360e3fa3deb52c23cd9df14b78639828a18762ed99493c14cdfe
-Slot 1: W[2]: TxSubmit: f22ad19506e8360e3fa3deb52c23cd9df14b78639828a18762ed99493c14cdfe
+Slot 1: W[2]: Signing tx: 5bbba5a7381f485a38b6fdba2bfc1657a22fe78a9fa6b9a603c64ae4320d4535
+Slot 1: W[2]: Submitting tx: 5bbba5a7381f485a38b6fdba2bfc1657a22fe78a9fa6b9a603c64ae4320d4535
+Slot 1: W[2]: TxSubmit: 5bbba5a7381f485a38b6fdba2bfc1657a22fe78a9fa6b9a603c64ae4320d4535
 Slot 1: W[3]: Balancing an unbalanced transaction:
                 Tx:
-                  Tx 2af78a497f8337036d66de2f386a82e89330b7a9efb4f6c1564a578789d31340:
+                  Tx cacb976afc740b7a041f7caa4134a57ba3c48156b90c21b8686b8c5080def8c8:
                     {inputs:
                     reference inputs:
                     collateral inputs:
                     outputs:
                       - Value (Map [(,Map [("",10000000)])]) addressed to
-                        ScriptCredential: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450 (no staking credential)
+                        ScriptCredential: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1 (no staking credential)
                         with datum hash 2cc2afd267462229babbc139837611310e4307bd6c7e870049c22fb02c2ad122
                     mint: Value (Map [])
                     fee: Value (Map [])
@@ -89,7 +89,7 @@ Slot 1: W[3]: Balancing an unbalanced transaction:
                 Requires signatures:
                 Utxo index:
 Slot 1: W[3]: Finished balancing:
-                Tx e7b3a7188ad64c00b7b48f75af4359fdcffa03b6b998f6896618194c5018b951:
+                Tx fb0c6e0323bae8bce2ebd2c2c749ac1f5a9dbe96d28db1f2a9afaa12d5242dfb:
                   {inputs:
                      - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!0
 
@@ -99,7 +99,7 @@ Slot 1: W[3]: Finished balancing:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",10000000)])]) addressed to
-                      ScriptCredential: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450 (no staking credential)
+                      ScriptCredential: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1 (no staking credential)
                       with datum hash 2cc2afd267462229babbc139837611310e4307bd6c7e870049c22fb02c2ad122
                     - Value (Map [(,Map [("",9823763)])]) addressed to
                       PubKeyCredential: 2e0ad60c3207248cecd47dbde3d752e0aad141d6b8f81ac2c6eca27c (no staking credential)
@@ -110,18 +110,18 @@ Slot 1: W[3]: Finished balancing:
                     ( 2cc2afd267462229babbc139837611310e4307bd6c7e870049c22fb02c2ad122
                     , ".\n\214\f2\a$\140\236\212}\189\227\215R\224\170\209A\214\184\248\SUB\194\198\236\162|" )
                   redeemers:}
-Slot 1: W[3]: Signing tx: e7b3a7188ad64c00b7b48f75af4359fdcffa03b6b998f6896618194c5018b951
-Slot 1: W[3]: Submitting tx: e7b3a7188ad64c00b7b48f75af4359fdcffa03b6b998f6896618194c5018b951
-Slot 1: W[3]: TxSubmit: e7b3a7188ad64c00b7b48f75af4359fdcffa03b6b998f6896618194c5018b951
+Slot 1: W[3]: Signing tx: fb0c6e0323bae8bce2ebd2c2c749ac1f5a9dbe96d28db1f2a9afaa12d5242dfb
+Slot 1: W[3]: Submitting tx: fb0c6e0323bae8bce2ebd2c2c749ac1f5a9dbe96d28db1f2a9afaa12d5242dfb
+Slot 1: W[3]: TxSubmit: fb0c6e0323bae8bce2ebd2c2c749ac1f5a9dbe96d28db1f2a9afaa12d5242dfb
 Slot 1: W[4]: Balancing an unbalanced transaction:
                 Tx:
-                  Tx 3b0e529aa25b8106a65a739c8547d5273e278a22bc07d6262c7e14ddd2e5ba6c:
+                  Tx e6515f5db19f87951eeedb74cdeefec5f4eeaafbecaa0e779a729f75847646b5:
                     {inputs:
                     reference inputs:
                     collateral inputs:
                     outputs:
                       - Value (Map [(,Map [("",2500000)])]) addressed to
-                        ScriptCredential: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450 (no staking credential)
+                        ScriptCredential: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1 (no staking credential)
                         with datum hash 63f4305deedb48449f218150b39eceb8d5951aa680e28a414024bc4c04758969
                     mint: Value (Map [])
                     fee: Value (Map [])
@@ -134,7 +134,7 @@ Slot 1: W[4]: Balancing an unbalanced transaction:
                 Requires signatures:
                 Utxo index:
 Slot 1: W[4]: Finished balancing:
-                Tx dd5fe9c105905d0fde03fded09d9ffc26138e1dcbc982978f6828e9117b6aa58:
+                Tx c7a3147b0398e169ccb6dfce2eae355322209126c9e32a1a18c6cc62021a1e9d:
                   {inputs:
                      - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!10
 
@@ -142,7 +142,7 @@ Slot 1: W[4]: Finished balancing:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",2500000)])]) addressed to
-                      ScriptCredential: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450 (no staking credential)
+                      ScriptCredential: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1 (no staking credential)
                       with datum hash 63f4305deedb48449f218150b39eceb8d5951aa680e28a414024bc4c04758969
                     - Value (Map [(,Map [("",7329791)])]) addressed to
                       PubKeyCredential: 557d23c0a533b4d295ac2dc14b783a7efc293bc23ede88a6fefd203d (no staking credential)
@@ -153,23 +153,23 @@ Slot 1: W[4]: Finished balancing:
                     ( 63f4305deedb48449f218150b39eceb8d5951aa680e28a414024bc4c04758969
                     , "U}#\192\165\&3\180\210\149\172-\193Kx:~\252);\194>\222\136\166\254\253 =" )
                   redeemers:}
-Slot 1: W[4]: Signing tx: dd5fe9c105905d0fde03fded09d9ffc26138e1dcbc982978f6828e9117b6aa58
-Slot 1: W[4]: Submitting tx: dd5fe9c105905d0fde03fded09d9ffc26138e1dcbc982978f6828e9117b6aa58
-Slot 1: W[4]: TxSubmit: dd5fe9c105905d0fde03fded09d9ffc26138e1dcbc982978f6828e9117b6aa58
-Slot 1: TxnValidate dd5fe9c105905d0fde03fded09d9ffc26138e1dcbc982978f6828e9117b6aa58 [  ]
-Slot 1: TxnValidate e7b3a7188ad64c00b7b48f75af4359fdcffa03b6b998f6896618194c5018b951 [  ]
-Slot 1: TxnValidate f22ad19506e8360e3fa3deb52c23cd9df14b78639828a18762ed99493c14cdfe [  ]
+Slot 1: W[4]: Signing tx: c7a3147b0398e169ccb6dfce2eae355322209126c9e32a1a18c6cc62021a1e9d
+Slot 1: W[4]: Submitting tx: c7a3147b0398e169ccb6dfce2eae355322209126c9e32a1a18c6cc62021a1e9d
+Slot 1: W[4]: TxSubmit: c7a3147b0398e169ccb6dfce2eae355322209126c9e32a1a18c6cc62021a1e9d
+Slot 1: TxnValidate c7a3147b0398e169ccb6dfce2eae355322209126c9e32a1a18c6cc62021a1e9d [  ]
+Slot 1: TxnValidate fb0c6e0323bae8bce2ebd2c2c749ac1f5a9dbe96d28db1f2a9afaa12d5242dfb [  ]
+Slot 1: TxnValidate 5bbba5a7381f485a38b6fdba2bfc1657a22fe78a9fa6b9a603c64ae4320d4535 [  ]
 Slot 20: 00000000-0000-4000-8000-000000000000 {Wallet W[1]}:
            Contract log: String "Collecting funds"
 Slot 20: W[1]: Balancing an unbalanced transaction:
                  Tx:
-                   Tx 3d0d7fbe8bf2c3081406a59bcaa85cc9245fee6ac86cd1d36df9d88548d9b0cc:
+                   Tx 87da7385a553a2684788c90af22945f73ea9e9fced027a8e9b0b1ecc47f2cdb2:
                      {inputs:
-                        - f22ad19506e8360e3fa3deb52c23cd9df14b78639828a18762ed99493c14cdfe!0
+                        - fb0c6e0323bae8bce2ebd2c2c749ac1f5a9dbe96d28db1f2a9afaa12d5242dfb!0
                           <>
-                        - e7b3a7188ad64c00b7b48f75af4359fdcffa03b6b998f6896618194c5018b951!0
+                        - c7a3147b0398e169ccb6dfce2eae355322209126c9e32a1a18c6cc62021a1e9d!0
                           <>
-                        - dd5fe9c105905d0fde03fded09d9ffc26138e1dcbc982978f6828e9117b6aa58!0
+                        - 5bbba5a7381f485a38b6fdba2bfc1657a22fe78a9fa6b9a603c64ae4320d4535!0
                           <>
                      reference inputs:
                      collateral inputs:
@@ -187,31 +187,31 @@ Slot 20: W[1]: Balancing an unbalanced transaction:
                        ( 77ab184b7537cd4b1dc3730f6a8a76a3d3aad1642fae9d769aa5dae40be38b51
                        , "\128\164\244[V\184\141\DC19\218#\188L<u\236m2\148<\b\DEL%\v\134\EM<\167" )
                      attached scripts:
-                       ( 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450
+                       ( b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1
                        , Plutus V1 )}
                  Requires signatures:
                    a2c20c77887ace1cd986193e4e75babd8993cfd56995cd5cfce609c2
                  Utxo index:
-                   ( dd5fe9c105905d0fde03fded09d9ffc26138e1dcbc982978f6828e9117b6aa58!0
-                   , - Value (Map [(,Map [("",2500000)])]) addressed to
-                       ScriptCredential: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450 (no staking credential)
-                       with datum hash 63f4305deedb48449f218150b39eceb8d5951aa680e28a414024bc4c04758969 )
-                   ( e7b3a7188ad64c00b7b48f75af4359fdcffa03b6b998f6896618194c5018b951!0
+                   ( 5bbba5a7381f485a38b6fdba2bfc1657a22fe78a9fa6b9a603c64ae4320d4535!0
                    , - Value (Map [(,Map [("",10000000)])]) addressed to
-                       ScriptCredential: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450 (no staking credential)
-                       with datum hash 2cc2afd267462229babbc139837611310e4307bd6c7e870049c22fb02c2ad122 )
-                   ( f22ad19506e8360e3fa3deb52c23cd9df14b78639828a18762ed99493c14cdfe!0
-                   , - Value (Map [(,Map [("",10000000)])]) addressed to
-                       ScriptCredential: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450 (no staking credential)
+                       ScriptCredential: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1 (no staking credential)
                        with datum hash 77ab184b7537cd4b1dc3730f6a8a76a3d3aad1642fae9d769aa5dae40be38b51 )
+                   ( c7a3147b0398e169ccb6dfce2eae355322209126c9e32a1a18c6cc62021a1e9d!0
+                   , - Value (Map [(,Map [("",2500000)])]) addressed to
+                       ScriptCredential: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1 (no staking credential)
+                       with datum hash 63f4305deedb48449f218150b39eceb8d5951aa680e28a414024bc4c04758969 )
+                   ( fb0c6e0323bae8bce2ebd2c2c749ac1f5a9dbe96d28db1f2a9afaa12d5242dfb!0
+                   , - Value (Map [(,Map [("",10000000)])]) addressed to
+                       ScriptCredential: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1 (no staking credential)
+                       with datum hash 2cc2afd267462229babbc139837611310e4307bd6c7e870049c22fb02c2ad122 )
 Slot 20: W[1]: Finished balancing:
-                 Tx 8847f6867d48315673c259fd391c83f7e88f2f88bf20d5bf5a32fea19511fb24:
+                 Tx 766a1aab6d44ad8e81d3c214d78e5f46541e9f8f77ef5421034b560bd0dddc3e:
                    {inputs:
-                      - dd5fe9c105905d0fde03fded09d9ffc26138e1dcbc982978f6828e9117b6aa58!0
+                      - 5bbba5a7381f485a38b6fdba2bfc1657a22fe78a9fa6b9a603c64ae4320d4535!0
 
-                      - e7b3a7188ad64c00b7b48f75af4359fdcffa03b6b998f6896618194c5018b951!0
+                      - c7a3147b0398e169ccb6dfce2eae355322209126c9e32a1a18c6cc62021a1e9d!0
 
-                      - f22ad19506e8360e3fa3deb52c23cd9df14b78639828a18762ed99493c14cdfe!0
+                      - fb0c6e0323bae8bce2ebd2c2c749ac1f5a9dbe96d28db1f2a9afaa12d5242dfb!0
 
                    reference inputs:
                    collateral inputs:
@@ -235,9 +235,9 @@ Slot 20: W[1]: Finished balancing:
                      ( 77ab184b7537cd4b1dc3730f6a8a76a3d3aad1642fae9d769aa5dae40be38b51
                      , "\128\164\244[V\184\141\DC19\218#\188L<u\236m2\148<\b\DEL%\v\134\EM<\167" )
                    redeemers:}
-Slot 20: W[1]: Signing tx: 8847f6867d48315673c259fd391c83f7e88f2f88bf20d5bf5a32fea19511fb24
-Slot 20: W[1]: Submitting tx: 8847f6867d48315673c259fd391c83f7e88f2f88bf20d5bf5a32fea19511fb24
-Slot 20: W[1]: TxSubmit: 8847f6867d48315673c259fd391c83f7e88f2f88bf20d5bf5a32fea19511fb24
+Slot 20: W[1]: Signing tx: 766a1aab6d44ad8e81d3c214d78e5f46541e9f8f77ef5421034b560bd0dddc3e
+Slot 20: W[1]: Submitting tx: 766a1aab6d44ad8e81d3c214d78e5f46541e9f8f77ef5421034b560bd0dddc3e
+Slot 20: W[1]: TxSubmit: 766a1aab6d44ad8e81d3c214d78e5f46541e9f8f77ef5421034b560bd0dddc3e
 Slot 20: 00000000-0000-4000-8000-000000000000 {Wallet W[1]}:
            Contract instance stopped (no errors)
-Slot 20: TxnValidate 8847f6867d48315673c259fd391c83f7e88f2f88bf20d5bf5a32fea19511fb24 [  ]
+Slot 20: TxnValidate 766a1aab6d44ad8e81d3c214d78e5f46541e9f8f77ef5421034b560bd0dddc3e [  ]

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -550,7 +550,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       dd5fe9c105905d0fde03fded09d9ffc26138e1dcbc982978f6828e9117b6aa58
+TxId:       c7a3147b0398e169ccb6dfce2eae355322209126c9e32a1a18c6cc62021a1e9d
 Fee:        Ada:      Lovelace:  170209
 Mint:       -
 Inputs:
@@ -565,7 +565,7 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  Script: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450
+  Destination:  Script: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1
   Value:
     Ada:      Lovelace:  2500000
 
@@ -616,12 +616,12 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450
+  Script: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1
   Value:
     Ada:      Lovelace:  2500000
 
 ==== Slot #1, Tx #1 ====
-TxId:       e7b3a7188ad64c00b7b48f75af4359fdcffa03b6b998f6896618194c5018b951
+TxId:       fb0c6e0323bae8bce2ebd2c2c749ac1f5a9dbe96d28db1f2a9afaa12d5242dfb
 Fee:        Ada:      Lovelace:  176237
 Mint:       -
 Inputs:
@@ -644,7 +644,7 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  Script: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450
+  Destination:  Script: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1
   Value:
     Ada:      Lovelace:  10000000
 
@@ -695,12 +695,12 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450
+  Script: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1
   Value:
     Ada:      Lovelace:  12500000
 
 ==== Slot #1, Tx #2 ====
-TxId:       f22ad19506e8360e3fa3deb52c23cd9df14b78639828a18762ed99493c14cdfe
+TxId:       5bbba5a7381f485a38b6fdba2bfc1657a22fe78a9fa6b9a603c64ae4320d4535
 Fee:        Ada:      Lovelace:  176237
 Mint:       -
 Inputs:
@@ -723,7 +723,7 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  Script: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450
+  Destination:  Script: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1
   Value:
     Ada:      Lovelace:  10000000
 
@@ -774,37 +774,37 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450
+  Script: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1
   Value:
     Ada:      Lovelace:  22500000
 
 ==== Slot #2, Tx #0 ====
-TxId:       8847f6867d48315673c259fd391c83f7e88f2f88bf20d5bf5a32fea19511fb24
+TxId:       766a1aab6d44ad8e81d3c214d78e5f46541e9f8f77ef5421034b560bd0dddc3e
 Fee:        Ada:      Lovelace:  469770
 Mint:       -
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450
+  Destination:  Script: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1
   Value:
-    Ada:      Lovelace:  2500000
+    Ada:      Lovelace:  10000000
   Source:
-    Tx:     dd5fe9c105905d0fde03fded09d9ffc26138e1dcbc982978f6828e9117b6aa58
+    Tx:     5bbba5a7381f485a38b6fdba2bfc1657a22fe78a9fa6b9a603c64ae4320d4535
     Output #0
 
   ---- Input 1 ----
-  Destination:  Script: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450
+  Destination:  Script: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1
   Value:
-    Ada:      Lovelace:  10000000
+    Ada:      Lovelace:  2500000
   Source:
-    Tx:     e7b3a7188ad64c00b7b48f75af4359fdcffa03b6b998f6896618194c5018b951
+    Tx:     c7a3147b0398e169ccb6dfce2eae355322209126c9e32a1a18c6cc62021a1e9d
     Output #0
 
   ---- Input 2 ----
-  Destination:  Script: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450
+  Destination:  Script: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1
   Value:
     Ada:      Lovelace:  10000000
   Source:
-    Tx:     f22ad19506e8360e3fa3deb52c23cd9df14b78639828a18762ed99493c14cdfe
+    Tx:     fb0c6e0323bae8bce2ebd2c2c749ac1f5a9dbe96d28db1f2a9afaa12d5242dfb
     Output #0
 
 
@@ -856,6 +856,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 016307ebfed4ec71e34605fbc2151a22e9eaa310ce3aed53bc481450
+  Script: b40b6dda1c97782a69e5cac5b56f474886cc0333903bd5f2a53104b1
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -550,7 +550,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       554791af2ac99e9cc552ca9ba54986fb7a1b54ca0576859d2311b143d07d097c
+TxId:       e20a4a780de1d51baa93253f2a619f90ad26757cc48b94a20b9c69eed3a7eb08
 Fee:        Ada:      Lovelace:  178173
 Mint:       -
 Inputs:
@@ -573,7 +573,7 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  Script: dc457d55084bd23618630162337ac43b48ac340b96052d67061f8f36
+  Destination:  Script: fdc7d46d3c725a075f1b6b3ed9bad7ac45ce32d18dcf820fb3681abc
   Value:
     Ada:      Lovelace:  8000000
 
@@ -624,6 +624,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: dc457d55084bd23618630162337ac43b48ac340b96052d67061f8f36
+  Script: fdc7d46d3c725a075f1b6b3ed9bad7ac45ce32d18dcf820fb3681abc
   Value:
     Ada:      Lovelace:  8000000

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -550,7 +550,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       47e78dcc833f5dd1b022f2ee96567eefde9f153b213b5ea950fe50f8e20f792f
+TxId:       c54d42adaea3968f162d89f0d877f2811f151ab8fc15fa00d7d4052d8004e6d0
 Fee:        Ada:      Lovelace:  205233
 Mint:       -
 Inputs:
@@ -613,7 +613,7 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  Script: 40cfe3534a528c1b067dcea891c23024caa3cba0a080e327b9173366
+  Destination:  Script: 482a6475b0be6c01a671605c44e48d625a1c73e7b1e06ed8f431b355
   Value:
     Ada:      Lovelace:  60000000
 
@@ -664,27 +664,27 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 40cfe3534a528c1b067dcea891c23024caa3cba0a080e327b9173366
+  Script: 482a6475b0be6c01a671605c44e48d625a1c73e7b1e06ed8f431b355
   Value:
     Ada:      Lovelace:  60000000
 
 ==== Slot #2, Tx #0 ====
-TxId:       d0f514ea6590c9e3e7475f7ca03c43bcd78e1cef77de82d4de5314edb80ba46a
+TxId:       91d04ed2c9f07a24272123a3ee8e4f0f883d4f61c472051d5eff0c2870d8cfa8
 Fee:        Ada:      Lovelace:  445737
 Mint:       -
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 40cfe3534a528c1b067dcea891c23024caa3cba0a080e327b9173366
+  Destination:  Script: 482a6475b0be6c01a671605c44e48d625a1c73e7b1e06ed8f431b355
   Value:
     Ada:      Lovelace:  60000000
   Source:
-    Tx:     47e78dcc833f5dd1b022f2ee96567eefde9f153b213b5ea950fe50f8e20f792f
+    Tx:     c54d42adaea3968f162d89f0d877f2811f151ab8fc15fa00d7d4052d8004e6d0
     Output #0
 
 
 Outputs:
   ---- Output 0 ----
-  Destination:  Script: 40cfe3534a528c1b067dcea891c23024caa3cba0a080e327b9173366
+  Destination:  Script: 482a6475b0be6c01a671605c44e48d625a1c73e7b1e06ed8f431b355
   Value:
     Ada:      Lovelace:  50000000
 
@@ -735,6 +735,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 40cfe3534a528c1b067dcea891c23024caa3cba0a080e327b9173366
+  Script: 482a6475b0be6c01a671605c44e48d625a1c73e7b1e06ed8f431b355
   Value:
     Ada:      Lovelace:  50000000


### PR DESCRIPTION
I chose to implement it as a typeclass implemented by `ScriptContext`s as it doesn't require manipulating an extra type to set the Plutus version and it doesn't require complex type machinery to work (we need to assert `ScriptContext PlutusV1Script ~ PV1.ScriptContext` in some places to use `mkUntyped` functions along with functions that manipulate `ScriptContext`).

The drawback though, is that we often need to specify explicitly the type of context we use to determine the typeclass and the order is different than the one of the parameters, as the type determining the instance needs to be provided first.
A possible mitigation is to provide explicitly the signature of the script function.




<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [x] Important changes are reflected in changelog.d of the affected packages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
