### PR TITLE
Threat modelling framework

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -154,7 +154,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/Quviq/quickcheck-contractmodel
-    tag: 462f8c25bea15f88e179e12ebf4e3a4ffcc92d18
+    tag: bc7718aa0b916369b6759b46658fc2f45c7eb4c7
     subdir:
       contractmodel
 

--- a/cabal.project
+++ b/cabal.project
@@ -154,7 +154,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/Quviq/quickcheck-contractmodel
-    tag: bc7718aa0b916369b6759b46658fc2f45c7eb4c7
+    tag: 6a9513c23c23717e31c55383bea46eea5d0c4343
     subdir:
       contractmodel
 

--- a/cabal.project
+++ b/cabal.project
@@ -154,7 +154,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/Quviq/quickcheck-contractmodel
-    tag: 6a9513c23c23717e31c55383bea46eea5d0c4343
+    tag: 5cd16ba995f1cd48c2b5f885c702ca6f2a2abbaa
     subdir:
       contractmodel
 

--- a/nix/pkgs/haskell/sha256map.nix
+++ b/nix/pkgs/haskell/sha256map.nix
@@ -3,6 +3,6 @@
   "https://github.com/input-output-hk/cardano-config"."1646e9167fab36c0bff82317743b96efa2d3adaa" = "sha256-TNbpnR7llUgBN2WY7CryMxNVupBIUH01h1hRNHoxboY=";
   "https://github.com/input-output-hk/cardano-ledger"."da3e9ae10cf9ef0b805a046c84745f06643583c2" = "sha256-3VUZKkLu1R43GUk9IwgsGQ55O0rnu8NrCkFX9gqA4ck=";
   "https://github.com/input-output-hk/cardano-wallet"."18a931648550246695c790578d4a55ee2f10463e" = "0i40hp1mdbljjcj4pn3n6zahblkb2jmpm8l4wnb36bya1pzf66fx";
-  "https://github.com/Quviq/quickcheck-contractmodel"."462f8c25bea15f88e179e12ebf4e3a4ffcc92d18" = "sha256-0NXBaWLGL5Hoz/A/yLIh5NZ4F5tqQUScB4Tr5u1Wg1Y=";
+  "https://github.com/Quviq/quickcheck-contractmodel"."bc7718aa0b916369b6759b46658fc2f45c7eb4c7" = "sha256-BNwmomu9kuMSFnTt9U7eqcxiqoGxjShU0m0xO2pc4ns=";
   "https://github.com/sevanspowell/hw-aeson"."b5ef03a7d7443fcd6217ed88c335f0c411a05408" = "1dwx90wqavdl4d0npbzbxyh2pzi9zs1qz7nvsrb3n1cm2xbv4i5z";
 }

--- a/nix/pkgs/haskell/sha256map.nix
+++ b/nix/pkgs/haskell/sha256map.nix
@@ -3,6 +3,6 @@
   "https://github.com/input-output-hk/cardano-config"."1646e9167fab36c0bff82317743b96efa2d3adaa" = "sha256-TNbpnR7llUgBN2WY7CryMxNVupBIUH01h1hRNHoxboY=";
   "https://github.com/input-output-hk/cardano-ledger"."da3e9ae10cf9ef0b805a046c84745f06643583c2" = "sha256-3VUZKkLu1R43GUk9IwgsGQ55O0rnu8NrCkFX9gqA4ck=";
   "https://github.com/input-output-hk/cardano-wallet"."18a931648550246695c790578d4a55ee2f10463e" = "0i40hp1mdbljjcj4pn3n6zahblkb2jmpm8l4wnb36bya1pzf66fx";
-  "https://github.com/Quviq/quickcheck-contractmodel"."bc7718aa0b916369b6759b46658fc2f45c7eb4c7" = "sha256-BNwmomu9kuMSFnTt9U7eqcxiqoGxjShU0m0xO2pc4ns=";
+  "https://github.com/Quviq/quickcheck-contractmodel"."6a9513c23c23717e31c55383bea46eea5d0c4343" = "sha256-lLFxixWlD6FfQKX+DeDQmEN6m5cgeJeyTk1sy00FsLM=";
   "https://github.com/sevanspowell/hw-aeson"."b5ef03a7d7443fcd6217ed88c335f0c411a05408" = "1dwx90wqavdl4d0npbzbxyh2pzi9zs1qz7nvsrb3n1cm2xbv4i5z";
 }

