### PR TITLE
PLT-856 use Cardano transactions in MockNode instead of EmulatorTx

### DIFF
--- a/plutus-chain-index-core/changelog.d/20230103_172918_nicolas.biri_PLT_856.md
+++ b/plutus-chain-index-core/changelog.d/20230103_172918_nicolas.biri_PLT_856.md
@@ -1,0 +1,3 @@
+### Changed
+
+- We now use `cardano-node` `Tx` type instead of the one of `plutus-ledger`.

--- a/plutus-contract/test/Spec/Emulator.hs
+++ b/plutus-contract/test/Spec/Emulator.hs
@@ -19,6 +19,7 @@ import Cardano.Node.Emulator.Generators (Mockchain (Mockchain))
 import Cardano.Node.Emulator.Generators qualified as Gen
 import Cardano.Node.Emulator.Params (Params (Params, pNetworkId))
 import Cardano.Node.Emulator.Validation qualified as Validation
+import Control.Applicative (Alternative)
 import Control.Lens ((&), (.~), (^.))
 import Control.Monad (void)
 import Control.Monad.Freer qualified as Eff
@@ -313,7 +314,7 @@ evalEmulatorTraceTest = property $ do
     Hedgehog.annotateShow res
     Hedgehog.assert (either (const False) (const True) res)
 
-genChainTxn :: Hedgehog.MonadGen m => m (Mockchain, CardanoTx)
+genChainTxn :: Alternative m => Hedgehog.MonadGen m => m (Mockchain, CardanoTx)
 genChainTxn = do
     m <- Gen.genMockchain
     txn <- Gen.genValidTransaction m

--- a/plutus-pab-executables/changelog.d/20230103_170014_nicolas.biri_PLT_856.rst
+++ b/plutus-pab-executables/changelog.d/20230103_170014_nicolas.biri_PLT_856.rst
@@ -1,0 +1,4 @@
+Changed
+-------
+
+- `tx-inject` now uses `Tx` from `cardano-node`

--- a/plutus-pab-executables/plutus-pab-executables.cabal
+++ b/plutus-pab-executables/plutus-pab-executables.cabal
@@ -445,6 +445,7 @@ executable tx-inject
   -- Local components
   --------------------
   build-depends:
+    , cardano-api            >=1.35
     , cardano-node-emulator  >=1.0.0
     , plutus-contract        >=1.0.0
     , plutus-ledger          >=1.0.0

--- a/plutus-pab/plutus-pab.cabal
+++ b/plutus-pab/plutus-pab.cabal
@@ -157,6 +157,7 @@ library
     , ouroboros-network-framework
     , plutus-ledger-api                >=1.0.0
     , plutus-tx                        >=1.0.0
+    , plutus-tx-plugin                 >=1.0.0
     , Win32-network
 
   ------------------------

--- a/plutus-pab/plutus-pab.cabal
+++ b/plutus-pab/plutus-pab.cabal
@@ -157,7 +157,6 @@ library
     , ouroboros-network-framework
     , plutus-ledger-api                >=1.0.0
     , plutus-tx                        >=1.0.0
-    , plutus-tx-plugin                 >=1.0.0
     , Win32-network
 
   ------------------------

--- a/plutus-pab/src/Cardano/Node/Client.hs
+++ b/plutus-pab/src/Cardano/Node/Client.hs
@@ -14,7 +14,7 @@ import Control.Monad.Freer.Error (Error, throwError)
 import Control.Monad.Freer.Reader (Reader, ask)
 import Control.Monad.IO.Class
 import Data.Proxy (Proxy (Proxy))
-import Ledger (onCardanoTx)
+import Ledger (SomeCardanoApiTx (CardanoApiEmulatorEraTx), onCardanoTx)
 import Servant (NoContent, (:<|>) (..))
 import Servant.Client (ClientM, client)
 
@@ -61,8 +61,8 @@ handleNodeClientClient params e = do
                   throwError TxSenderNotAvailable
               Just handle ->
                   liftIO $
