### PR TITLE
Fix computeRefinedCoverageIndex resulting in extra coverage annotations

### DIFF
--- a/plutus-use-cases/src/Plutus/Contracts/GameStateMachine.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/GameStateMachine.hs
@@ -44,7 +44,7 @@ import Control.Monad (void)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.ByteString.Char8 qualified as C
 import GHC.Generics (Generic)
-import Ledger (Address, POSIXTime, ScriptContext, TokenName, Value)
+import Ledger (Address, POSIXTime, TokenName, Value)
 import Ledger.Ada qualified as Ada
 import Ledger.Address.Orphans ()
 import Ledger.Constraints (TxConstraints)
@@ -261,11 +261,8 @@ guess = endpoint @"guess" $ \GuessArgs{guessArgsGameParam, guessTokenTarget, gue
         $ SM.runStep (client guessArgsGameParam)
             (Guess guessTokenTarget guessedSecret newSecret guessArgsValueTakenOut)
 
-cc :: PlutusTx.CompiledCode (GameParam -> GameState -> GameInput -> ScriptContext -> ())
-cc = $$(PlutusTx.compile [|| \a b c d -> check (mkValidator a b c d) ||])
-
 covIdx :: CoverageIndex
-covIdx = computeRefinedCoverageIndex cc
+covIdx = $refinedCoverageIndex $$(PlutusTx.compile [|| \a b c d -> check (mkValidator a b c d) ||])
 
 PlutusTx.unstableMakeIsData ''GameState
 PlutusTx.makeLift ''GameState

--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
@@ -55,11 +55,10 @@ import Plutus.Contracts.Uniswap.Pool
 import Plutus.Contracts.Uniswap.Types
 import Plutus.Script.Utils.V1.Address (mkValidatorCardanoAddress)
 import Plutus.Script.Utils.V1.Scripts (scriptCurrencySymbol)
-import Plutus.V1.Ledger.Api (CurrencySymbol, Datum (Datum), DatumHash, MintingPolicy, Redeemer (Redeemer),
-                             ScriptContext, Validator, Value)
+import Plutus.V1.Ledger.Api (CurrencySymbol, Datum (Datum), DatumHash, MintingPolicy, Redeemer (Redeemer), Validator,
+                             Value)
 import Plutus.V1.Ledger.Scripts (mkMintingPolicyScript)
 import PlutusTx qualified
-import PlutusTx.Code
 import PlutusTx.Coverage
 import PlutusTx.Prelude hiding (Semigroup (..), dropWhile, flip, unless)
 import Prelude as Haskell (Int, Semigroup (..), String, div, dropWhile, flip, show, (^))
@@ -127,17 +126,8 @@ liquidityPolicy us = mkMintingPolicyScript $
         `PlutusTx.applyCode` PlutusTx.liftCode us
         `PlutusTx.applyCode` PlutusTx.liftCode poolStateTokenName
 
-cc :: CompiledCode
-        (Uniswap
-         -> Coin PoolState
-         -> UniswapDatum
-         -> UniswapAction
-         -> ScriptContext
-         -> ())
-cc = $$(PlutusTx.compile [|| \u s r d c -> check $ mkUniswapValidator u s r d c ||])
-
 covIdx :: CoverageIndex
-covIdx = computeRefinedCoverageIndex cc
+covIdx = $refinedCoverageIndex $$(PlutusTx.compile [|| \u s r d c -> check $ mkUniswapValidator u s r d c ||])
 
 liquidityCurrency :: Uniswap -> CurrencySymbol
 liquidityCurrency = scriptCurrencySymbol . liquidityPolicy

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -550,7 +550,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       8083069715989b5cea2ecc0f0236f881af919baf980598519021057d02fb08b5
+TxId:       a1ef6b1e1f038caa7d2ca7eceb42679ba32a0aecd6d3e44be45753e1077d4a2b
 Fee:        Ada:      Lovelace:  178173
 Mint:       -
 Inputs:
@@ -573,7 +573,7 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  Script: 60bbffa967a7a644589aa75f3d1f88f399496730b70fc908393330d6
+  Destination:  Script: 26c99c353344ef5f5fdd12bb3f5bb94710176617892a809d9596c7a9
   Value:
     Ada:      Lovelace:  8000000
 
@@ -624,6 +624,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 60bbffa967a7a644589aa75f3d1f88f399496730b70fc908393330d6
+  Script: 26c99c353344ef5f5fdd12bb3f5bb94710176617892a809d9596c7a9
   Value:
     Ada:      Lovelace:  8000000


### PR DESCRIPTION
This PR introduces a hack to get around the issue whereby `computeRefinedCoverageIndex` introduces spurious unreachable coverage annotations.