--- a/nix/pkgs/haskell/sha256map.nix
+++ b/nix/pkgs/haskell/sha256map.nix
@@ -3,6 +3,6 @@
   "https://github.com/input-output-hk/cardano-config"."1646e9167fab36c0bff82317743b96efa2d3adaa" = "sha256-TNbpnR7llUgBN2WY7CryMxNVupBIUH01h1hRNHoxboY=";
   "https://github.com/input-output-hk/cardano-ledger"."da3e9ae10cf9ef0b805a046c84745f06643583c2" = "sha256-3VUZKkLu1R43GUk9IwgsGQ55O0rnu8NrCkFX9gqA4ck=";
   "https://github.com/input-output-hk/cardano-wallet"."18a931648550246695c790578d4a55ee2f10463e" = "0i40hp1mdbljjcj4pn3n6zahblkb2jmpm8l4wnb36bya1pzf66fx";
-  "https://github.com/Quviq/quickcheck-contractmodel"."6a9513c23c23717e31c55383bea46eea5d0c4343" = "sha256-lLFxixWlD6FfQKX+DeDQmEN6m5cgeJeyTk1sy00FsLM=";
+  "https://github.com/Quviq/quickcheck-contractmodel"."5cd16ba995f1cd48c2b5f885c702ca6f2a2abbaa" = "sha256-rVVdr68f+xEOV4s27Ix+wdBznSVFvq+Q2ZBo0SEnkp0=";
   "https://github.com/sevanspowell/hw-aeson"."b5ef03a7d7443fcd6217ed88c335f0c411a05408" = "1dwx90wqavdl4d0npbzbxyh2pzi9zs1qz7nvsrb3n1cm2xbv4i5z";
 }

--- a/plutus-contract/src/Plutus/Contract/Test/ContractModel/Interface.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/ContractModel/Interface.hs
@@ -68,6 +68,8 @@ module Plutus.Contract.Test.ContractModel.Interface
     , SpecificationEmulatorTrace
     , registerToken
     , delay
+    , fromSlotNo
+    , toSlotNo
 
     -- * Test scenarios
     --
@@ -117,6 +119,8 @@ module Plutus.Contract.Test.ContractModel.Interface
     , propRunActions
     , propRunActionsWithOptions
     , CMI.defaultCheckOptionsContractModel
+    , CMI.checkThreatModel
+    , CMI.checkThreatModelWithOptions
     -- ** DL properties
     , QCCM.forAllDL
     , QCCM.forAllDL_
@@ -185,7 +189,7 @@ import Test.QuickCheck qualified as QC
 import Plutus.Contract.Test.ContractModel.Internal qualified as CMI
 import Plutus.Contract.Test.Coverage as Coverage
 import Test.QuickCheck.ContractModel qualified as QCCM
-import Test.QuickCheck.ContractModel.ThreatModel qualified as QCCM
+import Test.QuickCheck.ContractModel.ThreatModel.DoubleSatisfaction qualified as QCCM
 import Test.QuickCheck.DynamicLogic qualified as QCD
 
 -- | A function returning the `ContractHandle` corresponding to a `ContractInstanceKey`. A
@@ -631,7 +635,7 @@ checkDoubleSatisfactionWithOptions :: forall m. ContractModel m
                                    -> Actions m
                                    -> Property
 checkDoubleSatisfactionWithOptions opts covopts acts =
-  CMI.propRunActionsWithOptions opts covopts (\ _ -> TracePredicate $ pure True) (CMI.threatModelPredicate QCCM.doubleSatisfaction) acts
+  CMI.checkThreatModelWithOptions opts covopts QCCM.doubleSatisfaction acts
 
 instance QCCM.HasSymTokens Wallet where
   getAllSymTokens _ = mempty

--- a/plutus-contract/src/Plutus/Contract/Test/ContractModel/Interface.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/ContractModel/Interface.hs
@@ -185,6 +185,7 @@ import Test.QuickCheck qualified as QC
 import Plutus.Contract.Test.ContractModel.Internal qualified as CMI
 import Plutus.Contract.Test.Coverage as Coverage
 import Test.QuickCheck.ContractModel qualified as QCCM
