### PR TITLE
Doctests configuration for plutus-ledger

### DIFF
--- a/plutus-ledger/Setup.hs
+++ b/plutus-ledger/Setup.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import Distribution.Extra.Doctest (defaultMainWithDoctests)
+
+main :: IO ()
+main = defaultMainWithDoctests "doctests"

--- a/plutus-ledger/doctests/Doctests.hs
+++ b/plutus-ledger/doctests/Doctests.hs
@@ -1,0 +1,16 @@
+module Main where
+
+import Build_doctests (flags, module_sources, pkgs)
+import Data.Foldable (traverse_)
+import System.Environment (unsetEnv)
+import Test.DocTest (doctest)
+
+main :: IO ()
+main = do
+  putStrLn ""
+  traverse_ putStrLn args -- optionally print arguments
+  unsetEnv "GHC_ENVIRONMENT" -- see 'Notes'; you may not need this
+  doctest args
+  where
+    args :: [String]
+    args = flags ++ pkgs ++ module_sources -- ++ ["-v"]

--- a/plutus-ledger/plutus-ledger.cabal
+++ b/plutus-ledger/plutus-ledger.cabal
@@ -11,8 +11,14 @@ author:          Michael Peyton Jones, Jann Mueller
 synopsis:        Wallet API
 description:     Plutus ledger library
 category:        Language
-build-type:      Simple
+build-type:      Custom
 extra-doc-files: README.md
+
+custom-setup
+  setup-depends:
+    , base           >=4 && <5
+    , Cabal
+    , cabal-doctest  ^>=1
 
 source-repository head
   type:     git
@@ -111,6 +117,7 @@ library
   other-modules:
     Codec.CBOR.Extras
     Ledger.Tx.CardanoAPITemp
+    Paths_plutus_ledger
 
   --------------------
   -- Local components
@@ -222,3 +229,15 @@ test-suite plutus-ledger-test
     , tasty
     , tasty-hedgehog
     , tasty-hunit
+
+test-suite doctests
+  hs-source-dirs:    doctests
+  x-doctest-options: --no-magic
+  type:              exitcode-stdio-1.0
+  main-is:           Doctests.hs
+  ghc-options:       -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+    , base     >=4.7 && <5
+    , doctest
+
+  default-language:  Haskell2010

--- a/plutus-ledger/src/Ledger/Ada.hs
+++ b/plutus-ledger/src/Ledger/Ada.hs
@@ -124,5 +124,11 @@ divide (Lovelace a) (Lovelace b) = Lovelace (P.divide a b)
 
 {-# INLINABLE isZero #-}
 -- | Check whether an 'Ada' value is zero.
+--
+-- >>> isZero $ lovelaceOf 1
+-- False
+--
+-- >>> isZero $ lovelaceOf 0
+-- True
 isZero :: Ada -> Bool
 isZero (Lovelace i) = i == 0


### PR DESCRIPTION
Was able to get doctests working following the example here: https://github.com/input-output-hk/haskell.nix/tree/master/test/cabal-doctests

This PR only activates it for `plutus-ledger`.

The only thing I need to verify is that we don't need to add dependencies in plutus-ledger lib for modules only used in doctests.

EDIT:

Cool! Using dependencies like `generic-arbitrary`  don't need to be added to the `cardano-ledger` lib, only in the `doctests` test-suite.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
