### PR TITLE
Add MintBurn indexer

### DIFF
--- a/marconi-chain-index/app/Main.hs
+++ b/marconi-chain-index/app/Main.hs
@@ -29,6 +29,7 @@ main = do
                                   (Cli.datumDbPath o)
                                   (Cli.scriptTxDbPath o)
                                   (Cli.epochStakepoolSizeDbPath o)
+                                  (Cli.mintBurnDbPath o)
                                   (Cli.optionsTargetAddresses o)
                                   (Cli.optionsNodeConfigPath o)
     (cp, coordinator) <- startIndexers indexers

--- a/marconi-chain-index/changelog.d/20230130_134918_markus.l2ll_plt_357.md
+++ b/marconi-chain-index/changelog.d/20230130_134918_markus.l2ll_plt_357.md
@@ -1,0 +1,3 @@
+### Added
+
+- Mint/burn indexer: indexes mint/burn events of custom tokens in transactions.

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -56,6 +56,7 @@ library
     Marconi.ChainIndex.Indexers.EpochStakepoolSize
     Marconi.ChainIndex.Indexers.ScriptTx
     Marconi.ChainIndex.Indexers.Utxo
+    Marconi.ChainIndex.Indexers.Common
     Marconi.ChainIndex.Logging
     Marconi.ChainIndex.Orphans
     Marconi.ChainIndex.Types

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -57,7 +57,6 @@ library
     Marconi.ChainIndex.Indexers.MintBurn
     Marconi.ChainIndex.Indexers.ScriptTx
     Marconi.ChainIndex.Indexers.Utxo
-    Marconi.ChainIndex.Indexers.Common
     Marconi.ChainIndex.Logging
     Marconi.ChainIndex.Orphans
     Marconi.ChainIndex.Types
@@ -215,6 +214,7 @@ test-suite marconi-chain-index-test
     Spec.Marconi.ChainIndex.Indexers.AddressDatum.Generators
     Spec.Marconi.ChainIndex.Indexers.AddressDatum.Utils
     Spec.Marconi.ChainIndex.Indexers.EpochStakepoolSize
+    Spec.Marconi.ChainIndex.Indexers.MintBurn
     Spec.Marconi.ChainIndex.Indexers.ScriptTx
     Spec.Marconi.ChainIndex.Indexers.Utxo
     Spec.Marconi.ChainIndex.Indexers.Utxo.UtxoIndex

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -54,6 +54,7 @@ library
     Marconi.ChainIndex.Indexers.AddressDatum
     Marconi.ChainIndex.Indexers.Datum
     Marconi.ChainIndex.Indexers.EpochStakepoolSize
+    Marconi.ChainIndex.Indexers.MintBurn
     Marconi.ChainIndex.Indexers.ScriptTx
     Marconi.ChainIndex.Indexers.Utxo
     Marconi.ChainIndex.Indexers.Common
@@ -75,6 +76,7 @@ library
     , cardano-api
     , cardano-binary
     , cardano-ledger-alonzo
+    , cardano-ledger-babbage
     , cardano-ledger-core
     , cardano-ledger-shelley
     , cardano-ledger-shelley-ma

--- a/marconi-chain-index/src/Marconi/ChainIndex/CLI.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/CLI.hs
@@ -13,6 +13,7 @@ module Marconi.ChainIndex.CLI
     , datumDbPath
     , scriptTxDbPath
     , epochStakepoolSizeDbPath
+    , mintBurnDbPath
     ) where
 
 import Control.Applicative (optional, some)
@@ -109,6 +110,7 @@ data Options = Options
     optionsDisableDatum         :: Bool,
     optionsDisableScript        :: Bool,
     optionsDisableStakepoolSize :: Bool,
+    optionsDisableMintBurn      :: Bool,
     optionsTargetAddresses      :: Maybe TargetAddresses,
     optionsNodeConfigPath       :: Maybe FilePath
   }