+import Test.QuickCheck.ContractModel.ThreatModel qualified as QCCM
 import Test.QuickCheck.DynamicLogic qualified as QCD
 
 -- | A function returning the `ContractHandle` corresponding to a `ContractInstanceKey`. A
@@ -529,7 +530,7 @@ propRunActionsWithOptions ::
     -> Actions state                              -- ^ The actions to run
     -> Property
 propRunActionsWithOptions opts copts predicate actions =
-  CMI.propRunActionsWithOptions opts copts (predicate . fmap coerce) actions
+  CMI.propRunActionsWithOptions opts copts (predicate . fmap coerce) CMI.balanceChangePredicate actions
 
 -- | Sanity check a `ContractModel`. Ensures that wallet balances are not always unchanged.
 propSanityCheckModel :: forall state. ContractModel state => Property
@@ -629,7 +630,8 @@ checkDoubleSatisfactionWithOptions :: forall m. ContractModel m
                                    -> CMI.CoverageOptions
                                    -> Actions m
                                    -> Property
-checkDoubleSatisfactionWithOptions _opts _covopts _acts = error "TODO"
+checkDoubleSatisfactionWithOptions opts covopts acts =
+  CMI.propRunActionsWithOptions opts covopts (\ _ -> TracePredicate $ pure True) (CMI.threatModelPredicate QCCM.doubleSatisfaction) acts
 
 instance QCCM.HasSymTokens Wallet where
   getAllSymTokens _ = mempty

--- a/plutus-contract/src/Plutus/Contract/Test/ContractModel/Internal.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/ContractModel/Internal.hs
@@ -69,6 +69,7 @@ import GHC.Generics
 
 import Cardano.Api (AssetId, SlotNo (..))
 import Cardano.Api qualified as CardanoAPI
+import Cardano.Api.Shelley (ProtocolParameters)
 import Cardano.Crypto.Hash.Class qualified as Crypto
 import Cardano.Node.Emulator.Params ()
 import Ledger.Address
@@ -91,6 +92,8 @@ import Test.QuickCheck.StateModel qualified as StateModel
 import Test.QuickCheck hiding (ShrinkState, checkCoverage, getSize, (.&&.), (.||.))
 import Test.QuickCheck qualified as QC
 import Test.QuickCheck.ContractModel as CM
+import Test.QuickCheck.ContractModel.Internal (ContractModelResult)
+import Test.QuickCheck.ContractModel.ThreatModel (ThreatModel, assertThreatModel)
 import Test.QuickCheck.Monadic (PropertyM, monadic)
 import Test.QuickCheck.Monadic qualified as QC
 
@@ -335,6 +338,22 @@ quickCheckWithCoverageAndResult qcargs copts prop = do
       when (chatty qcargs) $ putStrLn . show $ pretty report
       return (report, res)
 
+balanceChangePredicate :: ProtocolParameters -> ContractModelResult state -> Property
+balanceChangePredicate ps result =
+  let prettyAddr a = maybe (show a) show $ addressToWallet a
+  in assertBalanceChangesMatch (BalanceChangeOptions False signerPaysFees ps prettyAddr) result
+
+threatModelPredicate :: ThreatModel a -> ProtocolParameters -> ContractModelResult state -> Property
+threatModelPredicate m ps result = assertThreatModel ps m result
+
+checkThreatModel ::
+    CheckableContractModel state
+    => Actions (WithInstances state)                 -- ^ The actions to run
+    -> ThreatModel a
+    -> Property
+checkThreatModel actions m =
+    propRunActions (\ _ -> pure True) (threatModelPredicate m) actions
+
 -- | Run a `Actions` in the emulator and check that the model and the emulator agree on the final
 --   wallet balance changes. Equivalent to
 --
@@ -346,7 +365,7 @@ propRunActions_ ::
     => Actions (WithInstances state)                 -- ^ The actions to run
     -> Property
 propRunActions_ actions =
-    propRunActions (\ _ -> pure True) actions
+    propRunActions (\ _ -> pure True) balanceChangePredicate actions
 
 -- | Run a `Actions` in the emulator and check that the model and the emulator agree on the final
 --   wallet balance changes, and that the given `TracePredicate` holds at the end. Equivalent to:
@@ -357,31 +376,32 @@ propRunActions_ actions =
 propRunActions ::
     CheckableContractModel state
     => (ModelState (WithInstances state) -> TracePredicate) -- ^ Predicate to check at the end
+    -> (ProtocolParameters -> ContractModelResult (WithInstances state) -> Property) -- ^ Predicate to run on the contract model
     -> Actions (WithInstances state)                        -- ^ The actions to run
     -> Property
 propRunActions = propRunActionsWithOptions defaultCheckOptionsContractModel defaultCoverageOptions
+
 
 propRunActionsWithOptions :: forall state.
     CheckableContractModel state
     => CheckOptions                                         -- ^ Emulator options
     -> CoverageOptions                                      -- ^ Coverage options
     -> (ModelState (WithInstances state) -> TracePredicate) -- ^ Predicate to check at the end of execution
+    -> (ProtocolParameters -> ContractModelResult (WithInstances state) -> Property) -- ^ Predicate to run on the contract model
     -> Actions (WithInstances state)                        -- ^ The actions to run
     -> Property
-propRunActionsWithOptions opts copts predicate actions =
+propRunActionsWithOptions opts copts predicate contractmodelPredicate actions =
     asserts finalState QC..&&.
     monadic runFinalPredicate monadicPredicate
     where
         finalState = stateAfter actions
-
-        prettyAddr a = maybe (show a) show $ addressToWallet a
 
         monadicPredicate :: PropertyM (RunMonad (EmulatorTraceWithInstances state)) Property
         monadicPredicate = do
             ps <- QC.run . lift $ fmap pProtocolParams EmulatorControl.getParams
             QC.run . lift $ activateWallets (\ _ -> error "No SymTokens yet") initialInstances
             result <- runContractModel actions
-            pure $ assertBalanceChangesMatch (BalanceChangeOptions False signerPaysFees ps prettyAddr) result
+            pure $ contractmodelPredicate ps result
 
         runFinalPredicate :: RunMonad (EmulatorTraceWithInstances state) Property
                           -> Property
@@ -485,7 +505,7 @@ checkNoLockedFundsProofWithOptions
 checkNoLockedFundsProofWithOptions options =
   checkNoLockedFundsProof' prop
   where
-    prop = propRunActionsWithOptions options defaultCoverageOptions (\ _ -> TracePredicate $ pure True)
+    prop = propRunActionsWithOptions options defaultCoverageOptions (\ _ -> TracePredicate $ pure True) balanceChangePredicate
 
 checkNoLockedFundsProofFastWithOptions
   :: CheckableContractModel model