-                      onCardanoTx (MockClient.queueTx handle)
-                                  (const $ error "Cardano.Node.Client: Expecting a mock tx, not a cardano-api tx when publishing it.")
+                      onCardanoTx (const $ error "Cardano.Node.Client: Expecting a cardano-api tx, not a mock when publishing it.")
+                                  (MockClient.queueTx handle . (\(CardanoApiEmulatorEraTx c) -> c))
                                   tx
         GetClientSlot ->
             either (liftIO . MockClient.getCurrentSlot)

--- a/plutus-pab/src/Cardano/Node/Mock.hs
+++ b/plutus-pab/src/Cardano/Node/Mock.hs
@@ -26,6 +26,7 @@ import Data.Time.Units (Millisecond, toMicroseconds)
 import Data.Time.Units.Extra ()
 import Servant (NoContent (NoContent))
 
+import Cardano.Api qualified as C
 import Cardano.BM.Data.Trace (Trace)
 import Cardano.Chain (handleChain, handleControlChain)
 import Cardano.Node.Emulator.Chain qualified as Chain
@@ -34,7 +35,6 @@ import Cardano.Node.Emulator.TimeSlot (SlotConfig (SlotConfig, scSlotLength), cu
 import Cardano.Node.Types
 import Cardano.Protocol.Socket.Mock.Client qualified as Client
 import Cardano.Protocol.Socket.Mock.Server qualified as Server
-import Ledger (Tx)
 import Plutus.PAB.Arbitrary ()
 import Plutus.PAB.Monitoring.Monitoring qualified as LM
 
@@ -56,7 +56,7 @@ addTx ::
     , MonadIO m
     , LastMember m effs
     )
- => Tx -> Eff effs NoContent
+ => C.Tx C.BabbageEra -> Eff effs NoContent
 addTx tx = do
     logInfo $ BlockOperation $ NewTransaction tx
     clientHandler <- Eff.ask

--- a/plutus-pab/src/Cardano/Node/Types.hs
+++ b/plutus-pab/src/Cardano/Node/Types.hs
@@ -60,8 +60,7 @@ import Control.Monad.Freer.Extras.Log (LogMessage, LogMsg)
 import Control.Monad.Freer.Reader (Reader)
 import Control.Monad.Freer.State (State)
 import Control.Monad.IO.Class (MonadIO)
-import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), Value (Object), object, (.:), (.=))
-import Data.Aeson.Types (parseFail, prependFailure, typeMismatch)
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Default (Default, def)
 import Data.Either (fromRight)
 import Data.Map qualified as Map
@@ -224,20 +223,6 @@ instance ToObject PABServerLogMsg where
         BlockOperation e          ->  mkObjectStr "Block operation" (Tagged @"event" e)
         CreatingRandomTransaction ->  mkObjectStr "Creating random transaction" ()
         TxSendCalledWithoutMock   ->  mkObjectStr "Cannot send transaction without a mocked environment." ()
-
-instance ToJSON (C.Tx C.BabbageEra) where
-  toJSON tx =
-    object [ "tx" .= C.serialiseToTextEnvelope Nothing tx ]
-
-instance FromJSON (C.Tx C.BabbageEra) where
-  parseJSON (Object v) = do
-   envelope <- v .: "tx"
-   either (const $ parseFail "Failed to parse BabbageEra 'tx' field from SomeCardanoApiTx")
-          pure
-          $ C.deserialiseFromTextEnvelope (C.AsTx C.AsBabbageEra) envelope
-  parseJSON invalid =
-    prependFailure "parsing SomeCardanoApiTx failed, " (typeMismatch "Object" invalid)
-
 
 data BlockEvent = NewSlot
     | NewTransaction (C.Tx C.BabbageEra)


### PR DESCRIPTION
I decided to keep the generation of a cardano Tx (required by `tx-inject`) out of the scope of this PR to keep an atomic change. So in `tx-inject`, we're still generating emulator tx and then creating a Cardano Tx from it when we sign it.
It could be changed if needed later in the migration.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x]  Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