@@ -144,23 +146,21 @@ optionsParser =
                       <> Opt.help "Dirctory Path for SQLite database.")
     <*> Opt.switch (Opt.long "disable-utxo"
                       <> Opt.help "disable utxo indexers."
-                      <> Opt.showDefault
                      )
     <*> Opt.switch (Opt.long "disable-address-datum"
                       <> Opt.help "disable address->datum indexers."
-                      <> Opt.showDefault
                      )
     <*> Opt.switch (Opt.long "disable-datum"
                       <> Opt.help "disable datum indexers."
-                      <> Opt.showDefault
                      )
     <*> Opt.switch (Opt.long "disable-script-tx"
                       <> Opt.help "disable script-tx indexers."
-                      <> Opt.showDefault
                      )
     <*> Opt.switch (Opt.long "disable-epoch-stakepool-size"
                       <> Opt.help "disable epoch stakepool size indexers."
-                      <> Opt.showDefault
+                     )
+    <*> Opt.switch (Opt.long "disable-mintburn"
+                      <> Opt.help "disable mint/burn indexers."
                      )
     <*> optAddressesParser (Opt.long "addresses-to-index"
                             <> Opt.short 'a'
@@ -190,6 +190,9 @@ scriptTxDbName = "scripttx.db"
 epochStakepoolSizeDbName :: FilePath
 epochStakepoolSizeDbName = "epochstakepool.db"
 
+mintBurnDbName :: FilePath
+mintBurnDbName = "mintburn.db"
+
 utxoDbPath :: Options -> Maybe FilePath
 utxoDbPath o = if optionsDisableUtxo o then Nothing; else Just (optionsDbPath o </> utxoDbName)
 
@@ -204,3 +207,6 @@ scriptTxDbPath o = if optionsDisableScript o then Nothing; else Just (optionsDbP
 
 epochStakepoolSizeDbPath :: Options -> Maybe FilePath
 epochStakepoolSizeDbPath o = if optionsDisableStakepoolSize o then Nothing else Just (optionsDbPath o </> epochStakepoolSizeDbName)
+
+mintBurnDbPath :: Options -> Maybe FilePath
+mintBurnDbPath o = if optionsDisableMintBurn o then Nothing else Just (optionsDbPath o </> mintBurnDbName)

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/MintBurn.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/MintBurn.hs
@@ -1,0 +1,295 @@
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# OPTIONS_GHC -Wno-orphans     #-}
+
+module Marconi.ChainIndex.Indexers.MintBurn where
+
+import Control.Lens (view, (&), (^.))
+import Control.Lens qualified as L
+import Control.Monad.IO.Class (liftIO)
+import Data.ByteString.Short qualified as Short
+import Data.Coerce (coerce)
+import Data.Foldable (toList)
+import Data.Function (on)
+import Data.List (groupBy, sort)
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.List.NonEmpty qualified as NE
+import Data.Map qualified as Map
+import Data.Maybe (mapMaybe)
+import Data.Word (Word64)
+import Database.SQLite.Simple (NamedParam ((:=)))
+import Database.SQLite.Simple qualified as SQL
+import Database.SQLite.Simple.ToField qualified as SQL
+
+import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as C
+import Cardano.Ledger.Alonzo.Data qualified as LA
+import Cardano.Ledger.Alonzo.Scripts qualified as LA
+import Cardano.Ledger.Alonzo.Tx qualified as LA
+import Cardano.Ledger.Alonzo.TxWitness qualified as LA
+import Cardano.Ledger.Babbage.Tx qualified as LB
+import Cardano.Ledger.Mary.Value qualified as LM
+import Ouroboros.Consensus.Shelley.Eras qualified as OEra
+
+import Marconi.ChainIndex.Orphans ()
+import Marconi.Core.Storable qualified as RI
+
+-- * Event
+
+data TxMintEvent = TxMintEvent
+  { txMintEventSlotNo          :: C.SlotNo
+  , txMintEventBlockHeaderHash :: C.Hash C.BlockHeader
+  , txMintEventTxAssets        :: NE.NonEmpty (C.TxId, NE.NonEmpty MintAsset)
+  } deriving (Show, Eq, Ord)
+
+data MintAsset = MintAsset
+  { mintAssetPolicyId     :: C.PolicyId
+  , mintAssetAssetName    :: C.AssetName
+  , mintAssetQuantity     :: C.Quantity
+  , mintAssetRedeemerIdx  :: Word64
+  , mintAssetRedeemerData :: C.ScriptData
+  } deriving (Show, Eq, Ord)
+
+toUpdate :: C.BlockInMode C.CardanoMode -> Maybe TxMintEvent
+toUpdate (C.BlockInMode (C.Block (C.BlockHeader slotNo blockHeaderHash _blockNo) txs) _) =
+  case mapMaybe txMints txs of
+    x : xs -> Just $ TxMintEvent slotNo blockHeaderHash (x NE.:| xs)
+    _      -> Nothing
+
+txMints :: C.Tx era -> Maybe (C.TxId, NE.NonEmpty MintAsset)
+txMints (C.Tx txb _) = case txbMints txb of
+  x : xs -> Just (C.getTxId txb, x NE.:| xs )
+  _      -> Nothing
+
+txbMints :: C.TxBody era -> [MintAsset]
+txbMints txb = case txb of
+  C.ShelleyTxBody era shelleyTx _ _ _ _ -> case era of
+    C.ShelleyBasedEraShelley -> []
+    C.ShelleyBasedEraAllegra -> []
+    C.ShelleyBasedEraMary -> []
+    C.ShelleyBasedEraAlonzo -> do
+      (policyId, assetName, quantity, index', redeemer) <- getPolicyData txb $ LA.mint shelleyTx
+      pure $ MintAsset policyId assetName quantity index' redeemer
+    C.ShelleyBasedEraBabbage -> do
+      (policyId, assetName, quantity, index', redeemer) <- getPolicyData txb $ LB.mint shelleyTx
+      pure $ MintAsset policyId assetName quantity index' redeemer
+  _ -> [] -- ByronTxBody is not exported but as it's the only other data constructor then _ matches it.
+
+-- * Helpers
+
+txRedeemers :: C.TxBody era -> Map.Map LA.RdmrPtr (LA.Data (C.ShelleyLedgerEra era), LA.ExUnits)
+txRedeemers (C.ShelleyTxBody _ _ _ txScriptData _ _) = case txScriptData of
+  C.TxBodyScriptData _proof _datum redeemers -> LA.unRedeemers redeemers
+  C.TxBodyNoScriptData                       -> mempty
+txRedeemers _ = mempty
+
+mintRedeemers :: C.TxBody era -> [(Word64, (LA.Data (C.ShelleyLedgerEra era), LA.ExUnits))]
+mintRedeemers txb = txRedeemers txb
+  & Map.toList
+  & filter (\(LA.RdmrPtr tag _, _) -> tag == LA.Mint)
+  & map (\(LA.RdmrPtr _ w, a) -> (w, a))
+
+getPolicyData :: C.TxBody era -> LM.Value OEra.StandardCrypto -> [(C.PolicyId, C.AssetName, C.Quantity, Word64, C.ScriptData)]
+getPolicyData txb (LM.Value _ m) = do
+  let
+    policyIdList = Map.toList m
+    getPolicyId index' = policyIdList !! fromIntegral index'
+  ((maryPolicyID, assets), index'', (redeemer, _)) <- map (\(index', data_) -> (getPolicyId index', index', data_)) $ mintRedeemers txb
+  (assetName, quantity) :: (LM.AssetName, Integer) <- Map.toList assets
+  pure $ (fromMaryPolicyID maryPolicyID, fromMaryAssetName assetName, C.Quantity quantity, index'', fromAlonzoData redeemer)
+
+-- ** Copy-paste
+
+fromMaryPolicyID :: LM.PolicyID OEra.StandardCrypto -> C.PolicyId
+fromMaryPolicyID (LM.PolicyID sh) = C.PolicyId (C.fromShelleyScriptHash sh) -- from cardano-api:src/Cardano/Api/Value.hs
+
+fromMaryAssetName :: LM.AssetName -> C.AssetName
+fromMaryAssetName (LM.AssetName n) = C.AssetName $ Short.fromShort n -- from cardano-api:src/Cardano/Api/Value.hs
+
+fromAlonzoData :: LA.Data ledgerera -> C.ScriptData
+fromAlonzoData = C.fromPlutusData . LA.getPlutusData -- from cardano-api:src/Cardano/Api/ScriptData.hs
+
+-- * Sqlite
+
+sqliteInit :: SQL.Connection -> IO ()
+sqliteInit c = liftIO $ do
+  SQL.execute_ c
+    " CREATE TABLE IF NOT EXISTS        \
+    \   minting_policy_events           \
+    \   ( slotNo          INT NOT NULL  \
+    \   , blockHeaderHash INT NOT NULL  \
+    \   , txId            BLOB NOT NULL \
+    \   , policyId        BLOB NOT NULL \
+    \   , assetName       TEXT NOT NULL \
+    \   , quantity        INT NOT NULL  \
+    \   , redeemerIx      INT NOT NULL  \
+    \   , redeemerData    BLOB NOT NULL)"
+  SQL.execute_ c
+    " CREATE INDEX IF NOT EXISTS               \
+    \    minting_policy_events__txId_policyId  \
+    \ ON minting_policy_events (txId, policyId)"
+
+sqliteInsert :: SQL.Connection -> [TxMintEvent] -> IO ()
+sqliteInsert c es = SQL.executeMany c template $ toRows =<< toList es
+  where
+    template =
+      "INSERT INTO minting_policy_events \
+      \ ( slotNo, blockHeaderHash, txId  \
+      \ , policyId, assetName, quantity  \
+      \ , redeemerIx, redeemerData )     \
+      \ VALUES (?, ?, ?, ?, ?, ?, ?, ?)  "
+
+    toRows :: TxMintEvent -> [[SQL.SQLData]]
+    toRows e = do
+      (txId, txMintAssets) <- NE.toList $ txMintEventTxAssets e
+      mintAsset <- NE.toList txMintAssets
+      pure
+        [ SQL.toField $ txMintEventSlotNo e
+        , SQL.toField $ txMintEventBlockHeaderHash e
+        , SQL.toField txId
+        , SQL.toField $ mintAssetPolicyId mintAsset
+        , SQL.toField $ mintAssetAssetName mintAsset
+        , SQL.toField $ mintAssetQuantity mintAsset
+        , SQL.toField $ mintAssetRedeemerIdx mintAsset
+        , SQL.toField $ mintAssetRedeemerData mintAsset
+        ]
+
+type Row = (C.SlotNo, C.Hash C.BlockHeader, C.TxId, C.PolicyId, C.AssetName, C.Quantity, Word64, C.ScriptData)
+
+-- | Input rows must be sorted by C.SlotNo.
+fromRows :: [Row] -> [TxMintEvent]
+fromRows rows =  do
+  rs@(r :| _) <- NE.groupBy ((==) `on` slotNo) rows -- group by SlotNo
+  pure $ TxMintEvent (slotNo r) (hash r) $ do
+    rs' <- NE.groupBy1 ((==) `on` txId) rs -- group by TxId
+    pure (txId r, rowToMintAsset <$> rs')
+  where
+    slotNo = view L._1 :: Row -> C.SlotNo
+    hash = view L._2 :: Row -> C.Hash C.BlockHeader
+    txId = view L._3 :: Row -> C.TxId
+    rowToMintAsset :: Row -> MintAsset
+    rowToMintAsset row = MintAsset (row^.L._4) (row^.L._5) (row^.L._6) (row^.L._7) (row^.L._8)
+
+sqliteSelectByTxIdPolicyId :: SQL.Connection -> (SQL.Query, [NamedParam]) -> C.TxId -> C.PolicyId -> IO [TxMintEvent]
+sqliteSelectByTxIdPolicyId sqlCon (conditions, params) txId policyId =
+  fromRows <$> SQL.queryNamed sqlCon query ([":txId" := txId, ":policyId" := policyId] <> params)
+  where query =
+          " SELECT slotNo, blockHeaderHash, txId, policyId                    \
+          \      , assetName, quantity, redeemerIx, redeemerData              \
+          \   FROM minting_policy_events                                      \
+          \  WHERE txId = :txId AND policyId = :policyId " <> conditions <> " \
+          \  ORDER BY slotNo, txId                                            "
+
+sqliteSelectAll :: SQL.Connection -> (SQL.Query, [NamedParam]) -> IO [TxMintEvent]
+sqliteSelectAll sqlCon (conditions, params) = fromRows <$> SQL.queryNamed sqlCon query params
+  where
+    whereClause = if conditions == "" then "" else " WHERE " <> conditions <> " "
+    query =
+      "   SELECT slotNo, blockHeaderHash, txId, policyId       \
+      \        , assetName, quantity, redeemerIx, redeemerData \
+      \     FROM minting_policy_events                         \
+      \     " <> whereClause <> "                              \
+      \ ORDER BY slotNo, txId                                  "
+
+intervalToWhereClause :: RI.QueryInterval C.ChainPoint -> (SQL.Query, [NamedParam])
+intervalToWhereClause qi = case qi of
+  RI.QEverything -> ("", [])
+  RI.QInterval from to
+    | Just from' <- slotMaybe from, Just to' <- slotMaybe to -> ("slotNo BETWEEN :fromSlot AND :toSlot" , [":fromSlot" := from', ":toSlot" := to'])
+    | Just to' <- slotMaybe to -> ("slotNo <= :toSlot" , [":toSlot" := to'])
+    | otherwise -> ("FALSE", [])
+    where
+      slotMaybe :: C.ChainPoint -> Maybe C.SlotNo
+      slotMaybe = \case
+        C.ChainPoint slotNo _ -> Just slotNo
+        C.ChainPointAtGenesis -> Nothing
+
+groupBySlotAndHash :: [TxMintEvent] -> [TxMintEvent]
+groupBySlotAndHash events = events
+  & sort
+  & groupBy (\e1 e2 -> txMintEventSlotNo e1 == txMintEventSlotNo e2 && txMintEventBlockHeaderHash e1 == txMintEventBlockHeaderHash e2)
+  & concatMap (\case e : es -> [ TxMintEvent (txMintEventSlotNo e) (txMintEventBlockHeaderHash e) $ txMintEventTxAssets =<< (e :| es) ]
+                     _      -> [])
+
+-- * Indexer
+
+data MintBurnHandle = MintBurnHandle
+  { sqlConnection :: SQL.Connection
+  , securityParam :: Int
+  }
+
+type MintBurnIndexer = RI.State MintBurnHandle
+
+type instance RI.StorablePoint MintBurnHandle = C.ChainPoint
+
+type instance RI.StorableMonad MintBurnHandle = IO
+
+newtype instance RI.StorableEvent MintBurnHandle
+  = MintBurnEvent TxMintEvent
+
+data instance RI.StorableQuery MintBurnHandle
+  = ByTxIdAndPolicyId C.TxId C.PolicyId
+  | Everything
+
+data instance RI.StorableResult MintBurnHandle
+  = MintBurnResult [Row]
+
+instance RI.Queryable MintBurnHandle where
+  queryStorage queryInterval memoryEvents (MintBurnHandle sqlCon _k) query = case query of
+    Everything                      -> toResult <$> sqliteSelectAll sqlCon interval
+    ByTxIdAndPolicyId txId policyId -> toResult <$> sqliteSelectByTxIdPolicyId sqlCon interval txId policyId
+    where
+      toResult storedEvents = MintBurnResult $ do
+        TxMintEvent slotNo blockHeaderHash txAssets <- storedEvents <> map coerce (toList memoryEvents)
+        (txId, mintAssets) <- NE.toList txAssets
+        MintAsset policyId assetName quantity redeemerIx redeemerData <- NE.toList mintAssets
+        pure (slotNo, blockHeaderHash, txId, policyId, assetName, quantity, redeemerIx, redeemerData)
+
+      interval = intervalToWhereClause queryInterval
+
+instance RI.HasPoint (RI.StorableEvent MintBurnHandle) C.ChainPoint where
+  getPoint (MintBurnEvent e) = C.ChainPoint (txMintEventSlotNo e) (txMintEventBlockHeaderHash e)
+
+instance RI.Buffered MintBurnHandle where
+  persistToStorage events h@(MintBurnHandle sqlCon _k) = do
+    sqliteInsert sqlCon (map coerce $ toList events)
+    pure h
+
+  getStoredEvents (MintBurnHandle sqlCon k) =
+    map MintBurnEvent . fromRows <$> SQL.query sqlCon query (SQL.Only k)
+    where
+      query =
+        " SELECT slotNo, blockHeaderHash, txId, policyId, assetName, quantity  \
+        \        redeemerIx, redeemerData                                      \
+        \   FROM minting_policy_events                                         \
+        \  WHERE slotNo >= (SELECT MAX(slotNo) - ? FROM minting_policy_events) \
+        \  ORDER BY slotNo, txId                                               "
+
+instance RI.Resumable MintBurnHandle where
+  resumeFromStorage h = do
+    events <- RI.getStoredEvents h
+    pure $ map getChainPoint events <> [C.ChainPointAtGenesis]
+    where
+      getChainPoint (MintBurnEvent e) = C.ChainPoint (txMintEventSlotNo e) (txMintEventBlockHeaderHash e)
+
+instance RI.Rewindable MintBurnHandle where
+  rewindStorage cp h@(MintBurnHandle sqlCon _k) = doRewind >> pure (Just h)
+    where
+      doRewind = case cp of
+        C.ChainPoint slotNo _ ->
+          SQL.execute  sqlCon "DELETE FROM minting_policy_events WHERE slotNo > ?" (SQL.Only slotNo)
+        C.ChainPointAtGenesis ->
+          SQL.execute_ sqlCon "DELETE FROM minting_policy_events"
+
+open :: FilePath -> Int -> IO MintBurnIndexer
+open dbPath bufferSize = do
+  sqlCon <- SQL.open dbPath
+  sqliteInit sqlCon
+  RI.emptyState bufferSize (MintBurnHandle sqlCon bufferSize)

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/MintBurn.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/MintBurn.hs
@@ -9,6 +9,20 @@
 {-# LANGUAGE TypeFamilies        #-}
 {-# OPTIONS_GHC -Wno-orphans     #-}
 
+{- | Mint/burn event indexer, the result of which is an sqlite database
+   'mintburn.db' which has a table 'minting_policy_events' with the
+   following fields:
+
+     - slotNo          INT NOT NULL
+     - blockHeaderHash INT NOT NULL
+     - txId            BLOB NOT NULL
+     - policyId        BLOB NOT NULL
+     - assetName       TEXT NOT NULL
+     - quantity        INT NOT NULL
+     - redeemerIx      INT NOT NULL
+     - redeemerData    BLOB NOT NULL
+-}
+
 module Marconi.ChainIndex.Indexers.MintBurn where
 
 import Control.Lens (view, (&), (^.))

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/ScriptTx.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/ScriptTx.hs
@@ -37,6 +37,8 @@ import Marconi.Core.Storable (Buffered (getStoredEvents, persistToStorage), HasP
                               StorablePoint, StorableQuery, StorableResult, emptyState, filterWithQueryInterval)
 import Marconi.Core.Storable qualified as Storable
 
+import Marconi.Index.Common ()
+
 {- The first thing that we need to define for a new indexer is the `handler` data
    type, meant as a wrapper for the connection type (in this case the SQLite
    connection).

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/ScriptTx.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/ScriptTx.hs
@@ -37,8 +37,6 @@ import Marconi.Core.Storable (Buffered (getStoredEvents, persistToStorage), HasP
                               StorablePoint, StorableQuery, StorableResult, emptyState, filterWithQueryInterval)
 import Marconi.Core.Storable qualified as Storable
 
-import Marconi.Index.Common ()
-
 {- The first thing that we need to define for a new indexer is the `handler` data
    type, meant as a wrapper for the connection type (in this case the SQLite
    connection).

--- a/marconi-chain-index/test-lib/Helpers.hs
+++ b/marconi-chain-index/test-lib/Helpers.hs
@@ -234,6 +234,9 @@ workspace prefixPath f = GHC.withFrozenCallStack $ do
   when (IO.os /= "mingw32" && maybeKeepWorkspace /= Just "1") $ do
     H.evalIO $ IO.removeDirectoryRecursive ws
 
+setDarwinTmpdir :: IO ()
+setDarwinTmpdir = when (IO.os == "darwin") $ IO.setEnv "TMPDIR" "/tmp"
+
 -- * Accessors
 
 bimTxIds :: C.BlockInMode mode -> [C.TxId]

--- a/marconi-chain-index/test/Integration.hs
+++ b/marconi-chain-index/test/Integration.hs
@@ -14,7 +14,7 @@ import Codec.Serialise (serialise)
 import Control.Concurrent qualified as IO
 import Control.Concurrent.STM qualified as IO
 import Control.Exception (catch)
-import Control.Monad (void, when)
+import Control.Monad (void)
 import Control.Monad.IO.Class (liftIO)
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Short qualified as SBS
@@ -24,9 +24,7 @@ import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
 import Streaming.Prelude qualified as S
 import System.Directory qualified as IO
-import System.Environment qualified as IO
 import System.FilePath ((</>))
-import System.Info qualified as IO
 
 import Hedgehog (Property, assert, (===))
 import Hedgehog qualified as H
@@ -78,7 +76,7 @@ tests = testGroup "Integration"
       the indexer to see if it was indexed properly
 -}
 testIndex :: Property
-testIndex = H.integration $ (liftIO setDarwinTmpdir >>) $ HE.runFinallies $ H.workspace "." $ \tempAbsPath -> do
+testIndex = H.integration $ (liftIO TN.setDarwinTmpdir >>) $ HE.runFinallies $ H.workspace "." $ \tempAbsPath -> do
   base <- HE.noteM $ liftIO . IO.canonicalizePath =<< HE.getProjectBase
 
   (localNodeConnectInfo, conf, runtime) <- TN.startTestnet TN.defaultTestnetOptions base tempAbsPath
@@ -259,8 +257,3 @@ testIndex = H.integration $ (liftIO setDarwinTmpdir >>) $ HE.runFinallies $ H.wo
     H.leftFail $ C.deserialiseFromCBOR (C.AsTx C.AsAlonzoEra) txCbor
 
   tx2 === queriedTx2
-
--- * Helpers
-
-setDarwinTmpdir :: IO ()
-setDarwinTmpdir = when (IO.os == "darwin") $ IO.setEnv "TMPDIR" "/tmp"

--- a/marconi-chain-index/test/Spec.hs
+++ b/marconi-chain-index/test/Spec.hs
@@ -9,6 +9,7 @@ import Spec.Marconi.ChainIndex.Indexers.ScriptTx qualified as Indexers.ScriptTx
 -- TODO see tests below
 -- import Spec.Marconi.ChainIndex.Indexers.EpochStakepoolSize qualified as Indexers.EpochStakepoolSize
 import Integration qualified
+import Spec.Marconi.ChainIndex.Indexers.MintBurn qualified as Indexers.MintBurn
 import Spec.Marconi.ChainIndex.Indexers.Utxo qualified as Indexers.Utxo
 
 main :: IO ()
@@ -19,6 +20,7 @@ tests = testGroup "Marconi"
   [ Indexers.Utxo.tests
   , Indexers.ScriptTx.tests
   , Indexers.AddressDatum.tests
+  , Indexers.MintBurn.tests
   -- TODO Enable when test environemnt is reconfigured
   , Integration.tests
   -- , EpochStakepoolSize.tests

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
@@ -1,0 +1,413 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE TemplateHaskell    #-}
+module Spec.Marconi.ChainIndex.Indexers.MintBurn where
+
+import Codec.Serialise (serialise)
+import Control.Concurrent qualified as IO
+import Control.Concurrent.Async qualified as IO
+import Control.Concurrent.STM qualified as IO
+import Control.Exception (catch)
+import Control.Lens qualified as Lens
+import Control.Monad (foldM, forM, replicateM, void, when)
+import Control.Monad.IO.Class (liftIO)
+import Data.ByteString.Lazy qualified as LBS
+import Data.ByteString.Short qualified as SBS
+import Data.Coerce (coerce)
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Map qualified as Map
+import Data.Maybe (mapMaybe)
+import Data.Set qualified as Set
+import Data.String (fromString)
+import Data.Word (Word64)
+import Prettyprinter (defaultLayoutOptions, layoutPretty, pretty, (<+>))
+import Prettyprinter.Render.Text (renderStrict)
+import Streaming.Prelude qualified as S
+import System.Directory qualified as IO
+import System.FilePath ((</>))
+
+import Hedgehog (Gen, Property, forAll, (===))
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test qualified as HE
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testPropertyNamed)
+
+import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as C
+import Cardano.BM.Setup (withTrace)
+import Cardano.BM.Trace (logError)
+import Cardano.BM.Tracing (defaultConfigStdout)
+import Cardano.Streaming (ChainSyncEventException (NoIntersectionFound), withChainSyncEventStream)
+import Gen.Cardano.Api.Typed qualified as CGen
+import Plutus.V1.Ledger.Api qualified as PlutusV1
+import PlutusTx qualified
+import Test.Base qualified as H
+import Testnet.Cardano qualified as TN
+
+import Helpers qualified as TN
+import Marconi.ChainIndex.Indexers qualified as M
+import Marconi.ChainIndex.Indexers.MintBurn qualified as MintBurn
+import Marconi.ChainIndex.Logging ()
+import Marconi.Core.Storable qualified as RI
+
+-- | Each test case is described beside every top level property
+-- declaration.
+tests :: TestTree
+tests = testGroup "MintBurn"
+  [ testPropertyNamed
+      "Mints in `TxBodyContent` survive `makeTransactionBody` and end up in expected place in `TxBody`"
+      "mintsPreserved" mintsPreserved
+  , testPropertyNamed
+      "Mint events created and indexed are returned when querying the indexer"
+      "queryMintedValues" queryMintedValues
+  , testPropertyNamed
+      "Querying a resumed indexer returns only the persisted events"
+      "resume" resume
+  , testPropertyNamed
+      "Rewinding to any slot forgets any newer events than that slot"
+      "rewind" rewind
+  , testPropertyNamed
+      "Intervals work as expected"
+      "intervals" intervals
+  , testPropertyNamed
+      "Indexing a testnet and then submitting a transaction with a mint event to it has the indexer receive that mint event"
+      "endToEnd" endToEnd
+  ]
+
+-- | This is a sanity-check test that turns a TxBodyContent with mint
+-- events into a TxBody through `makeTransactionBody` and checks if
+-- the mint events are found in the result. It doesn't test an
+-- indexer.
+mintsPreserved :: Property
+mintsPreserved = H.property $ do
+  mintValue <- forAll genTxMintValue
+  C.Tx txb _ :: C.Tx C.AlonzoEra <- forAll (genTxWithMint mintValue) >>= \case
+    Left err  -> fail $ "TxBodyError: " <> show err
+    Right tx' -> return tx'
+  -- Index the transaction:
+  let mints = MintBurn.txbMints txb
+      gottenPolicyAssets = map (\mint -> (MintBurn.mintAssetPolicyId mint, MintBurn.mintAssetAssetName mint, MintBurn.mintAssetQuantity mint)) mints
+  -- Print footnote should the test fail:
+  let generatedPolicyAssets = getPolicyAssets mintValue
+  H.footnote $ "Assets to be created: " <> show generatedPolicyAssets <> "\n"
+            <> "Assets gotten: " <> show gottenPolicyAssets
+  -- The assets that were used to construct the transaction were found
+  -- in the generate transaction:
+  equalSet generatedPolicyAssets gottenPolicyAssets
+
+-- | Create transactions, index them, query indexer and find mint events.
+queryMintedValues :: Property
+queryMintedValues = H.property $ do
+  (indexer, insertedEvents, _) <- generateAndIndexEvents ":memory:"
+  -- Query results:
+  MintBurn.MintBurnResult queryResult <- liftIO $ RI.query RI.QEverything indexer MintBurn.Everything
+  -- Compare the sets of events inserted to the indexer and the set
+  -- gotten out of the indexer:
+  equalSet (MintBurn.groupBySlotAndHash insertedEvents) (MintBurn.fromRows queryResult)
+
+-- | Insert some events to an indexer, then recreate it from what is
+-- on disk (the in-memory part is lost), then query it and find all
+-- persisted events and none of the in-memory events.
+resume :: Property
+resume = H.property $ do
+  -- Index events that overflow:
+  (indexer, events, (bufferSize, _nTx)) <- generateAndIndexEvents ":memory:"
+  -- Open a new indexer based off of the old indexers sql connection:
+  indexer' <- liftIO $ mkNewIndexerBasedOnOldDb indexer
+  MintBurn.MintBurnResult queryResult <- liftIO $ RI.query RI.QEverything indexer' MintBurn.Everything
+  let expected = MintBurn.groupBySlotAndHash $ take (eventsPersisted bufferSize (length events)) events
+  -- The test: events that were persisted are exactly those we get from the query.
+  equalSet expected (MintBurn.fromRows queryResult)
+
+-- | Test that rewind (rollback for on-disk events) behaves as
+-- expected: insert events such that buffer overflows, rollback so far
+-- back that some events were already persisted, find no newer events
+-- than rollback point in query.
+rewind :: Property
+rewind = H.property $ do
+  (indexer, events, (_bufferSize, nTx)) <- generateAndIndexEvents ":memory:"
+  -- Rollback slot is from 0 to number of slots (slot numbers are from 0 to nTx - 1)
+  rollbackSlotNo <- fmap coerce $ forAll $ Gen.integral $ Range.constant 0 ((let w64 = fromIntegral nTx in if w64 == 0 then 0 else w64 - 1) :: Word64)
+  let cp = C.ChainPoint rollbackSlotNo dummyBlockHeaderHash
+  rewoundIndexer <- let errMsg = "Failed to rewind! This shouldn't happen and the test should be fixed"
+    in maybe (fail errMsg) pure =<< liftIO (RI.rewind cp indexer)
+  MintBurn.MintBurnResult queryResult <- liftIO $ RI.query RI.QEverything rewoundIndexer MintBurn.Everything
+  -- Expect only older than rollback events.
+  let expected = filter (\e -> MintBurn.txMintEventSlotNo e <= rollbackSlotNo) events
+  equalSet expected (MintBurn.fromRows queryResult)
+
+-- | Test that interval query works.
+intervals :: Property
+intervals = H.property $ do
+  (indexer, events, (_bufferSize, _nTx)) <- generateAndIndexEvents ":memory:"
+
+  let
+    cpFromSlot slotNo = C.ChainPoint slotNo dummyBlockHeaderHash
+    queryInterval from to = do
+      MintBurn.MintBurnResult queryResult <- liftIO $ RI.query (RI.QInterval from to) indexer MintBurn.Everything
+      pure $ MintBurn.fromRows queryResult
+
+  -- Genesis to genesis returns nothing
+  H.assert . null =<< queryInterval C.ChainPointAtGenesis C.ChainPointAtGenesis
+  -- When there were at least one event created:
+  when (not $ null events) $ do
+    let eventCp e = cpFromSlot $ MintBurn.txMintEventSlotNo e
+    -- From genesis to "latest slot + 1" returns everything:
+    equalSet events =<< (queryInterval C.ChainPointAtGenesis $ cpFromSlot $ (MintBurn.txMintEventSlotNo (last events)) + 1)
+    -- From first event's slot to last event's slot returns everything:
+    equalSet events =<< queryInterval (eventCp $ head events) (eventCp $ last events)
+    -- Form any slot to genesis returns nothing
+    ix <- forAll $ Gen.integral $ Range.constant 0 (length events - 1)
+    H.assert . null =<< queryInterval (cpFromSlot $ MintBurn.txMintEventSlotNo $ events !! ix) C.ChainPointAtGenesis
+
+    -- TODO: Enable the following test when there is an API for
+    -- getting an actual interval, and/or add another test for when
+    -- the meaning of queryInterval is clear.
+    --
+    -- Form any existing earlier slot to any existing same-or-later slot:
+    -- (from, to) <- do
+    --   a' <- forAll $ Gen.integral $ Range.constant 0 (length events - 1)
+    --   b' <- forAll $ Gen.integral $ Range.constant 0 (length events - 1)
+    --   let a = MintBurn.txMintEventSlotNo $ events !! a'
+    --       b = MintBurn.txMintEventSlotNo $ events !! b'
+    --   return $ if a <= b then (a, b) else (b, a)
+    -- let expected = filter (\e -> let slotNo = MintBurn.txMintEventSlotNo e in from <= slotNo && slotNo <= to) events
+    -- equalSet expected =<< queryInterval (cpFromSlot from) (cpFromSlot to)
+
+-- | Start testnet, start mint/burn indexer on it, create a single
+-- mint event, put it in a transaction and submit it, find the
+-- generated event passed back through the indexer.
+endToEnd :: Property
+endToEnd = H.withShrinks 0 $ H.integration $ (liftIO TN.setDarwinTmpdir >>) $ HE.runFinallies $ H.workspace "." $ \tempPath -> do
+  base <- HE.noteM $ liftIO . IO.canonicalizePath =<< HE.getProjectBase
+  (localNodeConnectInfo, conf, runtime) <- TN.startTestnet TN.defaultTestnetOptions base tempPath
+  let networkId = TN.getNetworkId runtime
+  socketPath <- TN.getSocketPathAbs conf runtime
+
+  -- This is the channel we wait on to know if the event has been indexed
+  indexedTxs <- liftIO IO.newChan
+  -- Start indexer
+  liftIO $ do
+    coordinator <- M.initialCoordinator 1
+    ch <- IO.atomically . IO.dupTChan $ M._channel coordinator
+    (loop, _indexerMVar) <- M.mintBurnWorker_ 123 (IO.writeChan indexedTxs) coordinator ch (tempPath </> "db.db")
+    void $ IO.async loop
+    -- Receive ChainSyncEvents and pass them on to indexer's channel
+    void $ IO.async $ do
+      let chainPoint = C.ChainPointAtGenesis :: C.ChainPoint
+      c <- defaultConfigStdout
+      withTrace c "marconi" $ \trace -> let
+        indexerWorker = withChainSyncEventStream socketPath networkId [chainPoint] $ S.mapM_ $
+          \chainSyncEvent -> IO.atomically $ IO.writeTChan ch chainSyncEvent
+        handleException NoIntersectionFound = logError trace $ renderStrict $ layoutPretty defaultLayoutOptions $
+          "No intersection found for chain point" <+> pretty chainPoint <> "."
+        in indexerWorker `catch` handleException :: IO ()
+
+  -- Create & submit transaction
+  pparams <- TN.getAlonzoProtocolParams localNodeConnectInfo
+  txMintValue <- forAll genTxMintValue
+
+  genesisVKey :: C.VerificationKey C.GenesisUTxOKey <- TN.readAs (C.AsVerificationKey C.AsGenesisUTxOKey) $ tempPath </> "shelley/utxo-keys/utxo1.vkey"
+  genesisSKey :: C.SigningKey C.GenesisUTxOKey <- TN.readAs (C.AsSigningKey C.AsGenesisUTxOKey) $ tempPath </> "shelley/utxo-keys/utxo1.skey"
+  let paymentKey = C.castVerificationKey genesisVKey :: C.VerificationKey C.PaymentKey
+      address :: C.Address C.ShelleyAddr
+      address = C.makeShelleyAddress
+        networkId
+        (C.PaymentCredentialByKey (C.verificationKeyHash paymentKey :: C.Hash C.PaymentKey))
+        C.NoStakeAddress :: C.Address C.ShelleyAddr
+
+  value <- H.fromJustM $ getValue txMintValue
+  (txIns, lovelace) <- TN.getAddressTxInsValue localNodeConnectInfo address
+  let fee = 500 :: C.Lovelace
+      amountReturned = lovelace - fee :: C.Lovelace
+      txOut :: C.TxOut ctx C.AlonzoEra
+      txOut =
+        C.TxOut
+          (C.AddressInEra (C.ShelleyAddressInEra C.ShelleyBasedEraAlonzo) address)
+          (C.TxOutValue C.MultiAssetInAlonzoEra $ C.lovelaceToValue amountReturned <> value)
+          C.TxOutDatumNone
+          C.ReferenceScriptNone
+      txBodyContent :: C.TxBodyContent C.BuildTx C.AlonzoEra
+      txBodyContent = (TN.emptyTxBodyContent fee pparams)
+        { C.txIns = map (\txIn -> (txIn, C.BuildTxWith $ C.KeyWitness C.KeyWitnessForSpending)) txIns
+        , C.txOuts = [txOut]
+        , C.txProtocolParams = C.BuildTxWith $ Just pparams
+        , C.txMintValue = txMintValue
+        , C.txInsCollateral = C.TxInsCollateral C.CollateralInAlonzoEra txIns
+        }
+  txBody :: C.TxBody C.AlonzoEra <- H.leftFail $ C.makeTransactionBody txBodyContent
+  let
+    kw :: C.KeyWitness C.AlonzoEra
+    kw = C.makeShelleyKeyWitness txBody (C.WitnessPaymentKey $ C.castSigningKey genesisSKey)
+    tx = C.makeSignedTransaction [kw] txBody
+  TN.submitTx localNodeConnectInfo tx
+
+  -- Receive event from the indexer, compare the mint that we
+  -- submitted above with the one we got from the indexer.
+  event <- liftIO $ IO.readChan indexedTxs
+  case MintBurn.txMintEventTxAssets event of
+     (_txId, gottenMintEvents :: NonEmpty MintBurn.MintAsset) :| [] -> let
+       in equalSet (mintsToPolicyAssets $ NonEmpty.toList gottenMintEvents) (getPolicyAssets txMintValue)
+     _ -> fail "More than one mint/burn event, but we created only one!"
+
+-- * Generators
+
+-- | The workhorse of the test: generate an indexer, then generate
+-- transactions to index, then index them.
+generateAndIndexEvents :: FilePath -> H.PropertyT IO (MintBurn.MintBurnIndexer, [MintBurn.TxMintEvent], (Int, Int))
+generateAndIndexEvents dbPath = do
+  (events, (bufferSize, nTx)) <- forAll generateTxsWithMints
+  -- Report buffer overflow:
+  let overflow = bufferSize < length events
+  H.classify "No events created at all" $ null events
+  H.classify "Buffer doesn't overflow" $ not (null events) && not overflow
+  H.classify "Buffer overflows" $ not (null events) && overflow
+  indexer <- liftIO $ do
+    indexer <- MintBurn.open dbPath bufferSize
+    foldM (\indexer' event -> RI.insert (MintBurn.MintBurnEvent event) indexer') indexer events
+  pure (indexer, events, (bufferSize, nTx))
+
+-- | Generate transactions which have mints inside, then extract
+-- TxMintEvent's from these, then return them with buffer size and
+-- number of transactions.
+generateTxsWithMints :: Gen ([MintBurn.TxMintEvent], (Int, Int))
+generateTxsWithMints = do
+  bufferSize <- Gen.integral (Range.constant 1 10)
+  nTx <- Gen.choice                                                   -- Number of events:
+    [ Gen.constant 0                                                  --  1. no events generated
+    , Gen.integral $ Range.constant 0 bufferSize                      --  2. buffer not filled
+    , Gen.integral $ Range.constant (bufferSize + 1) (bufferSize * 2) --  3. guaranteed buffer overflow
+    ]
+  -- Generate transactions
+  txAll' <- forM [0 .. (nTx - 1)] $ \slotNoInt -> do
+    tx <- genTxWithMint =<< genTxMintValue
+    pure (tx, fromIntegral slotNoInt :: C.SlotNo)
+  -- Filter out Left C.TxBodyError
+  txAll <- forM txAll' $ \case
+    (Right tx, slotNo) -> pure (tx, slotNo)
+    (Left txBodyError, _) -> fail $ "Failed to create a transaction! This shouldn't happen, the generator should be fixed. TxBodyError: " <> show txBodyError
+  let events = mapMaybe (\(tx, slotNo) -> MintBurn.TxMintEvent slotNo dummyBlockHeaderHash . pure <$> MintBurn.txMints tx) txAll
+  pure (events, (bufferSize, nTx))
+
+genTxWithMint :: C.TxMintValue C.BuildTx C.AlonzoEra -> Gen (Either C.TxBodyError (C.Tx C.AlonzoEra))
+genTxWithMint txMintValue = do
+  txbc <- CGen.genTxBodyContent C.AlonzoEra
+  txIn <- CGen.genTxIn
+  pparams' :: C.ProtocolParameters <- CGen.genProtocolParameters
+  let
+    pparams = C.BuildTxWith $ Just pparams'
+      { C.protocolParamUTxOCostPerWord = Just 1
+      , C.protocolParamPrices = Just $ C.ExecutionUnitPrices 1 1
+      , C.protocolParamMaxTxExUnits = Just $ C.ExecutionUnits 1 1
+      , C.protocolParamMaxBlockExUnits = Just $ C.ExecutionUnits 1 1
+      , C.protocolParamMaxValueSize = Just 1
+      , C.protocolParamCollateralPercent = Just 1
+      , C.protocolParamMaxCollateralInputs = Just 1
+      }
+    txbc' = txbc
+      { C.txMintValue = txMintValue
+      , C.txInsCollateral = C.TxInsCollateral C.CollateralInAlonzoEra [txIn]
+      , C.txProtocolParams = pparams
+      }
+  pure $ do
+    txb <- C.makeTransactionBody txbc'
+    pure $ C.signShelleyTransaction txb []
+
+-- | Helper to create tx with @commonMintingPolicy@, @assetName@ and @quantity@
+genTxWithAsset :: C.AssetName -> C.Quantity -> Gen (Either C.TxBodyError (C.Tx C.AlonzoEra))
+genTxWithAsset assetName quantity = genTxWithMint $ C.TxMintValue C.MultiAssetInAlonzoEra mintedValues (C.BuildTxWith $ Map.singleton policyId policyWitness)
+  where (policyId, policyWitness, mintedValues) = mkMintValue commonMintingPolicy [(assetName, quantity)]
+
+genTxMintValue :: Gen (C.TxMintValue C.BuildTx C.AlonzoEra)
+genTxMintValue = do
+  n :: Int <- Gen.integral (Range.constant 1 5)
+  -- n :: Int <- Gen.integral (Range.constant 0 5)
+  -- TODO: fix bug RewindableIndex.Storable.rewind and change range to start from 0.
+  policyAssets <- replicateM n genAsset
+  let (policyId, policyWitness, mintedValues) = mkMintValue commonMintingPolicy policyAssets
+  pure $ C.TxMintValue C.MultiAssetInAlonzoEra mintedValues (C.BuildTxWith $ Map.singleton policyId policyWitness)
+  where
+    genAsset :: Gen (C.AssetName, C.Quantity)
+    genAsset = (,) <$> genAssetName <*> genQuantity
+      where
+        genAssetName = coerce @_ @C.AssetName <$> Gen.bytes (Range.constant 1 5)
+        genQuantity = coerce @Integer @C.Quantity <$> Gen.integral (Range.constant 1 100)
+
+-- * Helpers
+
+-- | Remove events that remained in buffer.
+onlyPersisted :: Int -> [a] -> [a]
+onlyPersisted bufferSize events = take (eventsPersisted bufferSize $ length events) $ events
+
+eventsPersisted :: Int -> Int -> Int
+eventsPersisted bufferSize nEvents = let
+  -- Number of buffer flushes
+  bufferFlushesN = let
+    (n, m) = nEvents `divMod` bufferSize
+    in if m == 0 then n - 1 else n
+  -- Number of events persisted
+  numberOfEventsPersisted = bufferFlushesN * bufferSize
+  in numberOfEventsPersisted
+
+mkMintValue
+  :: PlutusV1.MintingPolicy -> [(C.AssetName, C.Quantity)]
+  -> (C.PolicyId, C.ScriptWitness C.WitCtxMint C.AlonzoEra, C.Value)
+mkMintValue policy policyAssets = (policyId, policyWitness, mintedValues)
+  where
+    serialisedPolicyScript :: C.PlutusScript C.PlutusScriptV1
+    serialisedPolicyScript = C.PlutusScriptSerialised $ SBS.toShort . LBS.toStrict $ serialise $ PlutusV1.unMintingPolicyScript policy
+
+    policyId :: C.PolicyId
+    policyId = C.scriptPolicyId $ C.PlutusScript C.PlutusScriptV1 serialisedPolicyScript :: C.PolicyId
+
+    executionUnits :: C.ExecutionUnits
+    executionUnits = C.ExecutionUnits {C.executionSteps = 300000, C.executionMemory = 1000 }
+    redeemer :: C.ScriptData
+    redeemer = C.fromPlutusData $ PlutusV1.toData ()
+    policyWitness :: C.ScriptWitness C.WitCtxMint C.AlonzoEra
+    policyWitness = C.PlutusScriptWitness C.PlutusScriptV1InAlonzo C.PlutusScriptV1
+      (C.PScript serialisedPolicyScript) C.NoScriptDatumForMint redeemer executionUnits
+
+    mintedValues :: C.Value
+    mintedValues = C.valueFromList $ map (\(assetName, quantity) -> (C.AssetId policyId assetName, quantity)) policyAssets
+
+commonMintingPolicy :: PlutusV1.MintingPolicy
+commonMintingPolicy = PlutusV1.mkMintingPolicyScript $$(PlutusTx.compile [||\_ _ -> ()||])
+
+-- | Recreate an indexe, useful because the sql connection to a
+-- :memory: database can be reused.
+mkNewIndexerBasedOnOldDb :: RI.State MintBurn.MintBurnHandle -> IO (RI.State MintBurn.MintBurnHandle)
+mkNewIndexerBasedOnOldDb indexer = let
+    MintBurn.MintBurnHandle sqlCon k = Lens.view RI.handle indexer
+  in RI.emptyState k (MintBurn.MintBurnHandle sqlCon k)
+
+dummyBlockHeaderHash :: C.Hash C.BlockHeader
+dummyBlockHeaderHash = fromString "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" :: C.Hash C.BlockHeader
+
+equalSet :: (H.MonadTest m, Show a, Ord a) => [a] -> [a] -> m ()
+equalSet a b = Set.fromList a === Set.fromList b
+
+getPolicyAssets :: C.TxMintValue C.BuildTx C.AlonzoEra -> [(C.PolicyId, C.AssetName, C.Quantity)]
+getPolicyAssets txMintValue = case txMintValue of
+  (C.TxMintValue C.MultiAssetInAlonzoEra mintedValues (C.BuildTxWith _policyIdToWitnessMap)) ->
+    mapMaybe (\(assetId, quantity) -> case assetId of
+             C.AssetId policyId assetName -> Just (policyId, assetName, quantity)
+             C.AdaAssetId                 -> Nothing
+        ) $ C.valueToList mintedValues
+  _ -> []
+
+getValue :: C.TxMintValue C.BuildTx C.AlonzoEra -> Maybe C.Value
+getValue = \case
+  C.TxMintValue C.MultiAssetInAlonzoEra value (C.BuildTxWith _policyIdToWitnessMap) -> Just value
+  _                                                                                 -> Nothing
+
+mintsToPolicyAssets :: [MintBurn.MintAsset] -> [(C.PolicyId, C.AssetName, C.Quantity)]
+mintsToPolicyAssets mints =
+  map (\mint -> (MintBurn.mintAssetPolicyId mint, MintBurn.mintAssetAssetName mint, MintBurn.mintAssetQuantity mint)) mints

--- a/marconi/test/MintBurn.hs
+++ b/marconi/test/MintBurn.hs
@@ -1,0 +1,413 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE TemplateHaskell    #-}
+module MintBurn where
+
+import Codec.Serialise (serialise)
+import Control.Concurrent qualified as IO
+import Control.Concurrent.Async qualified as IO
+import Control.Concurrent.STM qualified as IO
+import Control.Exception (catch)
+import Control.Lens qualified as Lens
+import Control.Monad (foldM, forM, replicateM, void, when)
+import Control.Monad.IO.Class (liftIO)
+import Data.ByteString.Lazy qualified as LBS
+import Data.ByteString.Short qualified as SBS
+import Data.Coerce (coerce)
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Map qualified as Map
+import Data.Maybe (mapMaybe)
+import Data.Set qualified as Set
+import Data.String (fromString)
+import Data.Word (Word64)
+import Prettyprinter (defaultLayoutOptions, layoutPretty, pretty, (<+>))
+import Prettyprinter.Render.Text (renderStrict)
+import Streaming.Prelude qualified as S
+import System.Directory qualified as IO
+import System.FilePath ((</>))
+
+import Hedgehog (Gen, Property, forAll, (===))
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test qualified as HE
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testPropertyNamed)
+
+import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as C
+import Cardano.BM.Setup (withTrace)
+import Cardano.BM.Trace (logError)
+import Cardano.BM.Tracing (defaultConfigStdout)
+import Cardano.Streaming (ChainSyncEventException (NoIntersectionFound), withChainSyncEventStream)
+import Gen.Cardano.Api.Typed qualified as CGen
+import Plutus.V1.Ledger.Api qualified as PlutusV1
+import PlutusTx qualified
+import Test.Base qualified as H
+import Testnet.Cardano qualified as TN
+
+import Helpers qualified as TN
+import Marconi.Index.MintBurn qualified as MintBurn
+import Marconi.Indexers qualified as M
+import Marconi.Logging ()
+import RewindableIndex.Storable qualified as RI
+
+-- | Each test case is described beside every top level property
+-- declaration.
+tests :: TestTree
+tests = testGroup "MintBurn"
+  [ testPropertyNamed
+      "Mints in `TxBodyContent` survive `makeTransactionBody` and end up in expected place in `TxBody`"
+      "mintsPreserved" mintsPreserved
+  , testPropertyNamed
+      "Mint events created and indexed are returned when querying the indexer"
+      "queryMintedValues" queryMintedValues
+  , testPropertyNamed
+      "Querying a resumed indexer returns only the persisted events"
+      "resume" resume
+  , testPropertyNamed
+      "Rewinding to any slot forgets any newer events than that slot"
+      "rewind" rewind
+  , testPropertyNamed
+      "Intervals work as expected"
+      "intervals" intervals
+  , testPropertyNamed
+      "Indexing a testnet and then submitting a transaction with a mint event to it has the indexer receive that mint event"
+      "endToEnd" endToEnd
+  ]
+
+-- | This is a sanity-check test that turns a TxBodyContent with mint
+-- events into a TxBody through `makeTransactionBody` and checks if
+-- the mint events are found in the result. It doesn't test an
+-- indexer.
+mintsPreserved :: Property
+mintsPreserved = H.property $ do
+  mintValue <- forAll genTxMintValue
+  C.Tx txb _ :: C.Tx C.AlonzoEra <- forAll (genTxWithMint mintValue) >>= \case
+    Left err  -> fail $ "TxBodyError: " <> show err
+    Right tx' -> return tx'
+  -- Index the transaction:
+  let mints = MintBurn.txbMints txb
+      gottenPolicyAssets = map (\mint -> (MintBurn.mintAssetPolicyId mint, MintBurn.mintAssetAssetName mint, MintBurn.mintAssetQuantity mint)) mints
+  -- Print footnote should the test fail:
+  let generatedPolicyAssets = getPolicyAssets mintValue
+  H.footnote $ "Assets to be created: " <> show generatedPolicyAssets <> "\n"
+            <> "Assets gotten: " <> show gottenPolicyAssets
+  -- The assets that were used to construct the transaction were found
+  -- in the generate transaction:
+  equalSet generatedPolicyAssets gottenPolicyAssets
+
+-- | Create transactions, index them, query indexer and find mint events.
+queryMintedValues :: Property
+queryMintedValues = H.property $ do
+  (indexer, insertedEvents, _) <- generateAndIndexEvents ":memory:"
+  -- Query results:
+  MintBurn.MintBurnResult queryResult <- liftIO $ RI.query RI.QEverything indexer MintBurn.Everything
+  -- Compare the sets of events inserted to the indexer and the set
+  -- gotten out of the indexer:
+  equalSet (MintBurn.groupBySlotAndHash insertedEvents) (MintBurn.fromRows queryResult)
+
+-- | Insert some events to an indexer, then recreate it from what is
+-- on disk (the in-memory part is lost), then query it and find all
+-- persisted events and none of the in-memory events.
+resume :: Property
+resume = H.property $ do
+  -- Index events that overflow:
+  (indexer, events, (bufferSize, _nTx)) <- generateAndIndexEvents ":memory:"
+  -- Open a new indexer based off of the old indexers sql connection:
+  indexer' <- liftIO $ mkNewIndexerBasedOnOldDb indexer
+  MintBurn.MintBurnResult queryResult <- liftIO $ RI.query RI.QEverything indexer' MintBurn.Everything
+  let expected = MintBurn.groupBySlotAndHash $ take (eventsPersisted bufferSize (length events)) events
+  -- The test: events that were persisted are exactly those we get from the query.
+  equalSet expected (MintBurn.fromRows queryResult)
+
+-- | Test that rewind (rollback for on-disk events) behaves as
+-- expected: insert events such that buffer overflows, rollback so far
+-- back that some events were already persisted, find no newer events
+-- than rollback point in query.
+rewind :: Property
+rewind = H.property $ do
+  (indexer, events, (_bufferSize, nTx)) <- generateAndIndexEvents ":memory:"
+  -- Rollback slot is from 0 to number of slots (slot numbers are from 0 to nTx - 1)
+  rollbackSlotNo <- fmap coerce $ forAll $ Gen.integral $ Range.constant 0 ((let w64 = fromIntegral nTx in if w64 == 0 then 0 else w64 - 1) :: Word64)
+  let cp = C.ChainPoint rollbackSlotNo dummyBlockHeaderHash
+  rewoundIndexer <- let errMsg = "Failed to rewind! This shouldn't happen and the test should be fixed"
+    in maybe (fail errMsg) pure =<< liftIO (RI.rewind cp indexer)
+  MintBurn.MintBurnResult queryResult <- liftIO $ RI.query RI.QEverything rewoundIndexer MintBurn.Everything
+  -- Expect only older than rollback events.
+  let expected = filter (\e -> MintBurn.txMintEventSlotNo e <= rollbackSlotNo) events
+  equalSet expected (MintBurn.fromRows queryResult)
+
+-- | Test that interval query works.
+intervals :: Property
+intervals = H.property $ do
+  (indexer, events, (_bufferSize, _nTx)) <- generateAndIndexEvents ":memory:"
+
+  let
+    cpFromSlot slotNo = C.ChainPoint slotNo dummyBlockHeaderHash
+    queryInterval from to = do
+      MintBurn.MintBurnResult queryResult <- liftIO $ RI.query (RI.QInterval from to) indexer MintBurn.Everything
+      pure $ MintBurn.fromRows queryResult
+
+  -- Genesis to genesis returns nothing
+  H.assert . null =<< queryInterval C.ChainPointAtGenesis C.ChainPointAtGenesis
+  -- When there were at least one event created:
+  when (not $ null events) $ do
+    let eventCp e = cpFromSlot $ MintBurn.txMintEventSlotNo e
+    -- From genesis to "latest slot + 1" returns everything:
+    equalSet events =<< (queryInterval C.ChainPointAtGenesis $ cpFromSlot $ (MintBurn.txMintEventSlotNo (last events)) + 1)
+    -- From first event's slot to last event's slot returns everything:
+    equalSet events =<< queryInterval (eventCp $ head events) (eventCp $ last events)
+    -- Form any slot to genesis returns nothing
+    ix <- forAll $ Gen.integral $ Range.constant 0 (length events - 1)
+    H.assert . null =<< queryInterval (cpFromSlot $ MintBurn.txMintEventSlotNo $ events !! ix) C.ChainPointAtGenesis
+
+    -- TODO: Enable the following test when there is an API for
+    -- getting an actual interval, and/or add another test for when
+    -- the meaning of queryInterval is clear.
+    --
+    -- Form any existing earlier slot to any existing same-or-later slot:
+    -- (from, to) <- do
+    --   a' <- forAll $ Gen.integral $ Range.constant 0 (length events - 1)
+    --   b' <- forAll $ Gen.integral $ Range.constant 0 (length events - 1)
+    --   let a = MintBurn.txMintEventSlotNo $ events !! a'
+    --       b = MintBurn.txMintEventSlotNo $ events !! b'
+    --   return $ if a <= b then (a, b) else (b, a)
+    -- let expected = filter (\e -> let slotNo = MintBurn.txMintEventSlotNo e in from <= slotNo && slotNo <= to) events
+    -- equalSet expected =<< queryInterval (cpFromSlot from) (cpFromSlot to)
+
+-- | Start testnet, start mint/burn indexer on it, create a single
+-- mint event, put it in a transaction and submit it, find the
+-- generated event passed back through the indexer.
+endToEnd :: Property
+endToEnd = H.withShrinks 0 $ H.integration $ (liftIO TN.setDarwinTmpdir >>) $ HE.runFinallies $ H.workspace "." $ \tempPath -> do
+  base <- HE.noteM $ liftIO . IO.canonicalizePath =<< HE.getProjectBase
+  (localNodeConnectInfo, conf, runtime) <- TN.startTestnet TN.defaultTestnetOptions base tempPath
+  let networkId = TN.getNetworkId runtime
+  socketPath <- TN.getSocketPathAbs conf runtime
+
+  -- This is the channel we wait on to know if the event has been indexed
+  indexedTxs <- liftIO IO.newChan
+  -- Start indexer
+  liftIO $ do
+    coordinator <- M.initialCoordinator 1
+    ch <- IO.atomically . IO.dupTChan $ M._channel coordinator
+    (loop, _indexerMVar) <- M.mintBurnWorker_ 123 (IO.writeChan indexedTxs) coordinator ch (tempPath </> "db.db")
+    void $ IO.async loop
+    -- Receive ChainSyncEvents and pass them on to indexer's channel
+    void $ IO.async $ do
+      let chainPoint = C.ChainPointAtGenesis :: C.ChainPoint
+      c <- defaultConfigStdout
+      withTrace c "marconi" $ \trace -> let
+        indexerWorker = withChainSyncEventStream socketPath networkId [chainPoint] $ S.mapM_ $
+          \chainSyncEvent -> IO.atomically $ IO.writeTChan ch chainSyncEvent
+        handleException NoIntersectionFound = logError trace $ renderStrict $ layoutPretty defaultLayoutOptions $
+          "No intersection found for chain point" <+> pretty chainPoint <> "."
+        in indexerWorker `catch` handleException :: IO ()
+
+  -- Create & submit transaction
+  pparams <- TN.getAlonzoProtocolParams localNodeConnectInfo
+  txMintValue <- forAll genTxMintValue
+
+  genesisVKey :: C.VerificationKey C.GenesisUTxOKey <- TN.readAs (C.AsVerificationKey C.AsGenesisUTxOKey) $ tempPath </> "shelley/utxo-keys/utxo1.vkey"
+  genesisSKey :: C.SigningKey C.GenesisUTxOKey <- TN.readAs (C.AsSigningKey C.AsGenesisUTxOKey) $ tempPath </> "shelley/utxo-keys/utxo1.skey"
+  let paymentKey = C.castVerificationKey genesisVKey :: C.VerificationKey C.PaymentKey
+      address :: C.Address C.ShelleyAddr
+      address = C.makeShelleyAddress
+        networkId
+        (C.PaymentCredentialByKey (C.verificationKeyHash paymentKey :: C.Hash C.PaymentKey))
+        C.NoStakeAddress :: C.Address C.ShelleyAddr
+
+  value <- H.fromJustM $ getValue txMintValue
+  (txIns, lovelace) <- TN.getAddressTxInsValue localNodeConnectInfo address
+  let fee = 500 :: C.Lovelace
+      amountReturned = lovelace - fee :: C.Lovelace
+      txOut :: C.TxOut ctx C.AlonzoEra
+      txOut =
+        C.TxOut
+          (C.AddressInEra (C.ShelleyAddressInEra C.ShelleyBasedEraAlonzo) address)
+          (C.TxOutValue C.MultiAssetInAlonzoEra $ C.lovelaceToValue amountReturned <> value)
+          C.TxOutDatumNone
+          C.ReferenceScriptNone
+      txBodyContent :: C.TxBodyContent C.BuildTx C.AlonzoEra
+      txBodyContent = (TN.emptyTxBodyContent fee pparams)
+        { C.txIns = map (\txIn -> (txIn, C.BuildTxWith $ C.KeyWitness C.KeyWitnessForSpending)) txIns
+        , C.txOuts = [txOut]
+        , C.txProtocolParams = C.BuildTxWith $ Just pparams
+        , C.txMintValue = txMintValue
+        , C.txInsCollateral = C.TxInsCollateral C.CollateralInAlonzoEra txIns
+        }
+  txBody :: C.TxBody C.AlonzoEra <- H.leftFail $ C.makeTransactionBody txBodyContent
+  let
+    kw :: C.KeyWitness C.AlonzoEra
+    kw = C.makeShelleyKeyWitness txBody (C.WitnessPaymentKey $ C.castSigningKey genesisSKey)
+    tx = C.makeSignedTransaction [kw] txBody
+  TN.submitTx localNodeConnectInfo tx
+
+  -- Receive event from the indexer, compare the mint that we
+  -- submitted above with the one we got from the indexer.
+  event <- liftIO $ IO.readChan indexedTxs
+  case MintBurn.txMintEventTxAssets event of
+     (_txId, gottenMintEvents :: NonEmpty MintBurn.MintAsset) :| [] -> let
+       in equalSet (mintsToPolicyAssets $ NonEmpty.toList gottenMintEvents) (getPolicyAssets txMintValue)
+     _ -> fail "More than one mint/burn event, but we created only one!"
+
+-- * Generators
+
+-- | The workhorse of the test: generate an indexer, then generate
+-- transactions to index, then index them.
+generateAndIndexEvents :: FilePath -> H.PropertyT IO (MintBurn.MintBurnIndexer, [MintBurn.TxMintEvent], (Int, Int))
+generateAndIndexEvents dbPath = do
+  (events, (bufferSize, nTx)) <- forAll generateTxsWithMints
+  -- Report buffer overflow:
+  let overflow = bufferSize < length events
+  H.classify "No events created at all" $ null events
+  H.classify "Buffer doesn't overflow" $ not (null events) && not overflow
+  H.classify "Buffer overflows" $ not (null events) && overflow
+  indexer <- liftIO $ do
+    indexer <- MintBurn.open dbPath bufferSize
+    foldM (\indexer' event -> RI.insert (MintBurn.MintBurnEvent event) indexer') indexer events
+  pure (indexer, events, (bufferSize, nTx))
+
+-- | Generate transactions which have mints inside, then extract
+-- TxMintEvent's from these, then return them with buffer size and
+-- number of transactions.
+generateTxsWithMints :: Gen ([MintBurn.TxMintEvent], (Int, Int))
+generateTxsWithMints = do
+  bufferSize <- Gen.integral (Range.constant 1 10)
+  nTx <- Gen.choice                                                   -- Number of events:
+    [ Gen.constant 0                                                  --  1. no events generated
+    , Gen.integral $ Range.constant 0 bufferSize                      --  2. buffer not filled
+    , Gen.integral $ Range.constant (bufferSize + 1) (bufferSize * 2) --  3. guaranteed buffer overflow
+    ]
+  -- Generate transactions
+  txAll' <- forM [0 .. (nTx - 1)] $ \slotNoInt -> do
+    tx <- genTxWithMint =<< genTxMintValue
+    pure (tx, fromIntegral slotNoInt :: C.SlotNo)
+  -- Filter out Left C.TxBodyError
+  txAll <- forM txAll' $ \case
+    (Right tx, slotNo) -> pure (tx, slotNo)
+    (Left txBodyError, _) -> fail $ "Failed to create a transaction! This shouldn't happen, the generator should be fixed. TxBodyError: " <> show txBodyError
+  let events = mapMaybe (\(tx, slotNo) -> MintBurn.TxMintEvent slotNo dummyBlockHeaderHash . pure <$> MintBurn.txMints tx) txAll
+  pure (events, (bufferSize, nTx))
+
+genTxWithMint :: C.TxMintValue C.BuildTx C.AlonzoEra -> Gen (Either C.TxBodyError (C.Tx C.AlonzoEra))
+genTxWithMint txMintValue = do
+  txbc <- CGen.genTxBodyContent C.AlonzoEra
+  txIn <- CGen.genTxIn
+  pparams' :: C.ProtocolParameters <- CGen.genProtocolParameters
+  let
+    pparams = C.BuildTxWith $ Just pparams'
+      { C.protocolParamUTxOCostPerWord = Just 1
+      , C.protocolParamPrices = Just $ C.ExecutionUnitPrices 1 1
+      , C.protocolParamMaxTxExUnits = Just $ C.ExecutionUnits 1 1
+      , C.protocolParamMaxBlockExUnits = Just $ C.ExecutionUnits 1 1
+      , C.protocolParamMaxValueSize = Just 1
+      , C.protocolParamCollateralPercent = Just 1
+      , C.protocolParamMaxCollateralInputs = Just 1
+      }
+    txbc' = txbc
+      { C.txMintValue = txMintValue
+      , C.txInsCollateral = C.TxInsCollateral C.CollateralInAlonzoEra [txIn]
+      , C.txProtocolParams = pparams
+      }
+  pure $ do
+    txb <- C.makeTransactionBody txbc'
+    pure $ C.signShelleyTransaction txb []
+
+-- | Helper to create tx with @commonMintingPolicy@, @assetName@ and @quantity@
+genTxWithAsset :: C.AssetName -> C.Quantity -> Gen (Either C.TxBodyError (C.Tx C.AlonzoEra))
+genTxWithAsset assetName quantity = genTxWithMint $ C.TxMintValue C.MultiAssetInAlonzoEra mintedValues (C.BuildTxWith $ Map.singleton policyId policyWitness)
+  where (policyId, policyWitness, mintedValues) = mkMintValue commonMintingPolicy [(assetName, quantity)]
+
+genTxMintValue :: Gen (C.TxMintValue C.BuildTx C.AlonzoEra)
+genTxMintValue = do
+  n :: Int <- Gen.integral (Range.constant 1 5)
+  -- n :: Int <- Gen.integral (Range.constant 0 5)
+  -- TODO: fix bug RewindableIndex.Storable.rewind and change range to start from 0.
+  policyAssets <- replicateM n genAsset
+  let (policyId, policyWitness, mintedValues) = mkMintValue commonMintingPolicy policyAssets
+  pure $ C.TxMintValue C.MultiAssetInAlonzoEra mintedValues (C.BuildTxWith $ Map.singleton policyId policyWitness)
+  where
+    genAsset :: Gen (C.AssetName, C.Quantity)
+    genAsset = (,) <$> genAssetName <*> genQuantity
+      where
+        genAssetName = coerce @_ @C.AssetName <$> Gen.bytes (Range.constant 1 5)
+        genQuantity = coerce @Integer @C.Quantity <$> Gen.integral (Range.constant 1 100)
+
+-- * Helpers
+
+-- | Remove events that remained in buffer.
+onlyPersisted :: Int -> [a] -> [a]
+onlyPersisted bufferSize events = take (eventsPersisted bufferSize $ length events) $ events
+
+eventsPersisted :: Int -> Int -> Int
+eventsPersisted bufferSize nEvents = let
+  -- Number of buffer flushes
+  bufferFlushesN = let
+    (n, m) = nEvents `divMod` bufferSize
+    in if m == 0 then n - 1 else n
+  -- Number of events persisted
+  numberOfEventsPersisted = bufferFlushesN * bufferSize
+  in numberOfEventsPersisted
+
+mkMintValue
+  :: PlutusV1.MintingPolicy -> [(C.AssetName, C.Quantity)]
+  -> (C.PolicyId, C.ScriptWitness C.WitCtxMint C.AlonzoEra, C.Value)
+mkMintValue policy policyAssets = (policyId, policyWitness, mintedValues)
+  where
+    serialisedPolicyScript :: C.PlutusScript C.PlutusScriptV1
+    serialisedPolicyScript = C.PlutusScriptSerialised $ SBS.toShort . LBS.toStrict $ serialise $ PlutusV1.unMintingPolicyScript policy
+
+    policyId :: C.PolicyId
+    policyId = C.scriptPolicyId $ C.PlutusScript C.PlutusScriptV1 serialisedPolicyScript :: C.PolicyId
+
+    executionUnits :: C.ExecutionUnits
+    executionUnits = C.ExecutionUnits {C.executionSteps = 300000, C.executionMemory = 1000 }
+    redeemer :: C.ScriptData
+    redeemer = C.fromPlutusData $ PlutusV1.toData ()
+    policyWitness :: C.ScriptWitness C.WitCtxMint C.AlonzoEra
+    policyWitness = C.PlutusScriptWitness C.PlutusScriptV1InAlonzo C.PlutusScriptV1
+      (C.PScript serialisedPolicyScript) C.NoScriptDatumForMint redeemer executionUnits
+
+    mintedValues :: C.Value
+    mintedValues = C.valueFromList $ map (\(assetName, quantity) -> (C.AssetId policyId assetName, quantity)) policyAssets
+
+commonMintingPolicy :: PlutusV1.MintingPolicy
+commonMintingPolicy = PlutusV1.mkMintingPolicyScript $$(PlutusTx.compile [||\_ _ -> ()||])
+
+-- | Recreate an indexe, useful because the sql connection to a
+-- :memory: database can be reused.
+mkNewIndexerBasedOnOldDb :: RI.State MintBurn.MintBurnHandle -> IO (RI.State MintBurn.MintBurnHandle)
+mkNewIndexerBasedOnOldDb indexer = let
+    MintBurn.MintBurnHandle sqlCon k = Lens.view RI.handle indexer
+  in RI.emptyState k (MintBurn.MintBurnHandle sqlCon k)
+
+dummyBlockHeaderHash :: C.Hash C.BlockHeader
+dummyBlockHeaderHash = fromString "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" :: C.Hash C.BlockHeader
+
+equalSet :: (H.MonadTest m, Show a, Ord a) => [a] -> [a] -> m ()
+equalSet a b = Set.fromList a === Set.fromList b
+
+getPolicyAssets :: C.TxMintValue C.BuildTx C.AlonzoEra -> [(C.PolicyId, C.AssetName, C.Quantity)]
+getPolicyAssets txMintValue = case txMintValue of
+  (C.TxMintValue C.MultiAssetInAlonzoEra mintedValues (C.BuildTxWith _policyIdToWitnessMap)) ->
+    mapMaybe (\(assetId, quantity) -> case assetId of
+             C.AssetId policyId assetName -> Just (policyId, assetName, quantity)
+             C.AdaAssetId                 -> Nothing
+        ) $ C.valueToList mintedValues
+  _ -> []
+
+getValue :: C.TxMintValue C.BuildTx C.AlonzoEra -> Maybe C.Value
+getValue = \case
+  C.TxMintValue C.MultiAssetInAlonzoEra value (C.BuildTxWith _policyIdToWitnessMap) -> Just value
+  _                                                                                 -> Nothing
+
+mintsToPolicyAssets :: [MintBurn.MintAsset] -> [(C.PolicyId, C.AssetName, C.Quantity)]
+mintsToPolicyAssets mints =
+  map (\mint -> (MintBurn.mintAssetPolicyId mint, MintBurn.mintAssetAssetName mint, MintBurn.mintAssetQuantity mint)) mints

--- a/marconi/test/Spec.hs
+++ b/marconi/test/Spec.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import Control.Monad (replicateM)
+import Data.Coerce (coerce)
+import Data.Set qualified as S
+
+import Hedgehog (Gen, Property, assert, forAll, property)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.Hedgehog (testPropertyNamed)
+
+import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as Shelley
+import Gen.Cardano.Api.Typed qualified as CGen
+
+import Marconi.Index.ScriptTx qualified as ScriptTx
+import Spec.Marconi.Index.AddressDatum qualified as AddressDatum
+
+-- See TODO below, import EpochStakepoolSize qualified
+import Integration qualified
+import MintBurn qualified
+import Spec.Utxo qualified
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Marconi"
+  [ testPropertyNamed "prop_script_hashes_in_tx_match" "getTxBodyScriptsRoundtrip" getTxBodyScriptsRoundtrip
+  , Spec.Utxo.tests
+  , AddressDatum.tests
+  , Integration.tests
+  -- , EpochStakepoolSize.tests
+  -- TODO Enable above when the following PR in cardano-node is merged: https://github.com/input-output-hk/cardano-node/pull/4680/
+  , MintBurn.tests
+  ]
+
+-- | Create @nScripts@ scripts, add them to a transaction body, then
+-- generate a transaction with @makeTransactionBody@ and check if the
+-- scripts put in are present in the generated transaction.
+getTxBodyScriptsRoundtrip :: Property
+getTxBodyScriptsRoundtrip = property $ do
+  nScripts <- forAll $ Gen.integral (Range.linear 5 500)
+  C.AnyCardanoEra (era :: C.CardanoEra era) <- forAll $
+    Gen.enum (C.AnyCardanoEra C.ShelleyEra) maxBound
+
+  txIns <- replicateM nScripts $ forAll CGen.genTxIn
+  witnessesHashes <- replicateM nScripts $ forAll $ genWitnessAndHashInEra era
+
+  let (witnesses, scriptHashes) = unzip witnessesHashes
+      collateral = case C.collateralSupportedInEra era of
+        Just yes -> C.TxInsCollateral yes txIns
+        _        -> C.TxInsCollateralNone
+
+  txBody <- forAll $ genTxBodyWithTxIns era (zip txIns $ map C.BuildTxWith witnesses) collateral
+  let hashesFound = map coerce $ ScriptTx.getTxBodyScripts txBody :: [C.ScriptHash]
+  assert $ S.fromList scriptHashes == S.fromList hashesFound
+
+genTxBodyWithTxIns
+  :: C.IsCardanoEra era
+  => C.CardanoEra era
+  -> [(C.TxIn, C.BuildTxWith C.BuildTx (C.Witness C.WitCtxTxIn era))]
+  -> C.TxInsCollateral era
+  -> Gen (C.TxBody era)
+genTxBodyWithTxIns era txIns txInsCollateral = do
+  txBodyContent <- genTxBodyContentWithTxInsCollateral era txIns txInsCollateral
+  case C.makeTransactionBody txBodyContent of
+    Left err     -> fail $ C.displayError err
+    Right txBody -> pure txBody
+
+genTxBodyContentWithTxInsCollateral
+  :: C.CardanoEra era
+  -> [(C.TxIn, C.BuildTxWith C.BuildTx (C.Witness C.WitCtxTxIn era))]
+  -> C.TxInsCollateral era
+  -> Gen (C.TxBodyContent C.BuildTx era)
+genTxBodyContentWithTxInsCollateral era txIns txInsCollateral = do
+  txbody <- CGen.genTxBodyContent era
+  txProtocolParams <- C.BuildTxWith . Just <$> CGen.genProtocolParameters
+  pure $ txbody
+    { C.txIns
+    , C.txInsCollateral
+    , C.txProtocolParams
+    }
+
+genWitnessAndHashInEra :: C.CardanoEra era -> Gen (C.Witness C.WitCtxTxIn era, C.ScriptHash)
+genWitnessAndHashInEra era = do
+  C.ScriptInEra scriptLanguageInEra script <- CGen.genScriptInEra era
+  witness :: C.Witness C.WitCtxTxIn era1 <- C.ScriptWitness C.ScriptWitnessForSpending <$> case script of
+    C.PlutusScript version plutusScript -> do
+      scriptData <- CGen.genScriptData
+      executionUnits <- genExecutionUnits
+      pure $ C.PlutusScriptWitness
+        scriptLanguageInEra
+        version
+        (Shelley.PScript plutusScript)
+        (C.ScriptDatumForTxIn scriptData)
+        scriptData
+        executionUnits
+    C.SimpleScript version simpleScript ->
+      pure $ C.SimpleScriptWitness scriptLanguageInEra version (Shelley.SScript simpleScript)
+  pure (witness, C.hashScript script)
+
+-- | TODO Copy-paste from cardano-node: cardano-api/gen/Gen/Cardano/Api/Typed.hs
+genExecutionUnits :: Gen C.ExecutionUnits
+genExecutionUnits = C.ExecutionUnits <$> Gen.integral (Range.constant 0 1000)
+                                     <*> Gen.integral (Range.constant 0 1000)


### PR DESCRIPTION
Ready for review, changes since the mob review:
- handling of intervals and a new interval test
- end-to-end test now also uses generator to create TxMintValue

I think I've also found and fixed two bugs in rewindable index:
- [4af8f94](https://github.com/input-output-hk/plutus-apps/pull/913/commits/4af8f946905c733abec642a65707a644b5900b76) `filterWithQueryInterval` wasn't using the start of interval to filter out elements
- [594f20a](https://github.com/input-output-hk/plutus-apps/pull/913/commits/594f20a57c765d4944023ea61d05215d40ae46a3) `rewind` didn't account for gaps in events

Not sure about the `filterWithQueryInterval` fix as it makes a test fail in rewindable-index: New index properties -> Insert is folding the structure.

@raduom should inspect these and perhaps add tests to for regressions.

(CI fails currently due to a bug in cabal-fmt, being worked on here: https://github.com/input-output-hk/plutus-apps/pull/921)

---
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [X] Important changes are reflected in changelog.d of the affected packages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [X] Reviewer requested