@@ -574,6 +594,7 @@ checkNoLockedFundsProofLight NoLockedFundsProofLight{nlfplMainStrategy = mainStr
     nextVarIdx as = 1 + maximum ([0] ++ [ i | StateModel.Var i <- varOf <$> as ])
     run = propRunActionsWithOptions defaultCheckOptionsContractModel
                                     defaultCoverageOptions (\ _ -> TracePredicate $ pure True)
+                                    balanceChangePredicate
 
 -- | A whitelist entry tells you what final log entry prefixes
 -- are acceptable for a given error
@@ -634,7 +655,7 @@ checkErrorWhitelistWithOptions :: forall m.
                                -> Actions (WithInstances m)
                                -> Property
 checkErrorWhitelistWithOptions opts copts whitelist =
-  propRunActionsWithOptions opts copts (const check)
+  propRunActionsWithOptions opts copts (const check) balanceChangePredicate
   where
     check :: TracePredicate
     check = checkOnchain .&&. (assertNoFailedTransactions .||. checkOffchain)

--- a/plutus-contract/src/Plutus/Contract/Test/ContractModel/Internal.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/ContractModel/Internal.hs
@@ -344,15 +344,26 @@ balanceChangePredicate ps result =
   in assertBalanceChangesMatch (BalanceChangeOptions False signerPaysFees ps prettyAddr) result
 
 threatModelPredicate :: ThreatModel a -> ProtocolParameters -> ContractModelResult state -> Property
-threatModelPredicate m ps result = assertThreatModel ps m result
+threatModelPredicate m ps result = assertThreatModel m ps result
 
+-- | Check a threat model on all transactions produced by the given actions.
 checkThreatModel ::
     CheckableContractModel state
-    => Actions (WithInstances state)                 -- ^ The actions to run
-    -> ThreatModel a
+    => ThreatModel a
+    -> Actions (WithInstances state)                 -- ^ The actions to run
     -> Property
-checkThreatModel actions m =
-    propRunActions (\ _ -> pure True) (threatModelPredicate m) actions
+checkThreatModel = checkThreatModelWithOptions defaultCheckOptionsContractModel defaultCoverageOptions
+
+-- | Check a threat model on all transactions produced by the given actions.
+checkThreatModelWithOptions ::
+    CheckableContractModel state
+    => CheckOptions                                  -- ^ Emulator options
+    -> CoverageOptions                               -- ^ Coverage options
+    -> ThreatModel a
+    -> Actions (WithInstances state)                 -- ^ The actions to run
+    -> Property
+checkThreatModelWithOptions opts covopts m actions =
+  propRunActionsWithOptions opts covopts (\ _ -> pure True) (threatModelPredicate m) actions
 
 -- | Run a `Actions` in the emulator and check that the model and the emulator agree on the final
 --   wallet balance changes. Equivalent to

--- a/plutus-script-utils/src/Plutus/Script/Utils/Typed.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/Typed.hs
@@ -13,6 +13,7 @@ module Plutus.Script.Utils.Typed (
   , TypedValidator (..)
   , validatorHash
   , validatorCardanoAddress
+  , validatorCardanoAddressAny
   , validatorAddress
   , validatorScript
   , vValidatorScript
@@ -98,6 +99,12 @@ validatorCardanoAddress networkId tv =
   in case version validator of
           PlutusV1 -> PSU.PV1.mkValidatorCardanoAddress networkId $ unversioned validator
           PlutusV2 -> PSU.PV2.mkValidatorCardanoAddress networkId $ unversioned validator
+
+validatorCardanoAddressAny :: C.NetworkId -> TypedValidator a -> C.AddressAny
+validatorCardanoAddressAny nid tv =
+  case validatorCardanoAddress nid tv of
+    C.AddressInEra C.ShelleyAddressInEra{} addr  -> C.AddressShelley addr
+    C.AddressInEra C.ByronAddressInAnyEra{} addr -> C.AddressByron addr
 
 -- | The unversioned validator script itself.
 validatorScript :: TypedValidator a -> PV1.Validator

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -224,6 +224,38 @@ test-suite plutus-use-cases-test
     , tasty-quickcheck
     , text
 
+  -- General dependencies
+  build-depends:
+      base           >=4.7 && <5
+    , containers
+    , contractmodel
+    , lens
+    , mmorph
+    , mtl
+    , pretty
+
+  -- QuickCheck dependencies
+  build-depends:
+      QuickCheck
+    , quickcheck-dynamic  >=2.0.0
+
+  -- Plutus and Cardano dependencies
+  build-depends:
+      cardano-api                  >=1.35
+    , cardano-binary
+    , cardano-ledger-alonzo
+    , cardano-ledger-babbage
+    , cardano-ledger-core
+    , cardano-ledger-shelley
+    , cardano-ledger-shelley-ma
+    , cardano-slotting
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano
+    , plutus-ledger-api
+    , plutus-tx
+    , strict-containers
+    , time
+
 -- runs emulator traces from plutus-use-cases-tests and
 -- writes all applied validator scripts to a folder
 executable plutus-use-cases-scripts
@@ -292,6 +324,7 @@ executable plutus-use-cases-scripts
       base                  >=4.9 && <5
     , bytestring
     , containers
+    , contractmodel
     , data-default
     , foldl
     , freer-simple

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -194,9 +194,20 @@ test-suite plutus-use-cases-test
   -- Other IOG dependencies
   --------------------------
   build-depends:
-      cardano-api
-    , plutus-ledger-api  >=1.0.0
-    , plutus-tx          >=1.0.0
+      cardano-api                  >=1.35
+    , cardano-binary
+    , cardano-ledger-alonzo
+    , cardano-ledger-babbage
+    , cardano-ledger-core
+    , cardano-ledger-shelley
+    , cardano-ledger-shelley-ma
+    , cardano-slotting
+    , contractmodel
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano
+    , plutus-ledger-api            >=1.0.0
+    , plutus-tx                    >=1.0.0
+    , quickcheck-dynamic           >=2.0.0
 
   if !(impl(ghcjs) || os(ghcjs))
     build-depends: plutus-tx-plugin >=1.0.0
@@ -206,54 +217,26 @@ test-suite plutus-use-cases-test
   ------------------------
   build-depends:
       aeson
-    , base              >=4.9     && <5
+    , base               >=4.9     && <5
     , bytestring
     , containers
     , data-default
     , foldl
     , freer-simple
     , lens
-    , mtl
-    , prettyprinter
-    , QuickCheck
-    , streaming
-    , tasty
-    , tasty-golden
-    , tasty-hedgehog    >=0.2.0.0
-    , tasty-hunit
-    , tasty-quickcheck
-    , text
-
-  -- General dependencies
-  build-depends:
-      base           >=4.7 && <5
-    , containers
-    , contractmodel
-    , lens
     , mmorph
     , mtl
     , pretty
-
-  -- QuickCheck dependencies
-  build-depends:
-      QuickCheck
-    , quickcheck-dynamic  >=2.0.0
-
-  -- Plutus and Cardano dependencies
-  build-depends:
-      cardano-api                  >=1.35
-    , cardano-binary
-    , cardano-ledger-alonzo
-    , cardano-ledger-babbage
-    , cardano-ledger-core
-    , cardano-ledger-shelley
-    , cardano-ledger-shelley-ma
-    , cardano-slotting
-    , ouroboros-consensus
-    , ouroboros-consensus-cardano
-    , plutus-ledger-api
-    , plutus-tx
+    , prettyprinter
+    , QuickCheck
+    , streaming
     , strict-containers
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog     >=0.2.0.0
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
     , time
 
 -- runs emulator traces from plutus-use-cases-tests and

--- a/plutus-use-cases/src/Plutus/Contracts/Auction.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Auction.hs
@@ -12,7 +12,7 @@
 {-# LANGUAGE TypeApplications   #-}
 {-# LANGUAGE TypeOperators      #-}
 {-# LANGUAGE ViewPatterns       #-}
-{-# OPTIONS_GHC -g -fplugin-opt PlutusTx.Plugin:coverage-all #-}
+-- {-# OPTIONS_GHC -g -fplugin-opt PlutusTx.Plugin:coverage-all #-}
 module Plutus.Contracts.Auction(
     AuctionState(..),
     AuctionInput(..),

--- a/plutus-use-cases/src/Plutus/Contracts/Auction.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Auction.hs
@@ -12,7 +12,7 @@
 {-# LANGUAGE TypeApplications   #-}
 {-# LANGUAGE TypeOperators      #-}
 {-# LANGUAGE ViewPatterns       #-}
--- {-# OPTIONS_GHC -g -fplugin-opt PlutusTx.Plugin:coverage-all #-}
+{-# OPTIONS_GHC -g -fplugin-opt PlutusTx.Plugin:coverage-all #-}
 module Plutus.Contracts.Auction(
     AuctionState(..),
     AuctionInput(..),

--- a/plutus-use-cases/test/Spec/Auction.hs
+++ b/plutus-use-cases/test/Spec/Auction.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE GADTs              #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RankNTypes         #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeApplications   #-}
@@ -366,6 +367,7 @@ check_propAuctionWithCoverage = do
         (set minLogLevel Critical options) covopts (const (pure True))
   writeCoverageReport "Auction" cr
 
+-- | Note: this property fails, because the contract is vulnerable to double satisfaction.
 prop_doubleSatisfaction :: Actions AuctionModel -> Property
 prop_doubleSatisfaction = checkDoubleSatisfactionWithOptions options defaultCoverageOptions
 
@@ -397,3 +399,4 @@ tests =
         , testProperty "prop_doubleSatisfaction fails" $
             expectFailure $ noShrinking prop_doubleSatisfaction
         ]
+


### PR DESCRIPTION
Updates the quickcheck-contractmodel dependency to the latest version with the new threat modelling framework.

- Reenable double satisfaction tests (this now comes with the threat modelling)
- Some simple threat model examples (GameStateMachine and Escrow)
- Use min Ada balance change logic from quickcheck-contractmodel