### PR TITLE
PLT-1205 improve the performance of `fromOnChainTx`

### DIFF
--- a/plutus-contract/src/Plutus/Contract/StateMachine/OnChain.hs
+++ b/plutus-contract/src/Plutus/Contract/StateMachine/OnChain.hs
@@ -133,8 +133,9 @@ mkValidator (StateMachine step isFinal check threadToken) currentState input ptx
                 | otherwise ->
                     let -- Check that the thread token value is still there
                         valueWithToken = newValue <> threadTokenValueInner threadToken (ownHash ptx)
-                        constraint = mustPayToTheScriptWithDatumInTx newData valueWithToken
-                        -- Overwrite `txOwnOutputs` to change the output type
+                        -- Type annotation is required to compile validator when profiling is activated.
+                        -- If 'Void' is not explicitly set, the plutus plugin can't handle the free type variable.
+                        constraint = mustPayToTheScriptWithDatumInTx @s @Void newData valueWithToken
                         txc = newConstraints { txOwnOutputs = txOwnOutputs constraint }
                     in traceIfFalse "S5" {-"State transition invalid - constraints not satisfied by ScriptContext"-} (checkScriptContext @_ @s txc ptx)
             Nothing -> trace "S6" {-"State transition invalid - input is not a valid transition at the current state"-} False

--- a/plutus-ledger/src/Ledger/Tx/CardanoAPI/Internal.hs
+++ b/plutus-ledger/src/Ledger/Tx/CardanoAPI/Internal.hs
@@ -395,13 +395,19 @@ fromLedgerScript C.ShelleyBasedEraBabbage script = fromLedgerPlutusScript script
 fromLedgerPlutusScript :: Alonzo.Script a -> Maybe (P.ScriptHash, P.Versioned P.Script)
 fromLedgerPlutusScript Alonzo.TimelockScript {} = Nothing
 fromLedgerPlutusScript (Alonzo.PlutusScript Alonzo.PlutusV1 bs) =
-  let script = fmap (\s -> (PV1.scriptHash s, P.Versioned s P.PlutusV1))
+  let hash = PV1.fromCardanoHash
+           $ C.hashScript
+           $ C.PlutusScript C.PlutusScriptV1 $ C.PlutusScriptSerialised bs
+      script = fmap (\s -> (hash, P.Versioned s P.PlutusV1))
              $ deserialiseOrFail
              $ BSL.fromStrict
              $ SBS.fromShort bs
-   in either (const Nothing) Just script
+  in either (const Nothing) Just script
 fromLedgerPlutusScript (Alonzo.PlutusScript Alonzo.PlutusV2 bs) =
-  let script = fmap (\s -> (PV2.scriptHash s, P.Versioned s P.PlutusV2))
+  let hash = PV1.fromCardanoHash
+           $ C.hashScript
+           $ C.PlutusScript C.PlutusScriptV2 $ C.PlutusScriptSerialised bs
+      script = fmap (\s -> (hash, P.Versioned s P.PlutusV2))
              $ deserialiseOrFail
              $ BSL.fromStrict
              $ SBS.fromShort bs

--- a/plutus-script-utils/src/Plutus/Script/Utils/Typed.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/Typed.hs
@@ -193,8 +193,7 @@ class PV1.UnsafeFromData sc => IsScriptContext sc where
     -- Thus, if a parameter can't be decoded, the culprit is the first parameter in the list that doesn't appear as
     -- successfully decoded in the log trace.
     mkUntypedValidator
-        :: forall d r
-        . (PV1.UnsafeFromData d, PV1.UnsafeFromData r)
+        :: (PV1.UnsafeFromData d, PV1.UnsafeFromData r)
         => (d -> r -> sc -> Bool)
         -> UntypedValidator
     -- We can use unsafeFromBuiltinData here as we would fail immediately anyway if parsing failed

--- a/plutus-script-utils/src/Plutus/Script/Utils/V1/Scripts.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V1/Scripts.hs
@@ -13,6 +13,7 @@ module Plutus.Script.Utils.V1.Scripts
     , PV1.MintingPolicyHash
     , PV1.StakeValidator
     , PV1.StakeValidatorHash
+    , fromCardanoHash
     , validatorHash
     , mintingPolicyHash
     , stakeValidatorHash
@@ -22,6 +23,7 @@ module Plutus.Script.Utils.V1.Scripts
     , toCardanoApiScript
     ) where
 
+import Cardano.Api qualified as C
 import Cardano.Api qualified as Script
 import Cardano.Api.Shelley qualified as Script
 import Codec.Serialise (serialise)
@@ -58,11 +60,16 @@ stakeValidatorHash =
 -- | Hash a 'Script'
 scriptHash :: PV1.Script -> PV1.ScriptHash
 scriptHash =
+    fromCardanoHash
+    . Script.hashScript
+    . toCardanoApiScript
+
+-- | Transform a Cardano Script hash in a Plutus Script hash
+fromCardanoHash :: C.ScriptHash -> PV1.ScriptHash
+fromCardanoHash =
     PV1.ScriptHash
     . Builtins.toBuiltin
     . Script.serialiseToRawBytes
-    . Script.hashScript
-    . toCardanoApiScript
 
 -- | Convert a 'Script' to a 'cardano-api' script.
 --


### PR DESCRIPTION
We can avoid serialising and unserialising again to compute a hash.
The deserialisation of the script is costly too, but it's harder to avoid. We could keep both version using `These` and compute them on demand, but I'm not sure if it worth the effort.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
