### PR TITLE
Mention GC_DONT_GC=1 in CONTRIBUTING.adoc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -8,7 +8,8 @@ Make sure you have set up the link:./README{outfilesuffix}#prerequisites[prerequ
 
 === How to get a shell environment with tools
 
-You can get an environment for developing the entire project using `nix-shell` in the root directory.
+You can get an environment for developing the entire project using a nix shell.
+To enter the shell, run the `./shell` script or the command `GC_DONT_GC=1 nix-shell`.
 This includes a variety of useful tools:
 
 * The right version of GHC with all the external Haskell dependencies in its package database.

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -9,7 +9,8 @@ Make sure you have set up the link:./README{outfilesuffix}#prerequisites[prerequ
 === How to get a shell environment with tools
 
 You can get an environment for developing the entire project using a nix shell.
-To enter the shell, run the `./shell` script or the command `GC_DONT_GC=1 nix-shell`.
+To enter the shell run the command `nix-shell`.
+If you get a segfault, try `GC_DONT_GC=1 nix-shell` instead.
 This includes a variety of useful tools:
 
 * The right version of GHC with all the external Haskell dependencies in its package database.

--- a/shell
+++ b/shell
@@ -1,1 +1,0 @@
-GC_DONT_GC=1 nix-shell --show-trace

--- a/shell
+++ b/shell
@@ -1,1 +1,1 @@
-GC_DONT_GC=1 nix-shell
+GC_DONT_GC=1 nix-shell --show-trace

--- a/shell
+++ b/shell
@@ -1,0 +1,1 @@
+GC_DONT_GC=1 nix-shell


### PR DESCRIPTION
Several people have complained that running `nix-shell` segfaults.
We can't expect them to know the `GC_DONT_GC=1` trick.
This PR updates the CONTRIBUTING