### PR TITLE
PLT-662 Added Address->Datum indexer in Marconi

### DIFF
--- a/marconi/app/Main.hs
+++ b/marconi/app/Main.hs
@@ -25,6 +25,7 @@ main = do
   c <- defaultConfigStdout
   withTrace c "marconi" $ \trace -> do
     let indexers = filterIndexers (Cli.utxoDbPath o)
+                                  (Cli.addressDatumDbPath o)
                                   (Cli.datumDbPath o)
                                   (Cli.scriptTxDbPath o)
                                   (Cli.epochStakepoolSizeDbPath o)

--- a/marconi/changelog.d/20230130_140515_konstantinos.lambrou_PLT_662_maconi_address_datum.md
+++ b/marconi/changelog.d/20230130_140515_konstantinos.lambrou_PLT_662_maconi_address_datum.md
@@ -1,0 +1,5 @@
+### Added
+
+- Address-Datum indexer: indexes all datums for any given address in Cardano.
+
+- CLI flag to allow disabling the Address-Datum indexer.

--- a/marconi/marconi.cabal
+++ b/marconi/marconi.cabal
@@ -50,6 +50,7 @@ library
   hs-source-dirs:  src
   exposed-modules:
     Marconi.CLI
+    Marconi.Index.AddressDatum
     Marconi.Index.Datum
     Marconi.Index.EpochStakepoolSize
     Marconi.Index.ScriptTx
@@ -194,6 +195,11 @@ test-suite marconi-test
   other-modules:
     EpochStakepoolSize
     Integration
+    Spec.Marconi.Index.AddressDatum
+    Spec.Marconi.Index.AddressDatum.AddressDatumIndex
+    Spec.Marconi.Index.AddressDatum.AddressDatumIndexEvent
+    Spec.Marconi.Index.AddressDatum.Generators
+    Spec.Marconi.Index.AddressDatum.Utils
     Spec.Utxo
 
   --------------------
@@ -210,8 +216,13 @@ test-suite marconi-test
   --------------------------
   build-depends:
     , cardano-api:{cardano-api, gen}
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-ledger-core
     , cardano-testnet
     , iohk-monitoring
+    , ouroboros-network
+    , plutus-core
     , plutus-ledger-api
     , plutus-tx
     , plutus-tx-plugin

--- a/marconi/src/Marconi/CLI.hs
+++ b/marconi/src/Marconi/CLI.hs
@@ -9,6 +9,7 @@ module Marconi.CLI
     , optionsParser
     , parseOptions
     , utxoDbPath
+    , addressDatumDbPath
     , datumDbPath
     , scriptTxDbPath
     , epochStakepoolSizeDbPath
@@ -104,6 +105,7 @@ data Options = Options
     optionsChainPoint           :: ChainPoint,
     optionsDbPath               :: FilePath,    -- ^ SQLite database directory path
     optionsDisableUtxo          :: Bool,
+    optionsDisableAddressDatum  :: Bool,
     optionsDisableDatum         :: Bool,
     optionsDisableScript        :: Bool,
     optionsDisableStakepoolSize :: Bool,
@@ -144,6 +146,10 @@ optionsParser =
                       <> Opt.help "disable utxo indexers."
                       <> Opt.showDefault
                      )
+    <*> Opt.switch (Opt.long "disable-address-datum"
+                      <> Opt.help "disable address->datum indexers."
+                      <> Opt.showDefault
+                     )
     <*> Opt.switch (Opt.long "disable-datum"
                       <> Opt.help "disable datum indexers."
                       <> Opt.showDefault
@@ -172,6 +178,9 @@ optAddressesParser =  optional . multiString
 utxoDbName :: FilePath
 utxoDbName = "utxo.db"
 
+addressDatumDbName :: FilePath
+addressDatumDbName = "addressdatum.db"
+
 datumDbName :: FilePath
 datumDbName = "datum.db"
 
@@ -183,6 +192,9 @@ epochStakepoolSizeDbName = "epochstakepool.db"
 
 utxoDbPath :: Options -> Maybe FilePath
 utxoDbPath o = if optionsDisableUtxo o then Nothing; else Just (optionsDbPath o </> utxoDbName)
+
+addressDatumDbPath :: Options -> Maybe FilePath
+addressDatumDbPath o = if optionsDisableAddressDatum o then Nothing; else Just (optionsDbPath o </> addressDatumDbName)
 
 datumDbPath :: Options -> Maybe FilePath
 datumDbPath o = if optionsDisableDatum o then Nothing; else Just (optionsDbPath o </> datumDbName)

--- a/marconi/src/Marconi/Index/AddressDatum.hs
+++ b/marconi/src/Marconi/Index/AddressDatum.hs
@@ -1,0 +1,510 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE QuasiQuotes        #-}
+{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE TupleSections      #-}
+
+-- | Module for indexing the datums for all addresses in the Cardano blockchain.
+
+-- This module will create the SQL tables:
+
+-- + table: address_datums
+--
+-- @
+--    |---------+------------+---------+------------|
+--    | address | datum_hash | slot_no | block_hash |
+--    |---------+------------+---------+------------|
+-- @
+--
+-- + table: datumhash_datum
+--
+-- @
+--    |------------+-------|
+--    | datum_hash | datum |
+--    |------------+-------|
+-- @
+
+-- To create these tables, we extract all transactions outputs from each transactions fetched with
+-- the chain-sync protocol of the local node.
+
+-- Here is a synopsis of the indexing algorithm.
+
+-- Each transaction output contains an address along with an optional datum hash or an optional inline
+-- datum (actual datum).
+-- In the inline datum scenario, we simply create an entry in the `address_datums` table with the hash
+-- of the datum, and add an entry in the `datumhash_datum` table.
+-- In the datum hash scenario, we create an entry in the `address_datums` table, but not in the
+-- `datumhash_datum` table, as we don't know the actual value of the datum and we can't infer it from
+-- the hash.
+-- In that last scenario, we can resolve in the datum hash in one of three ways (which we then simply
+-- add an entry in the `datumhash_datum` table):
+--
+--     * a different transaction output has an inline datum with that same hash
+--
+--     * a datum with that same hash has been found in the in transaction body
+--
+--     * a datum with that same hash was included in the witnesses for a Plutus spending script
+--     which was included in the transaction body
+--
+module Marconi.Index.AddressDatum
+  ( -- * AddressDatumIndex
+    AddressDatumIndex
+  , AddressDatumHandle
+  , StorableEvent(..)
+  , StorableQuery(..)
+  , StorableResult(..)
+  , toAddressDatumIndexEvent
+  , AddressDatumQuery
+  , AddressDatumResult
+  , AddressDatumDepth (..)
+  , open
+  ) where
+
+import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as C
+import Cardano.Ledger.Alonzo.TxWitness qualified as Ledger
+import Control.Applicative ((<|>))
+import Control.Monad (forM, forM_)
+import Data.Foldable (Foldable (foldl'), fold, toList)
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (catMaybes, listToMaybe, mapMaybe)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Database.SQLite.Simple qualified as SQL
+import Database.SQLite.Simple.ToField qualified as SQL
+import GHC.Generics (Generic)
+import Marconi.Orphans ()
+import RewindableIndex.Storable (Buffered (persistToStorage), HasPoint (getPoint),
+                                 QueryInterval (QEverything, QInterval), Queryable (queryStorage), Resumable,
+                                 Rewindable (rewindStorage), StorableEvent, StorableMonad, StorablePoint, StorableQuery,
+                                 StorableResult, emptyState, filterWithQueryInterval)
+import RewindableIndex.Storable qualified as Storable
+import Text.RawString.QQ (r)
+
+-- | Define the `handler` data type, meant as a wrapper for the connection type (in this case the
+-- SQLite connection). In this indexer, we also add the number of events that we want to return from
+-- the on-disk buffer.
+data AddressDatumHandle = AddressDatumHandle
+    { addressDatumHandleConnection :: SQL.Connection
+    , _addressDatumHandleDiskStore :: Int
+    }
+
+type instance StorableMonad AddressDatumHandle = IO
+
+-- | 'StorableEvent AddressDatumHandle is the type of events. Events are the data atoms that the
+-- indexer consumes.
+-- They depend on the `handle` because they need to eventually be persisted in the database, so the
+-- database has to be able to accomodate them.
+
+-- We store the datum hashes of each address that we processed.
+-- Then we keep a separate 'Map' which stores the actual datum given a datum hash.
+-- Note that we don't always have the actual datum for a given hash.
+data instance StorableEvent AddressDatumHandle =
+    AddressDatumIndexEvent
+        (Map C.AddressAny (Set (C.Hash C.ScriptData)))
+        (Map (C.Hash C.ScriptData) C.ScriptData)
+        !C.ChainPoint
+    deriving (Eq, Show)
+
+instance Semigroup (StorableEvent AddressDatumHandle) where
+    AddressDatumIndexEvent ad1 d1 c1 <> AddressDatumIndexEvent ad2 d2 c2 =
+        AddressDatumIndexEvent
+            (Map.unionWith (<>) ad1 ad2)
+            (Map.union d1 d2)
+            (max c1 c2)
+
+instance Monoid (StorableEvent AddressDatumHandle) where
+    mempty = AddressDatumIndexEvent Map.empty Map.empty C.ChainPointAtGenesis
+    mappend = (<>)
+
+type instance StorablePoint AddressDatumHandle = C.ChainPoint
+
+instance HasPoint (StorableEvent AddressDatumHandle) C.ChainPoint where
+  getPoint (AddressDatumIndexEvent _ _ s) = s
+
+data instance StorableQuery AddressDatumHandle =
+    AllAddressesQuery
+    | AddressDatumQuery C.AddressAny
+
+data instance StorableResult AddressDatumHandle =
+    AllAddressesResult (Set C.AddressAny)
+  | AddressDatumResult (Set C.ScriptData)
+    deriving (Eq, Show)
+
+type AddressDatumQuery = StorableQuery AddressDatumHandle
+type AddressDatumResult = StorableResult AddressDatumHandle
+
+type AddressDatumIndex = Storable.State AddressDatumHandle
+
+newtype AddressDatumDepth = AddressDatumDepth Int
+
+-- * SQLite
+
+data AddressDatumHashRow = AddressDatumHashRow
+  { addressDatumRowAddress   :: !C.AddressAny
+  , addressDatumRowDatumHash :: !(C.Hash C.ScriptData)
+  , addressDatumRowSlot      :: !C.SlotNo
+  , addressDatumRowBlockHash :: !(C.Hash C.BlockHeader)
+  } deriving (Show, Generic)
+
+instance SQL.ToRow AddressDatumHashRow where
+  toRow (AddressDatumHashRow addr d slotNo blockHash) =
+      [ SQL.toField addr
+      , SQL.toField d
+      , SQL.toField slotNo
+      , SQL.toField blockHash
+      ]
+
+deriving anyclass instance SQL.FromRow AddressDatumHashRow
+
+data DatumRow = DatumRow
+    { datumRowDatumHash :: C.Hash C.ScriptData
+    , datumRowDatum     :: C.ScriptData
+    } deriving (Show, Generic)
+
+instance SQL.ToRow DatumRow where
+  toRow (DatumRow dh d) = [SQL.toField dh, SQL.toField d]
+
+deriving anyclass instance SQL.FromRow DatumRow
+
+toAddressDatumIndexEvent
+    :: Maybe (C.Address C.ShelleyAddr -> Bool)
+    -> [C.Tx era]
+    -> C.ChainPoint
+    -> StorableEvent AddressDatumHandle
+toAddressDatumIndexEvent addressFilter txs chainPoint = do
+    let datumsPerAddr = getDatumsPerAddressFromTxs
+        filterFun =
+            case addressFilter of
+              Nothing -> id
+              Just f -> Map.filterWithKey $ \k _ ->
+                  case k of
+                      -- Target addresses filter are only shelley addresses. Therefore, as we
+                      -- encounter Byron addresses with datum, we don't filter them. However, that
+                      -- is highly improbable as Byron addresses are almost never used anymore.
+                      C.AddressByron _      -> True
+                      C.AddressShelley addr -> f addr
+        filteredDatumsPerAddr = filterFun datumsPerAddr
+        datumMap = Map.fromList
+                 $ mapMaybe (\(dh, d) -> fmap (dh,) d)
+                 $ concatMap (\datums -> Map.toList datums)
+                 $ Map.elems filteredDatumsPerAddr
+     in AddressDatumIndexEvent
+            (fmap Map.keysSet filteredDatumsPerAddr)
+            (Map.union datumMap getPlutusWitDatumsFromTxs)
+            chainPoint
+ where
+    getDatumsPerAddressFromTxs :: Map C.AddressAny (Map (C.Hash C.ScriptData) (Maybe C.ScriptData))
+    getDatumsPerAddressFromTxs =
+         Map.filter (not . Map.null)
+            $ Map.fromListWith (Map.unionWith (<|>))
+            $ concatMap getDatumsPerAddressFromTx txs
+
+    getDatumsPerAddressFromTx
+        :: C.Tx era
+        -> [(C.AddressAny, Map (C.Hash C.ScriptData) (Maybe C.ScriptData))]
+    getDatumsPerAddressFromTx (C.Tx (C.TxBody C.TxBodyContent { C.txOuts }) _) =
+         fmap
+            (\(C.TxOut (C.AddressInEra _ addr) _ dat _) ->
+                ( C.toAddressAny addr
+                , maybe Map.empty (uncurry Map.singleton) $ getScriptDataFromTxOutDatum dat
+                ))
+            txOuts
+
+    getScriptDataFromTxOutDatum
+        :: C.TxOutDatum C.CtxTx era
+        -> Maybe (C.Hash C.ScriptData, Maybe C.ScriptData)
+    getScriptDataFromTxOutDatum (C.TxOutDatumHash _ dh)  = Just (dh, Nothing)
+    getScriptDataFromTxOutDatum (C.TxOutDatumInTx _ d)   = Just (C.hashScriptData d, Just d)
+    getScriptDataFromTxOutDatum (C.TxOutDatumInline _ d) = Just (C.hashScriptData d, Just d)
+    getScriptDataFromTxOutDatum _                        = Nothing
+
+    getPlutusWitDatumsFromTxs :: Map (C.Hash C.ScriptData) C.ScriptData
+    getPlutusWitDatumsFromTxs =
+        foldr (\acc x -> Map.union acc x) Map.empty
+        $ fmap (\(C.Tx txBody _) -> getPlutusWitDatumsFromTxBody txBody) txs
+
+    getPlutusWitDatumsFromTxBody :: C.TxBody era -> Map (C.Hash C.ScriptData) C.ScriptData
+    getPlutusWitDatumsFromTxBody (C.ShelleyTxBody _ _ _ (C.TxBodyScriptData _ (Ledger.TxDats' datum) _) _ _) =
+        -- TODO I'm recomputing the ScriptHash hash, because cardano-api doesn't provide the correct
+        -- functions to convert 'Ledger.DataHash' to 'C.Hash C.ScriptData'. This should go away once
+        -- we fully switch to `cardano-ledger` types.
+        Map.fromList
+            $ fmap (\(_, alonzoDat) -> let d = C.fromAlonzoData alonzoDat in (C.hashScriptData d, d))
+            $ Map.toList datum
+    getPlutusWitDatumsFromTxBody (C.TxBody _) = Map.empty
+
+instance Buffered AddressDatumHandle where
+  persistToStorage
+    :: Foldable f
+    => f (StorableEvent AddressDatumHandle)
+    -> AddressDatumHandle
+    -> IO AddressDatumHandle
+  persistToStorage es h = do
+    let addressDatumHashRows = foldl' (\ea e -> ea ++ toAddressDatumHashRow e) [] es
+        datumRows = foldl' (\ea e -> ea ++ toDatumRow e) [] es
+        c    = addressDatumHandleConnection h
+    SQL.execute_ c "BEGIN"
+    forM_ addressDatumHashRows $
+      SQL.execute c
+          [r|INSERT INTO address_datums
+              ( address
+              , datum_hash
+              , slot_no
+              , block_hash
+              )
+             VALUES (?, ?, ?, ?)|]
+    forM_ datumRows $
+      -- We ignore inserts that introduce duplicate datum hashes in the table
+      SQL.execute c
+        [r|INSERT OR IGNORE INTO datumhash_datum
+            ( datum_hash
+            , datum
+            )
+           VALUES (?, ?)|]
+    SQL.execute_ c "COMMIT"
+    pure h
+    where
+      toAddressDatumHashRow :: StorableEvent AddressDatumHandle -> [AddressDatumHashRow]
+      toAddressDatumHashRow (AddressDatumIndexEvent _ _ C.ChainPointAtGenesis) = []
+      toAddressDatumHashRow (AddressDatumIndexEvent addressDatumHashMap _ (C.ChainPoint sl bh)) = do
+          (addr, dhs) <- Map.toList addressDatumHashMap
+          dh <- Set.toList dhs
+          pure $ AddressDatumHashRow addr dh sl bh
+      toDatumRow :: StorableEvent AddressDatumHandle -> [DatumRow]
+      toDatumRow (AddressDatumIndexEvent _ datumMap _) =
+          fmap (uncurry DatumRow) $ Map.toList datumMap
+
+  getStoredEvents
+    :: AddressDatumHandle
+    -> IO [StorableEvent AddressDatumHandle]
+  getStoredEvents (AddressDatumHandle c n) = do
+      sns :: [[Integer]] <-
+          SQL.query c
+            [r|SELECT slot_no
+               FROM address_datums
+               GROUP BY slot_no
+               ORDER BY slot_no
+               DESC LIMIT ?|]
+            (SQL.Only n)
+      -- Take the slot number of the sz'th slot
+      let sn = if null sns
+                  then 0
+                  else head . last $ take n sns
+      res <-
+          SQL.query c
+            [r|SELECT address, address_datums.datum_hash, datumhash_datum.datum, slot_no, block_hash
+               FROM address_datums
+               LEFT JOIN datumhash_datum
+               ON datumhash_datum.datum_hash = address_datums.datum_hash
+               WHERE slot_no >= ?
+               ORDER BY slot_no DESC, address, datumhash_datum.datum_hash|]
+            (SQL.Only (sn :: Integer))
+      pure $ asEvents res
+
+-- | This function recomposes the in-memory format from the database records.
+asEvents
+  :: [(C.AddressAny, C.Hash C.ScriptData, Maybe C.ScriptData, C.SlotNo, C.Hash C.BlockHeader)]
+  -- ^ Should be sorted by C.SlotNo in ascending order.
+  -> [StorableEvent AddressDatumHandle]
+asEvents events =
+    fmap toEvent $ NonEmpty.groupWith (\(_, _, _, s, _) -> s) events
+ where
+     toEvent
+         :: NonEmpty ( C.AddressAny
+                     , C.Hash C.ScriptData
+                     , Maybe C.ScriptData
+                     , C.SlotNo
+                     , C.Hash C.BlockHeader
+                     )
+         -> StorableEvent AddressDatumHandle
+     toEvent es =
+         let (_, _, _, slot, blockHash) = NonEmpty.head es
+          in AddressDatumIndexEvent (toAddressDatums es) (toDatumMap es) (C.ChainPoint slot blockHash)
+
+     toAddressDatums
+         :: NonEmpty ( C.AddressAny
+                     , C.Hash C.ScriptData
+                     , Maybe C.ScriptData
+                     , C.SlotNo
+                     , C.Hash C.BlockHeader
+                     )
+         -> Map C.AddressAny (Set (C.Hash C.ScriptData))
+     toAddressDatums es =
+         Map.fromListWith (<>)
+            $ NonEmpty.toList
+            $ fmap (\(addr, dh, _, _, _) -> (addr, Set.singleton dh)) es
+
+     toDatumMap
+         :: NonEmpty ( C.AddressAny
+                     , C.Hash C.ScriptData
+                     , Maybe C.ScriptData
+                     , C.SlotNo
+                     , C.Hash C.BlockHeader
+                     )
+         -> Map (C.Hash C.ScriptData) C.ScriptData
+     toDatumMap es =
+         Map.fromList
+            $ catMaybes
+            $ NonEmpty.toList
+            $ fmap (\(_, dh, d, _, _) -> fmap (dh,) d) es
+
+instance Queryable AddressDatumHandle where
+  queryStorage
+    :: Foldable f
+    => QueryInterval C.ChainPoint
+    -> f (StorableEvent AddressDatumHandle)
+    -> AddressDatumHandle
+    -> StorableQuery AddressDatumHandle
+    -> IO (StorableResult AddressDatumHandle)
+  queryStorage qi es (AddressDatumHandle c _) AllAddressesQuery = do
+    persistedData :: [(C.AddressAny, C.Hash C.ScriptData, Maybe C.ScriptData, C.SlotNo, C.Hash C.BlockHeader)] <-
+      case qi of
+        QEverything ->
+            SQL.query c
+                [r|SELECT address, address_datums.datum_hash, datumhash_datum.datum, slot_no, block_hash
+                   FROM address_datums
+                   LEFT JOIN datumhash_datum
+                   ON datumhash_datum.datum_hash = address_datums.datum_hash
+                   ORDER BY slot_no ASC, address, datumhash_datum.datum_hash|]
+                ()
+        QInterval (C.ChainPoint _ _) (C.ChainPoint e _) -> do
+            SQL.query c
+                [r|SELECT address, address_datums.datum_hash, datumhash_datum.datum, slot_no, block_hash
+                   FROM address_datums
+                   LEFT JOIN datumhash_datum
+                   ON datumhash_datum.datum_hash = address_datums.datum_hash
+                   WHERE slot_no <= ?
+                   ORDER BY slot_no ASC, address, datumhash_datum.datum_hash|]
+                (SQL.Only e)
+        QInterval C.ChainPointAtGenesis (C.ChainPoint e _) ->
+            SQL.query c
+                [r|SELECT address, address_datums.datum_hash, datumhash_datum.datum, slot_no, block_hash
+                   FROM address_datums
+                   LEFT JOIN datumhash_datum
+                   ON datumhash_datum.datum_hash = address_datums.datum_hash
+                   WHERE slot_no <= ?
+                   ORDER BY slot_no ASC, address, datumhash_datum.datum_hash|]
+                (SQL.Only e)
+        QInterval _ C.ChainPointAtGenesis -> pure []
+    let addressDatumIndexEvents = filterWithQueryInterval qi (asEvents persistedData ++ toList es)
+    pure $ AllAddressesResult
+         $ Set.fromList
+         $ concatMap (\(AddressDatumIndexEvent addrMap _ _) -> Map.keys addrMap) addressDatumIndexEvents
+
+  queryStorage qi es (AddressDatumHandle c _) (AddressDatumQuery q) = do
+    persistedData :: [(C.AddressAny, C.Hash C.ScriptData, Maybe C.ScriptData, C.SlotNo, C.Hash C.BlockHeader)] <-
+      case qi of
+        QEverything ->
+            SQL.query c
+                [r|SELECT address, address_datums.datum_hash, datumhash_datum.datum, slot_no, block_hash
+                   FROM address_datums
+                   LEFT JOIN datumhash_datum
+                   ON datumhash_datum.datum_hash = address_datums.datum_hash
+                   WHERE address = ?
+                   ORDER BY slot_no ASC, address, datumhash_datum.datum_hash|]
+                (SQL.Only q)
+        QInterval _ (C.ChainPoint _ _) ->
+            -- TODO When intervals are more clearer
+            -- SQL.query c
+            --     [r|SELECT address, address_datums.datum_hash, datumhash_datum.datum, slot_no, block_hash
+            --        FROM address_datums
+            --        LEFT JOIN datumhash_datum
+            --        ON datumhash_datum.datum_hash = address_datums.datum_hash
+            --        WHERE address = ? AND slot_no <= ?
+            --        ORDER BY slot_no ASC, address, datumhash_datum.datum_hash|]
+            --     (q, e)
+            pure []
+        QInterval _ C.ChainPointAtGenesis -> pure []
+
+    -- IMPORTANT: Ordering is quite important here, as the `filterWithQueryInterval`
+    -- function assumes events are ordered from oldest (the head) to most recent.
+    let addressDatumIndexEvents = filterWithQueryInterval qi (asEvents persistedData ++ toList es)
+    let (AddressDatumIndexEvent addressDatumMap datumMap cp) = fold addressDatumIndexEvents
+
+    -- Datum hashes that are linked to an address, but do not have a corresponding datum value
+    -- associated with it.
+    let unresolvedDatumHashes =
+            Set.toList $ fold (Map.elems addressDatumMap) `Set.difference` Map.keysSet datumMap
+    datums <- forM unresolvedDatumHashes $ \dh -> do
+        (datum :: Maybe DatumRow) <- listToMaybe <$> SQL.query c
+          "SELECT datum_hash, datum FROM datumhash_datum WHERE datum_hash = ?" (SQL.Only dh)
+        pure $ fmap (\(DatumRow _ d) -> (dh, d)) datum
+    let resolvedDatumHashes = Map.fromList $ catMaybes datums
+
+    pure $ AddressDatumResult
+         $ storableEventToResult
+            q
+            (AddressDatumIndexEvent addressDatumMap (datumMap <> resolvedDatumHashes) cp)
+
+    where
+      storableEventToResult
+          :: C.AddressAny
+          -> StorableEvent AddressDatumHandle
+          -> Set C.ScriptData
+      storableEventToResult targetAddr (AddressDatumIndexEvent addressDatumMap datumMap _chainPoint) =
+          Set.map snd
+            $ Set.filter ((==) targetAddr . fst)
+            $ foldMap (\(addr, datumHashes) -> Set.map (addr,) $ resolveMapKeys datumHashes datumMap)
+            $ Map.toList addressDatumMap
+
+      resolveMapKeys
+          :: (Ord k, Ord v)
+          => Set k
+          -> Map k v
+          -> Set v
+      resolveMapKeys keys m =
+          -- TODO Not efficient to convert back n forth between Set
+          Set.fromList $ mapMaybe (\k -> Map.lookup k m) $ Set.toList keys
+
+instance Rewindable AddressDatumHandle where
+    rewindStorage
+        :: C.ChainPoint
+        -> AddressDatumHandle
+        -> IO (Maybe AddressDatumHandle )
+    rewindStorage C.ChainPointAtGenesis h@(AddressDatumHandle c _) = do
+         SQL.execute_ c "DELETE FROM address_datums"
+         pure $ Just h
+    rewindStorage (C.ChainPoint sn _) h@(AddressDatumHandle c _) = do
+         SQL.execute c "DELETE FROM address_datums WHERE slot_no > ?" (SQL.Only sn)
+         pure $ Just h
+
+instance Resumable AddressDatumHandle where
+    resumeFromStorage
+        :: AddressDatumHandle
+        -> IO [C.ChainPoint]
+    resumeFromStorage h = do
+        es <- Storable.getStoredEvents h
+        pure $ fmap (\(AddressDatumIndexEvent _ _ chainPoint) -> chainPoint) es
+            ++ [C.ChainPointAtGenesis]
+
+open
+  :: FilePath
+  -> AddressDatumDepth
+  -> IO AddressDatumIndex
+open dbPath (AddressDatumDepth k) = do
+    c <- SQL.open dbPath
+
+    SQL.execute_ c
+        [r|CREATE TABLE IF NOT EXISTS address_datums
+            ( address TEXT NOT NULL
+            , datum_hash BLOB NOT NULL
+            , slot_no INT NOT NULL
+            , block_hash BLOB NOT NULL
+            )|]
+    SQL.execute_ c
+        [r|CREATE TABLE IF NOT EXISTS datumhash_datum
+            ( datum_hash BLOB PRIMARY KEY
+            , datum BLOB
+            )|]
+    SQL.execute_ c
+        [r|CREATE INDEX IF NOT EXISTS address_datums_index
+           ON address_datums (address)|]
+
+    emptyState k (AddressDatumHandle c k)

--- a/marconi/src/Marconi/Orphans.hs
+++ b/marconi/src/Marconi/Orphans.hs
@@ -1,11 +1,23 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Marconi.Orphans where
 
 import Cardano.Api (BlockHeader, BlockNo (BlockNo), ChainPoint (ChainPoint, ChainPointAtGenesis),
-                    ChainTip (ChainTip, ChainTipAtGenesis), Hash, SlotNo (SlotNo), serialiseToRawBytesHexText)
+                    ChainTip (ChainTip, ChainTipAtGenesis), Hash, SlotNo (SlotNo))
+import Cardano.Api qualified as C
+import Cardano.Binary (fromCBOR, toCBOR)
+import Codec.Serialise (Serialise (decode, encode), deserialiseOrFail, serialise)
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy (toStrict)
+import Data.Functor ((<&>))
+import Data.Maybe (fromMaybe)
+import Data.Proxy (Proxy (Proxy))
+import Database.SQLite.Simple qualified as SQL
+import Database.SQLite.Simple.FromField qualified as SQL
+import Database.SQLite.Simple.ToField qualified as SQL
 import Prettyprinter (Pretty (pretty), (<+>))
 
 instance Pretty ChainTip where
@@ -16,11 +28,124 @@ instance Pretty ChainPoint where
   pretty ChainPointAtGenesis = "ChainPointAtGenesis"
   pretty (ChainPoint sn ha)  = "ChainPoint(" <> pretty sn <> "," <+> pretty ha <> ")"
 
+instance Ord ChainPoint where
+   C.ChainPointAtGenesis <= _                  = True
+   _ <= C.ChainPointAtGenesis                  = False
+   (C.ChainPoint sn _) <= (C.ChainPoint sn' _) = sn <= sn'
+
+-- * C.Hash C.BlockHeader
+
 instance Pretty (Hash BlockHeader) where
-  pretty hash = "BlockHash" <+> pretty (serialiseToRawBytesHexText hash)
+  pretty hash = "BlockHash" <+> pretty (C.serialiseToRawBytesHexText hash)
+
+instance SQL.ToField (C.Hash C.BlockHeader) where
+  toField f = SQL.toField $ C.serialiseToRawBytes f
+
+instance SQL.FromField (C.Hash C.BlockHeader) where
+   fromField f =
+      SQL.fromField f <&>
+        fromMaybe (error "Cannot deserialise C.Hash C.BlockHeader") .
+          C.deserialiseFromRawBytes (C.proxyToAsType Proxy)
+
+-- * C.SlotNo
 
 instance Pretty SlotNo where
   pretty (SlotNo n) = "Slot" <+> pretty n
 
+instance SQL.ToField C.SlotNo where
+  toField (C.SlotNo n) =  SQL.toField (fromIntegral n :: Int)
+
+instance SQL.FromField C.SlotNo where
+  fromField f = C.SlotNo <$> SQL.fromField f
+
 instance Pretty BlockNo where
   pretty (BlockNo bn) = "BlockNo" <+> pretty bn
+
+instance SQL.FromField C.BlockNo where
+  fromField f = C.BlockNo <$> SQL.fromField f
+
+instance SQL.ToField C.BlockNo where
+  toField (C.BlockNo s) = SQL.SQLInteger $ fromIntegral s
+
+-- * C.AddressAny
+
+instance SQL.FromField C.AddressAny where
+  fromField f = SQL.fromField f >>= \b -> maybe
+    cantDeserialise
+    pure $ C.deserialiseFromRawBytes C.AsAddressAny
+    b
+    where
+      cantDeserialise = SQL.returnError SQL.ConversionFailed f "Cannot deserialise address."
+
+
+instance SQL.ToField C.AddressAny where
+  toField = SQL.SQLBlob . C.serialiseToRawBytes
+
+-- * C.Hash C.ScriptData
+
+instance SQL.FromField (C.Hash C.ScriptData) where
+  fromField f = SQL.fromField f >>=
+    maybe (SQL.returnError SQL.ConversionFailed f "Cannot deserialise C.Hash C.ScriptData.") pure
+    . C.deserialiseFromRawBytes (C.AsHash C.AsScriptData)
+
+instance SQL.ToField (C.Hash C.ScriptData) where
+  toField = SQL.SQLBlob . C.serialiseToRawBytes
+
+-- * C.ScriptData
+
+instance Serialise C.ScriptData where
+  encode = toCBOR
+  decode = fromCBOR
+
+instance SQL.FromField C.ScriptData where
+  fromField f = SQL.fromField f >>=
+    either (const $ SQL.returnError SQL.ConversionFailed f "Cannot deserialise C.ScriptData.") pure
+    . deserialiseOrFail
+
+instance SQL.ToField C.ScriptData where
+  toField = SQL.SQLBlob . toStrict . serialise
+
+instance SQL.FromRow C.TxIn where
+  fromRow = C.TxIn <$> SQL.field <*> SQL.field
+
+instance SQL.ToRow C.TxIn where
+  toRow (C.TxIn txid txix) = SQL.toRow (txid, txix)
+
+instance SQL.FromField C.TxId where
+  fromField f = SQL.fromField f >>= maybe
+    (SQL.returnError SQL.ConversionFailed f "Cannot deserialise TxId.")
+    pure . C.deserialiseFromRawBytes (C.proxyToAsType Proxy)
+
+instance SQL.ToField C.TxId where
+  toField = SQL.SQLBlob . C.serialiseToRawBytes
+
+instance SQL.FromField C.TxIx where
+  fromField = fmap C.TxIx . SQL.fromField
+
+instance SQL.ToField C.TxIx where
+  toField (C.TxIx i) = SQL.SQLInteger $ fromIntegral i
+
+instance SQL.ToField C.Value where
+  toField = SQL.SQLBlob . toStrict . Aeson.encode
+
+instance SQL.FromField C.Value where
+  fromField f = SQL.fromField f >>= either
+    (const $ SQL.returnError SQL.ConversionFailed f "Cannot deserialise value.")
+    pure . Aeson.eitherDecode
+
+instance SQL.ToField C.ScriptInAnyLang where
+  toField = SQL.SQLBlob . toStrict . Aeson.encode
+
+instance SQL.FromField C.ScriptInAnyLang where
+  fromField f = SQL.fromField f >>= either
+    (const $ SQL.returnError SQL.ConversionFailed f "Cannot deserialise value.")
+    pure . Aeson.eitherDecode
+
+instance SQL.ToField C.ScriptHash where
+  toField = SQL.SQLBlob . C.serialiseToRawBytesHex
+
+instance SQL.FromField C.ScriptHash where
+  fromField f = SQL.fromField f >>= either
+    (const $ SQL.returnError SQL.ConversionFailed f "Cannot deserialise scriptDataHash.")
+    pure . C.deserialiseFromRawBytesHex (C.proxyToAsType Proxy)
+

--- a/marconi/src/Marconi/Types.hs
+++ b/marconi/src/Marconi/Types.hs
@@ -3,9 +3,6 @@
 {-# LANGUAGE PatternSynonyms    #-}
 {-# LANGUAGE TypeFamilies       #-}
 
-{-# OPTIONS_GHC -Wno-orphans #-}
-
-
 -- | This module provides several type aliases and utility functions to deal with them.
 module Marconi.Types
        (
@@ -22,9 +19,7 @@ module Marconi.Types
        ) where
 
 import Cardano.Api qualified as C
-
 import Data.List.NonEmpty (NonEmpty)
-
 
 -- | Typre represents non empty list of Bech32 Shelley compatable addresses
 type TargetAddresses = NonEmpty (C.Address C.ShelleyAddr)
@@ -48,8 +43,3 @@ type TxOutRef = C.TxIn
 
 txOutRef :: C.TxId -> C.TxIx -> C.TxIn
 txOutRef = C.TxIn
-
-instance Ord C.ChainPoint where
-   C.ChainPointAtGenesis <= _                  = True
-   _ <= C.ChainPointAtGenesis                  = False
-   (C.ChainPoint sn _) <= (C.ChainPoint sn' _) = sn <= sn'

--- a/marconi/test/Spec.hs
+++ b/marconi/test/Spec.hs
@@ -18,6 +18,7 @@ import Cardano.Api.Shelley qualified as Shelley
 import Gen.Cardano.Api.Typed qualified as CGen
 
 import Marconi.Index.ScriptTx qualified as ScriptTx
+import Spec.Marconi.Index.AddressDatum qualified as AddressDatum
 
 -- See TODO below, import EpochStakepoolSize qualified
 import Integration qualified
@@ -30,6 +31,7 @@ tests :: TestTree
 tests = testGroup "Marconi"
   [ testPropertyNamed "prop_script_hashes_in_tx_match" "getTxBodyScriptsRoundtrip" getTxBodyScriptsRoundtrip
   , Spec.Utxo.tests
+  , AddressDatum.tests
   , Integration.tests
   -- , EpochStakepoolSize.tests
   -- TODO Enable above when the following PR in cardano-node is merged: https://github.com/input-output-hk/cardano-node/pull/4680/

--- a/marconi/test/Spec/Marconi/Index/AddressDatum.hs
+++ b/marconi/test/Spec/Marconi/Index/AddressDatum.hs
@@ -1,0 +1,14 @@
+module Spec.Marconi.Index.AddressDatum (tests) where
+
+import Test.Tasty (TestTree, localOption, testGroup)
+import Test.Tasty.Hedgehog (HedgehogTestLimit (HedgehogTestLimit))
+
+import Spec.Marconi.Index.AddressDatum.AddressDatumIndex qualified as AddressDatumIndex
+import Spec.Marconi.Index.AddressDatum.AddressDatumIndexEvent qualified as AddressDatumIndexEvent
+
+tests :: TestTree
+tests = localOption (HedgehogTestLimit $ Just 200) $
+    testGroup "Spec.Marconi.Index.AddressDatum"
+    [ AddressDatumIndexEvent.tests
+    , AddressDatumIndex.tests
+    ]

--- a/marconi/test/Spec/Marconi/Index/AddressDatum/AddressDatumIndex.hs
+++ b/marconi/test/Spec/Marconi/Index/AddressDatum/AddressDatumIndex.hs
@@ -1,0 +1,365 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Spec.Marconi.Index.AddressDatum.AddressDatumIndex
+    ( tests
+    ) where
+
+import Cardano.Api qualified as C
+import Control.Lens ((^.))
+import Control.Monad (foldM, forM, forM_, when)
+import Control.Monad.IO.Class (liftIO)
+import Data.Foldable (fold)
+import Data.List qualified as List
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Word (Word64)
+import Hedgehog (Gen, Property, forAll, property, (===))
+import Hedgehog qualified
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Marconi.Index.AddressDatum (AddressDatumDepth (AddressDatumDepth), AddressDatumHandle,
+                                   StorableEvent (AddressDatumIndexEvent),
+                                   StorableQuery (AddressDatumQuery, AddressDatumQuery, AllAddressesQuery),
+                                   StorableResult (AddressDatumResult, AllAddressesResult))
+import Marconi.Index.AddressDatum qualified as AddressDatum
+import RewindableIndex.Storable qualified as Storable
+import Spec.Marconi.Index.AddressDatum.Generators (genAddressInEra, genHashBlockHeader, genSimpleScriptData)
+import Spec.Marconi.Index.AddressDatum.Utils (addressInEraToAddressAny)
+import Test.Tasty (TestTree, localOption, testGroup)
+import Test.Tasty.Hedgehog (HedgehogTestLimit (HedgehogTestLimit), testPropertyNamed)
+
+tests :: TestTree
+tests = localOption (HedgehogTestLimit $ Just 200) $
+    testGroup "Spec.Marconi.Index.AddressDatum.AddressDatumIndex"
+    [
+      testPropertyNamed
+          "All addresses from generated events are queryable from the index"
+          "propAllAddressesAreQueryable"
+          propAllAddressesAreQueryable
+    , testPropertyNamed
+          "All addresses from generated events are queryable from the index when specifying a query range within the range of indexed points"
+          "propAllAddressesAreQueryableInGeneratedRange"
+          propAllAddressesAreQueryableInGeneratedRange
+    , testPropertyNamed
+          "All addresses from generated events are queryable from the index when specifying a query range within the range of indexed points"
+          "propAllAddressesAreQueryableInGeneratedRange"
+          propAllAddressesAreQueryableInGeneratedRange
+    , testPropertyNamed
+          "No addresses from generated events are queryable from the index when specifying a query range where it's lowest slot is higher than the last indexed slot"
+          "propNoAddressQueryableIfLowestSlotInQueryRangeIsHigherThanLastIndexedSlot "
+          propNoAddressQueryableIfLowestSlotInQueryRangeIsHigherThanLastIndexedSlot
+    , testPropertyNamed
+          "All datums of each address in generated events are queryable from the index"
+          "propAddressDatumAreQueryable"
+          propAddressDatumAreQueryable
+    -- TODO Reactivate when intervals become more clearer
+    -- , testPropertyNamed
+    --       "All datums of each address in generated events are queryable from the index when specifying a query range which the range of indexed points"
+    --       "propAddressDatumAreQueryableInGeneratedRange"
+    --       propAddressDatumAreQueryableInGeneratedRange
+    , testPropertyNamed
+          "Rewinding an index to a point which is later than the last indexed point should not alter then index"
+          "propRewindingWithNewSlotShouldKeepIndexState "
+          propRewindingWithNewSlotShouldKeepIndexState
+    , testPropertyNamed
+          "Rewinding an index to a point which is before than the last indexed point should bring the index to a previous state"
+          "propRewindingWithOldSlotShouldBringIndexInPreviousState "
+          propRewindingWithOldSlotShouldBringIndexInPreviousState
+    , testPropertyNamed
+          "The points that indexer can be resumed from should return at least the genesis point"
+          "propResumingShouldReturnAtLeastTheGenesisPoint"
+          propResumingShouldReturnAtLeastTheGenesisPoint
+    , testPropertyNamed
+          "The points that indexer can be resumed from should return at least non-genesis point when some data was indexed on disk"
+          "propResumingShouldReturnAtLeastOneNonGenesisPointIfStoredOnDisk"
+          propResumingShouldReturnAtLeastOneNonGenesisPointIfStoredOnDisk
+    ]
+
+-- | The property verifies that the addresses in those generated events are all queryable from the
+-- index.
+propAllAddressesAreQueryable :: Property
+propAllAddressesAreQueryable = property $ do
+    cps <- forAll $ genChainPoints 1 5
+    events <- forAll $ forM cps genAddressDatumStorableEvent
+    depth <- forAll $ Gen.int (Range.linear 1 $ length cps)
+    initialIndex <- liftIO $ AddressDatum.open ":memory:" (AddressDatumDepth depth)
+    finalIndex <- liftIO $ Storable.insertMany events initialIndex
+    let addrs = Set.fromList
+              $ concatMap (\(AddressDatumIndexEvent addressDatumMap _ _) ->
+                  Map.keys addressDatumMap) events
+    (AllAddressesResult actualAddrs) <- liftIO $ do
+        Storable.query Storable.QEverything finalIndex AllAddressesQuery
+    actualAddrs === addrs
+
+-- | Property that any interval where it's highest slot is higher than the current indexed slot and
+-- where it's lowest slot is lower that the last indexed slot should return the same as results as
+-- QEverything.
+propAllAddressesAreQueryableInGeneratedRange :: Property
+propAllAddressesAreQueryableInGeneratedRange = property $ do
+    cps <- forAll $ genChainPoints 2 5
+    events <- forAll $ forM cps genAddressDatumStorableEvent
+    depth <- forAll $ Gen.int (Range.linear 1 $ length cps)
+    initialIndex <- liftIO $ AddressDatum.open ":memory:" (AddressDatumDepth depth)
+    finalIndex <- liftIO $ Storable.insertMany events initialIndex
+
+    r1 <- forAll $ Gen.element cps
+    r2 <- forAll $ Gen.element (C.ChainPointAtGenesis : cps)
+
+    let expectedAddrs = Set.fromList
+              $ concatMap (\(AddressDatumIndexEvent addressDatumMap _ _) ->
+                  Map.keys addressDatumMap)
+              $ filter (\(AddressDatumIndexEvent _ _ cp) -> cp <= max r1 r2) events
+
+    case (min r1 r2, max r1 r2) of
+      (minCp, maxCp) -> do
+          (AllAddressesResult actualAddrs) <- liftIO $ do
+              Storable.query
+                  (Storable.QInterval minCp maxCp)
+                  finalIndex
+                  AllAddressesQuery
+          actualAddrs === expectedAddrs
+
+          when (minCp < maxCp) $ do
+              (AllAddressesResult actualAddrs') <- liftIO $ do
+                  Storable.query
+                      (Storable.QInterval maxCp minCp)
+                      finalIndex
+                      AllAddressesQuery
+              Hedgehog.assert $ Set.null actualAddrs'
+
+-- | Property that any interval where it's lowest slot is higher than the indexed slot
+-- should return no result.
+propNoAddressQueryableIfLowestSlotInQueryRangeIsHigherThanLastIndexedSlot :: Property
+propNoAddressQueryableIfLowestSlotInQueryRangeIsHigherThanLastIndexedSlot = property $ do
+    cps <- forAll $ genChainPoints 2 10
+    events <- forAll $ forM (init $ init cps) genAddressDatumStorableEvent
+    depth <- forAll $ Gen.int (Range.linear 1 $ length cps)
+    initialIndex <- liftIO $ AddressDatum.open ":memory:" (AddressDatumDepth depth)
+    finalIndex <- liftIO $ Storable.insertMany events initialIndex
+
+    (AllAddressesResult actualAddrs) <- liftIO $ do
+        Storable.query
+            (Storable.QInterval (last $ init cps) (last cps))
+            finalIndex
+            AllAddressesQuery
+    Hedgehog.assert $ Set.null actualAddrs
+
+    (AllAddressesResult actualAddrs'') <- liftIO $ do
+        Storable.query
+            (Storable.QInterval (last cps) (last $ init cps))
+            finalIndex
+            AllAddressesQuery
+    Hedgehog.assert $ Set.null actualAddrs''
+
+    (AllAddressesResult actualAddrs''') <- liftIO $ do
+        Storable.query
+            (Storable.QInterval (head cps) C.ChainPointAtGenesis)
+            finalIndex
+            AllAddressesQuery
+    Hedgehog.assert $ Set.null actualAddrs'''
+
+    (AllAddressesResult actualAddrs'''') <- liftIO $ do
+        Storable.query
+            (Storable.QInterval C.ChainPointAtGenesis C.ChainPointAtGenesis)
+            finalIndex
+            AllAddressesQuery
+    Hedgehog.assert $ Set.null actualAddrs''''
+
+-- | The property verifies that the datums of each address in those generated events are all
+-- queryable from the index.
+propAddressDatumAreQueryable :: Property
+propAddressDatumAreQueryable = property $ do
+    cps <- forAll $ genChainPoints 1 5
+    events <- forAll $ forM cps genAddressDatumStorableEvent
+    depth <- forAll $ Gen.int (Range.linear 1 $ length cps)
+    initialIndex <- liftIO $ AddressDatum.open ":memory:" (AddressDatumDepth depth)
+    finalIndex <- liftIO $ Storable.insertMany events initialIndex
+    let addressDatumsMap = indexEventsToAddressDatumsMap events
+    forM_ (Map.toList addressDatumsMap) $ \(addr, expectedDatums) -> do
+        (AddressDatumResult actualDatums) <- liftIO $ do
+            Storable.query Storable.QEverything finalIndex $ AddressDatumQuery addr
+        actualDatums === expectedDatums
+ where
+    indexEventsToAddressDatumsMap
+         :: [Storable.StorableEvent AddressDatumHandle]
+         -> Map C.AddressAny (Set C.ScriptData)
+    indexEventsToAddressDatumsMap events =
+        indexEventToAddressDatumsMap $ fold events
+
+    indexEventToAddressDatumsMap
+         :: Storable.StorableEvent AddressDatumHandle
+         -> Map C.AddressAny (Set C.ScriptData)
+    indexEventToAddressDatumsMap (AddressDatumIndexEvent addressDatumMap datumMap _chainPoint) =
+        Map.fromListWith (<>)
+            $ foldMap (\(addr, datumHashes) -> [(addr, resolveMapKeys datumHashes datumMap)])
+            $ Map.toList addressDatumMap
+
+    resolveMapKeys
+        :: (Ord k, Ord v)
+        => Set k
+        -> Map k v
+        -> Set v
+    resolveMapKeys keys m =
+        -- TODO Not efficient to convert back n forth between Set
+        Set.fromList $ mapMaybe (\k -> Map.lookup k m) $ Set.toList keys
+
+-- | The property verifies that the datums of each address in those generated events are all
+-- queryable from the index given a 'C.ChainPoint' interval.
+-- propAddressDatumAreQueryableInGeneratedRange  :: Property
+-- propAddressDatumAreQueryableInGeneratedRange = property $ do
+--     cps <- forAll $ genChainPoints 1 5
+--     events <- forAll $ forM cps genAddressDatumStorableEvent
+--     depth <- forAll $ Gen.int (Range.linear 1 $ length cps)
+--     initialIndex <- liftIO $ AddressDatum.open ":memory:" (AddressDatumDepth depth)
+--     finalIndex <- liftIO $ Storable.insertMany events initialIndex
+
+--     r1 <- forAll $ Gen.element cps
+--     r2 <- forAll $ Gen.element (C.ChainPointAtGenesis : cps)
+--     let addressDatumsMap =
+--             indexEventsToAddressDatumsMap
+--             $ filter (\(AddressDatumIndexEvent _ _ cp) -> cp <= max r1 r2) events
+
+--     forM_ (Map.toList addressDatumsMap) $ \(addr, expectedDatums) -> do
+--         case (min r1 r2, max r1 r2) of
+--           (minCp, maxCp) -> do
+--               (AddressDatumResult actualDatums) <- liftIO $ do
+--                   Storable.query
+--                       (Storable.QInterval minCp maxCp)
+--                       finalIndex
+--                       (AddressDatumQuery addr)
+--               actualDatums === expectedDatums
+
+--               when (minCp < maxCp) $ do
+--                   (AddressDatumResult actualDatums') <- liftIO $ do
+--                       Storable.query
+--                           (Storable.QInterval maxCp minCp)
+--                           finalIndex
+--                           (AddressDatumQuery addr)
+--                   Hedgehog.assert $ Set.null actualDatums'
+--  where
+--     indexEventsToAddressDatumsMap
+--          :: [Storable.StorableEvent AddressDatumHandle]
+--          -> Map C.AddressAny (Set C.ScriptData)
+--     indexEventsToAddressDatumsMap events =
+--         indexEventToAddressDatumsMap $ fold events
+
+--     indexEventToAddressDatumsMap
+--          :: Storable.StorableEvent AddressDatumHandle
+--          -> Map C.AddressAny (Set C.ScriptData)
+--     indexEventToAddressDatumsMap (AddressDatumIndexEvent addressDatumMap datumMap _chainPoint) =
+--         Map.fromListWith (<>)
+--             $ foldMap (\(addr, datumHashes) -> [(addr, resolveMapKeys datumHashes datumMap)])
+--             $ Map.toList addressDatumMap
+
+--     resolveMapKeys
+--         :: (Ord k, Ord v)
+--         => Set k
+--         -> Map k v
+--         -> Set v
+--     resolveMapKeys keys m =
+--         -- TODO Not efficient to convert back n forth between Set
+--         Set.fromList $ mapMaybe (\k -> Map.lookup k m) $ Set.toList keys
+
+-- | The property verifies that rewinding an index to a 'C.ChainPoint' later than the last one we
+-- indexed will yield an index with an unchanged state.
+--
+-- TODO Think about using the Conversion adapter in order to take advantage of the properties
+-- defined in Spec.hs in rewindable-index.
+propRewindingWithNewSlotShouldKeepIndexState :: Property
+propRewindingWithNewSlotShouldKeepIndexState = property $ do
+    cps <- forAll $ genChainPoints 1 5
+    events <- forAll $ forM cps genAddressDatumStorableEvent
+    initialIndex <- liftIO $ AddressDatum.open ":memory:" (AddressDatumDepth 1)
+    finalIndex <- liftIO $ foldM insertAndRewind initialIndex events
+    let addrs = Set.fromList
+              $ concatMap (\(AddressDatumIndexEvent addressDatumMap _ _) ->
+                  Map.keys addressDatumMap) events
+    (AllAddressesResult actualAddrs) <- liftIO $ do
+        Storable.query Storable.QEverything finalIndex AllAddressesQuery
+    actualAddrs === addrs
+
+ where
+    insertAndRewind index e@(AddressDatumIndexEvent _ _ cp) = do
+        newIndex <- Storable.insert e index
+        fmap (fromMaybe newIndex) (Storable.rewind cp newIndex)
+
+-- | The property verifies that inserting events in an index and rewinding that index to a previous
+-- slot will yield an empty index.
+propRewindingWithOldSlotShouldBringIndexInPreviousState :: Property
+propRewindingWithOldSlotShouldBringIndexInPreviousState = property $ do
+    cps <- forAll $ genChainPoints 1 5
+    events <- forAll $ forM cps genAddressDatumStorableEvent
+    initialIndex <- liftIO $ AddressDatum.open ":memory:" (AddressDatumDepth 1)
+    finalIndex <- liftIO $ foldM (insertAndRewindToPreviousPoint cps) initialIndex events
+    (AllAddressesResult actualAddrs) <- liftIO $ do
+        Storable.query Storable.QEverything finalIndex AllAddressesQuery
+    Hedgehog.assert $ List.null actualAddrs
+ where
+    insertAndRewindToPreviousPoint cps index e@(AddressDatumIndexEvent _ _ cp) = do
+        newIndex <- Storable.insert e index
+        fmap (fromMaybe newIndex) (Storable.rewind (previousChainPoint cp cps) newIndex)
+
+    previousChainPoint :: C.ChainPoint -> [C.ChainPoint] -> C.ChainPoint
+    previousChainPoint cp cps =
+        case List.elemIndex cp cps of
+          Nothing -> C.ChainPointAtGenesis
+          Just i ->
+            case List.splitAt i cps of
+              ([], _)     -> C.ChainPointAtGenesis
+              (before, _) -> last before
+
+-- | The property verifies that the 'Storable.resumeFromStorage' call returns at least the
+-- 'C.ChainPointAtGenesis' point.
+--
+-- TODO: ChainPointAtGenesis should always be returned by default. Don't need this property test.
+--
+-- TODO: Add a property test which makes sure that the points are ordered.
+propResumingShouldReturnAtLeastTheGenesisPoint :: Property
+propResumingShouldReturnAtLeastTheGenesisPoint = property $ do
+    cps <- forAll $ genChainPoints 1 5
+    events <- forAll $ forM (init cps) genAddressDatumStorableEvent
+    initialIndex <- liftIO $ AddressDatum.open ":memory:" (AddressDatumDepth 1)
+    finalIndex <- liftIO $ Storable.insertMany events initialIndex
+
+    resumablePoints <- liftIO $ Storable.resumeFromStorage $ finalIndex ^. Storable.handle
+    Hedgehog.assert $ List.elem C.ChainPointAtGenesis resumablePoints
+
+-- | The property verifies that the 'Storable.resumeFromStorage' call returns at least a point which
+-- is not 'C.ChainPointAtGenesis' when some events are inserted on disk.
+propResumingShouldReturnAtLeastOneNonGenesisPointIfStoredOnDisk :: Property
+propResumingShouldReturnAtLeastOneNonGenesisPointIfStoredOnDisk = property $ do
+    cps <- forAll $ genChainPoints 1 5
+    events <- forAll $ forM (init cps) genAddressDatumStorableEvent
+    initialIndex <- liftIO $ AddressDatum.open ":memory:" (AddressDatumDepth 1)
+    finalIndex <- liftIO $ Storable.insertMany events initialIndex
+        >>= Storable.insert (AddressDatum.toAddressDatumIndexEvent Nothing [] (last cps))
+
+    resumablePoints <- liftIO $ Storable.resumeFromStorage $ finalIndex ^. Storable.handle
+    Hedgehog.assert $ length resumablePoints >= 2
+
+genChainPoints :: Word64 -> Word64 -> Gen [C.ChainPoint]
+genChainPoints b e = do
+    maxSlots <- Gen.word64 (Range.linear b e)
+    mapM (\s -> C.ChainPoint (C.SlotNo s) <$> genHashBlockHeader) [0..maxSlots]
+
+genAddressDatumStorableEvent :: C.ChainPoint -> Gen (Storable.StorableEvent AddressDatumHandle)
+genAddressDatumStorableEvent cp = do
+    addresses <- fmap addressInEraToAddressAny
+             <$> Gen.list (Range.linear 1 5) (genAddressInEra C.BabbageEra)
+    addressDatums <- forM addresses $ \address -> do
+        scriptDats <- fmap (\dats -> fmap (\dat -> (C.hashScriptData dat, dat)) dats)
+                    $ Gen.list (Range.linear 1 5) genSimpleScriptData
+        datumMap <- Map.fromList <$> Gen.subsequence scriptDats
+        pure (address, Set.fromList $ fmap fst scriptDats, datumMap)
+    let addressDatumsMap = Map.fromList $ fmap (\(addr, datums, _) -> (addr, datums)) addressDatums
+    let datumMap = foldMap (\(_, _, dm) -> dm) addressDatums
+    pure $
+        AddressDatumIndexEvent
+            addressDatumsMap
+            datumMap
+            cp

--- a/marconi/test/Spec/Marconi/Index/AddressDatum/AddressDatumIndexEvent.hs
+++ b/marconi/test/Spec/Marconi/Index/AddressDatum/AddressDatumIndexEvent.hs
@@ -1,0 +1,430 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
+{-# LANGUAGE TypeApplications  #-}
+
+module Spec.Marconi.Index.AddressDatum.AddressDatumIndexEvent
+    ( tests
+    ) where
+
+import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as C
+import Cardano.Binary qualified as CBOR
+import Cardano.Crypto.Hash.Class qualified as CRYPTO
+import Cardano.Ledger.SafeHash (unsafeMakeSafeHash)
+import Control.Monad (forM)
+import Data.Coerce (coerce)
+import Data.List qualified as List
+import Data.Map qualified as Map
+import Data.Maybe (catMaybes, fromMaybe, isJust, mapMaybe)
+import Data.Set qualified as Set
+import GHC.Int (Int64)
+import GHC.Natural (Natural)
+import GHC.Real (Ratio, (%))
+import Gen.Cardano.Api.Typed qualified as CGen
+import PlutusCore (defaultCostModelParams)
+import RewindableIndex.Storable qualified as Storable
+import Test.Tasty (TestTree, localOption, testGroup)
+import Test.Tasty.Hedgehog (HedgehogTestLimit (HedgehogTestLimit), testPropertyNamed)
+
+import Hedgehog (Gen, Property, forAll, property, (===))
+import Hedgehog qualified
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+
+import Marconi.Index.AddressDatum (AddressDatumHandle, StorableEvent (AddressDatumIndexEvent))
+import Marconi.Index.AddressDatum qualified as AddressDatum
+import Spec.Marconi.Index.AddressDatum.Generators (genAddressInEra, genChainPoint, genSimpleScriptData)
+import Spec.Marconi.Index.AddressDatum.Utils (addressInEraToAddressAny)
+
+tests :: TestTree
+tests = localOption (HedgehogTestLimit $ Just 200) $
+    testGroup "Spec.Marconi.Index.AddressDatum.AddressDatumIndexEvent.toAddressDatumIndexEvent"
+    [ testPropertyNamed
+          "should track the addresses with datum in a transaction output (datum hash, datum in tx body and inline datum)"
+          "propShouldIndexAddressWithTxOutDatum"
+          propShouldIndexAddressWithTxOutDatum
+    -- TODO Very slow test case. There seems to be a performance issue with creating transactions
+    -- with cardano-api when Plutus scripts are included in the witness set.
+    , testPropertyNamed
+          "should track the addresses with datums that are part of a Plutus datum witness set"
+          "propShouldAlwaysIndexPlutusDatumWitness"
+          propShouldAlwaysIndexPlutusDatumWitness
+    , testPropertyNamed
+          "should not track addresses that are not linked to any datum"
+          "propShouldNotIndexAddressWithoutDatum"
+          propShouldNotIndexAddressWithoutDatum
+    , testPropertyNamed
+          "should track addresses based on provided address filter"
+          "propShouldIndexAddressBasedOnFilter"
+          propShouldIndexAddressBasedOnFilter
+    ]
+
+propShouldIndexAddressWithTxOutDatum :: Property
+propShouldIndexAddressWithTxOutDatum = property $ do
+    cp <- forAll genChainPoint
+    let datGen =
+            Gen.choice
+                [ fmap (\d -> TxOutDatumHashLocation (C.hashScriptData d) d) genSimpleScriptData
+                , fmap (\d -> TxOutDatumInTxLocation (C.hashScriptData d) d) genSimpleScriptData
+                , fmap (\d -> TxOutDatumInlineLocation (C.hashScriptData d) d) genSimpleScriptData
+                ]
+    addressesDatum <- forAll $ genAddressesWithDatum datGen
+    Hedgehog.cover 30 "At least one address with datum hash in tx out"
+        $ isJust
+        $ List.find (\(_, dat) -> case dat of { TxOutDatumHashLocation {} -> True; _ -> False })
+        addressesDatum
+    Hedgehog.cover 30 "At least one address with datum hash in tx out and datum in tx body"
+        $ isJust
+        $ List.find (\(_, dat) -> case dat of { TxOutDatumInTxLocation {} -> True; _ -> False })
+        addressesDatum
+    Hedgehog.cover 30 "At least one address with inline datum in tx out"
+        $ isJust
+        $ List.find (\(_, dat) -> case dat of { TxOutDatumInlineLocation {} -> True; _ -> False })
+        addressesDatum
+    Hedgehog.cover 10 "At least one address with multiple datums"
+        $ isJust
+        $ List.find (\xs -> length xs > 1)
+        $ List.groupBy (\x y -> fst x == fst y)
+        $ List.sortOn (addressInEraToAddressAny . fst)
+        addressesDatum
+
+    txs <- forAll $ Gen.list (Range.constant 1 5)
+                  $ C.makeSignedTransaction [] <$> genTxBodyWithAddresses addressesDatum
+
+    let actualAddressDatumIndexEvent = AddressDatum.toAddressDatumIndexEvent Nothing txs cp
+    let expectedAddressDatumIndexEvent =
+            addressesDatumToAddressDatumIndexEvent Nothing cp addressesDatum
+    expectedAddressDatumIndexEvent === actualAddressDatumIndexEvent
+
+propShouldNotIndexAddressWithoutDatum :: Property
+propShouldNotIndexAddressWithoutDatum = property $ do
+    cp <- forAll genChainPoint
+    let datGen = pure NoDatumLocation
+    addresses <- forAll $ genAddressesWithDatum datGen
+    txs <- forAll $ Gen.list (Range.constant 1 5)
+                  $ C.makeSignedTransaction [] <$> genTxBodyWithAddresses addresses
+    let (AddressDatumIndexEvent addressDats datums _) = AddressDatum.toAddressDatumIndexEvent Nothing txs cp
+
+    Hedgehog.assert $ List.null addressDats
+    Hedgehog.assert $ List.null datums
+
+-- Having a Plutus Script datum witness implies that there is an UTxO with the hash of that datum.
+propShouldAlwaysIndexPlutusDatumWitness :: Property
+propShouldAlwaysIndexPlutusDatumWitness = property $ do
+    cp <- forAll genChainPoint
+
+    let txOutDatGen =
+            Gen.choice [ fmap (\d -> TxOutDatumHashLocation (C.hashScriptData d) d) genSimpleScriptData
+                       , fmap (\d -> TxOutDatumInTxLocation (C.hashScriptData d) d) genSimpleScriptData
+                       , fmap (\d -> TxOutDatumInlineLocation (C.hashScriptData d) d) genSimpleScriptData
+                       ]
+    addressesDatum1 <- forAll $ genAddressesWithDatum txOutDatGen
+    txs1 <- forAll $ Gen.list (Range.constant 1 5)
+                   $ C.makeSignedTransaction [] <$> genTxBodyWithAddresses addressesDatum1
+
+    let plutusWitDatGen =
+            fmap (\d -> PlutusScriptDatumLocation (C.hashScriptData d) d) genSimpleScriptData
+    addressesDatum2 <- forAll $ genAddressesWithDatum plutusWitDatGen
+    txs2 <- forAll $ Gen.list (Range.constant 1 5)
+                   $ C.makeSignedTransaction [] <$> genTxBodyWithAddresses addressesDatum2
+    let txs = txs2 <> txs1
+        addressesDatum = addressesDatum1 <> addressesDatum2
+
+    let actualAddressDatumIndexEvent = AddressDatum.toAddressDatumIndexEvent Nothing txs cp
+    let expectedAddressDatumIndexEvent =
+            addressesDatumToAddressDatumIndexEvent Nothing cp addressesDatum
+    expectedAddressDatumIndexEvent === actualAddressDatumIndexEvent
+
+propShouldIndexAddressBasedOnFilter :: Property
+propShouldIndexAddressBasedOnFilter = property $ do
+    cp <- forAll genChainPoint
+    let datGen = fmap (\d -> TxOutDatumInlineLocation (C.hashScriptData d) d) genSimpleScriptData
+    addressesWithDatum <- forAll $ genAddressesWithDatum datGen
+    let filteredAddresses =
+            List.nub
+          $ fmap (fst . snd)
+          $ filter (\(i, (addr, _)) -> even i || not (isShelleyAddressInEra addr))
+          $ zip [(0::Integer)..] addressesWithDatum
+    let filterF addr =
+            C.AddressInEra (C.ShelleyAddressInEra C.ShelleyBasedEraBabbage) addr `elem` filteredAddresses
+    txs <- forAll $ Gen.list (Range.constant 1 5)
+                  $ C.makeSignedTransaction [] <$> genTxBodyWithAddresses addressesWithDatum
+
+    let actualAddressDatumIndexEvent = AddressDatum.toAddressDatumIndexEvent (Just filterF) txs cp
+    let expectedAddressDatumIndexEvent =
+            addressesDatumToAddressDatumIndexEvent (Just filterF) cp addressesWithDatum
+    expectedAddressDatumIndexEvent === actualAddressDatumIndexEvent
+
+addressesDatumToAddressDatumIndexEvent
+    :: Maybe (C.Address C.ShelleyAddr -> Bool)
+    -> C.ChainPoint
+    -> [(C.AddressInEra C.BabbageEra, DatumLocation)]
+    -> Storable.StorableEvent AddressDatumHandle
+addressesDatumToAddressDatumIndexEvent filterF cp addressDatums =
+    let addressesWithDatumFilter (C.AddressInEra C.ByronAddressInAnyEra _, _) =
+            True
+        addressesWithDatumFilter (C.AddressInEra (C.ShelleyAddressInEra C.ShelleyBasedEraBabbage) addr, _) =
+            case filterF of
+              Nothing -> True
+              Just f  -> f addr
+        filteredAddressDatums = filter addressesWithDatumFilter addressDatums
+
+        addressDatumsMap =
+            Map.fromListWith (<>)
+                $ mapMaybe (\(addr, datLoc) ->
+                    fmap (\(dh, _) -> (addressInEraToAddressAny addr, Set.singleton dh))
+                        $ getDatumFromTxOutLocation datLoc) filteredAddressDatums
+
+        datums = Map.fromList
+               $ mapMaybe (\(h, d) -> fmap (h,) d)
+               $ mapMaybe (\(_ , datLoc) -> getDatumFromAnyLocation datLoc) filteredAddressDatums
+     in AddressDatumIndexEvent addressDatumsMap datums cp
+ where
+    getDatumFromAnyLocation :: DatumLocation -> Maybe (C.Hash C.ScriptData, Maybe C.ScriptData)
+    getDatumFromAnyLocation NoDatumLocation                  = Nothing
+    getDatumFromAnyLocation (TxOutDatumHashLocation hd _)    = Just (hd, Nothing)
+    getDatumFromAnyLocation (TxOutDatumInTxLocation hd d)    = Just (hd, Just d)
+    getDatumFromAnyLocation (TxOutDatumInlineLocation hd d)  = Just (hd, Just d)
+    getDatumFromAnyLocation (PlutusScriptDatumLocation hd d) = Just (hd, Just d)
+
+    getDatumFromTxOutLocation :: DatumLocation -> Maybe (C.Hash C.ScriptData, Maybe C.ScriptData)
+    getDatumFromTxOutLocation NoDatumLocation                 = Nothing
+    getDatumFromTxOutLocation (TxOutDatumHashLocation hd _)   = Just (hd, Nothing)
+    getDatumFromTxOutLocation (TxOutDatumInTxLocation hd d)   = Just (hd, Just d)
+    getDatumFromTxOutLocation (TxOutDatumInlineLocation hd d) = Just (hd, Just d)
+    getDatumFromTxOutLocation (PlutusScriptDatumLocation _ _) = Nothing
+
+-- | TxOutDatumInScriptWitness C.ScriptData
+data DatumLocation
+    = NoDatumLocation
+    | TxOutDatumHashLocation (C.Hash C.ScriptData) C.ScriptData
+    | TxOutDatumInTxLocation (C.Hash C.ScriptData) C.ScriptData
+    | TxOutDatumInlineLocation (C.Hash C.ScriptData) C.ScriptData
+    | PlutusScriptDatumLocation (C.Hash C.ScriptData) C.ScriptData
+    deriving (Show)
+
+genAddressesWithDatum :: Gen DatumLocation -> Gen [(C.AddressInEra C.BabbageEra, DatumLocation)]
+genAddressesWithDatum genDatumLocation = do
+    addresses <- Gen.list (Range.constant 1 5) $ genAddressInEra C.BabbageEra
+    -- We do 'addresses ++ addresses' to generate duplicate addresses so that we can test that we
+    -- correctly index different datums for the same address.
+    forM (addresses ++ addresses) $ \addr -> do
+        datLocation <- genDatumLocation
+        pure (addr, datLocation)
+
+genTxBodyWithAddresses :: [(C.AddressInEra C.BabbageEra, DatumLocation)] -> Gen (C.TxBody C.BabbageEra)
+genTxBodyWithAddresses addresses = do
+  res <- C.makeTransactionBody <$> genTxBodyContentWithAddresses addresses
+  case res of
+    Left err     -> fail (C.displayError err)
+    Right txBody -> pure txBody
+
+genTxBodyContentWithAddresses
+    :: [(C.AddressInEra C.BabbageEra, DatumLocation)]
+    -> Gen (C.TxBodyContent C.BuildTx C.BabbageEra)
+genTxBodyContentWithAddresses addressesDatumLocation = do
+    exUnits <- genExecutionUnits
+    scriptTxIns <- fmap catMaybes <$> forM addressesDatumLocation
+        $ \case
+            (_, PlutusScriptDatumLocation _ d) -> do
+                txIn <- CGen.genTxIn
+                let witness = C.ScriptWitness C.ScriptWitnessForSpending
+                            $ C.PlutusScriptWitness
+                                C.PlutusScriptV1InBabbage
+                                C.PlutusScriptV1
+                                (C.PScript $ C.examplePlutusScriptAlwaysSucceeds C.WitCtxTxIn)
+                                (C.ScriptDatumForTxIn d)
+                                d
+                                exUnits
+                pure $ Just (txIn, C.BuildTxWith witness)
+            (_, _) -> pure Nothing
+
+    txOuts <- forM addressesDatumLocation
+        $ \case
+            (addr, TxOutDatumHashLocation hd _) -> do
+                let txOutGen =
+                        C.TxOut addr <$> genTxOutValue C.BabbageEra
+                                     <*> pure (C.TxOutDatumHash C.ScriptDataInBabbageEra hd)
+                                     <*> pure C.ReferenceScriptNone
+                Gen.list (Range.constant 1 2) txOutGen
+            (addr, TxOutDatumInTxLocation _ d) -> do
+                let txOutGen =
+                        C.TxOut addr <$> genTxOutValue C.BabbageEra
+                                     <*> pure (C.TxOutDatumInTx C.ScriptDataInBabbageEra d)
+                                     <*> pure C.ReferenceScriptNone
+                Gen.list (Range.constant 1 2) txOutGen
+            (addr, TxOutDatumInlineLocation _ d) -> do
+                let txOutGen =
+                        C.TxOut addr <$> genTxOutValue C.BabbageEra
+                                     <*> pure (C.TxOutDatumInline C.ReferenceTxInsScriptsInlineDatumsInBabbageEra d)
+                                     <*> pure C.ReferenceScriptNone
+                Gen.list (Range.constant 1 2) txOutGen
+            (_, _) -> pure []
+
+    txBody <- genTxBodyContentWithPlutusScripts
+    pure $ txBody
+        { C.txIns = C.txIns txBody <> scriptTxIns
+        , C.txOuts = concat txOuts
+        }
+
+genTxBodyContentWithPlutusScripts :: Gen (C.TxBodyContent C.BuildTx C.BabbageEra)
+genTxBodyContentWithPlutusScripts = do
+  txIns <- map (, C.BuildTxWith (C.KeyWitness C.KeyWitnessForSpending)) <$> Gen.list (Range.constant 1 10) CGen.genTxIn
+  txInsCollateral <- C.TxInsCollateral C.CollateralInBabbageEra <$> Gen.list (Range.linear 1 10) CGen.genTxIn
+  let txInsReference = C.TxInsReferenceNone
+  txOuts <- Gen.list (Range.constant 1 10) (genTxOutTxContext C.BabbageEra)
+  let txTotalCollateral = C.TxTotalCollateralNone
+  let txReturnCollateral = C.TxReturnCollateralNone
+  txFee <- genTxFee C.BabbageEra
+  let txValidityRange = (C.TxValidityNoLowerBound, C.TxValidityNoUpperBound C.ValidityNoUpperBoundInBabbageEra)
+  let txMetadata = C.TxMetadataNone
+  let txAuxScripts = C.TxAuxScriptsNone
+  let txExtraKeyWits = C.TxExtraKeyWitnessesNone
+  txProtocolParams <- C.BuildTxWith . Just <$> genProtocolParametersForPlutusScripts
+  let txWithdrawals = C.TxWithdrawalsNone
+  let txCertificates = C.TxCertificatesNone
+  let txUpdateProposal = C.TxUpdateProposalNone
+  let txMintValue = C.TxMintNone
+  let txScriptValidity = C.TxScriptValidity C.TxScriptValiditySupportedInBabbageEra C.ScriptValid
+
+  pure $ C.TxBodyContent
+    { C.txIns
+    , C.txInsCollateral
+    , C.txInsReference
+    , C.txOuts
+    , C.txTotalCollateral
+    , C.txReturnCollateral
+    , C.txFee
+    , C.txValidityRange
+    , C.txMetadata
+    , C.txAuxScripts
+    , C.txExtraKeyWits
+    , C.txProtocolParams
+    , C.txWithdrawals
+    , C.txCertificates
+    , C.txUpdateProposal
+    , C.txMintValue
+    , C.txScriptValidity
+    }
+ where
+    genTxOutTxContext :: C.CardanoEra era -> Gen (C.TxOut C.CtxTx era)
+    genTxOutTxContext era =
+      C.TxOut <$> genAddressInEra era
+              <*> genTxOutValue era
+              <*> genSimpleTxOutDatumHashTxContext era
+              <*> constantReferenceScript era
+    constantReferenceScript :: C.CardanoEra era -> Gen (C.ReferenceScript era)
+    constantReferenceScript era =
+      case C.refInsScriptsAndInlineDatsSupportedInEra era of
+        Nothing -> return C.ReferenceScriptNone
+        Just supp -> pure
+                   $ C.ReferenceScript supp
+                   $ C.ScriptInAnyLang (C.PlutusScriptLanguage C.PlutusScriptV1)
+                   $ C.PlutusScript C.PlutusScriptV1
+                   $ C.examplePlutusScriptAlwaysSucceeds C.WitCtxTxIn
+
+    genSimpleTxOutDatumHashTxContext :: C.CardanoEra era -> Gen (C.TxOutDatum C.CtxTx era)
+    genSimpleTxOutDatumHashTxContext era = case era of
+        C.ByronEra   -> pure C.TxOutDatumNone
+        C.ShelleyEra -> pure C.TxOutDatumNone
+        C.AllegraEra -> pure C.TxOutDatumNone
+        C.MaryEra    -> pure C.TxOutDatumNone
+        C.AlonzoEra  -> Gen.choice
+                        [ pure C.TxOutDatumNone
+                        , C.TxOutDatumHash C.ScriptDataInAlonzoEra <$> genHashScriptData
+                        , C.TxOutDatumInTx C.ScriptDataInAlonzoEra <$> genSimpleScriptData
+                        ]
+        C.BabbageEra -> Gen.choice
+                        [ pure C.TxOutDatumNone
+                        , C.TxOutDatumHash C.ScriptDataInBabbageEra <$> genHashScriptData
+                        , C.TxOutDatumInTx C.ScriptDataInBabbageEra <$> genSimpleScriptData
+                        , C.TxOutDatumInline C.ReferenceTxInsScriptsInlineDatumsInBabbageEra <$> genSimpleScriptData
+                        ]
+
+    -- Copied from cardano-api. Delete when this function is reexported
+    genHashScriptData :: Gen (C.Hash C.ScriptData)
+    genHashScriptData = C.ScriptDataHash . unsafeMakeSafeHash . mkDummyHash <$> Gen.int (Range.linear 0 10)
+
+    mkDummyHash :: forall h a. CRYPTO.HashAlgorithm h => Int -> CRYPTO.Hash h a
+    mkDummyHash = coerce . CRYPTO.hashWithSerialiser @h CBOR.toCBOR
+
+    -- Copied from cardano-api. Delete when this function is reexported
+    genTxFee :: C.CardanoEra era -> Gen (C.TxFee era)
+    genTxFee era =
+      case C.txFeesExplicitInEra era of
+        Left supported  -> pure (C.TxFeeImplicit supported)
+        Right supported -> C.TxFeeExplicit supported <$> CGen.genLovelace
+
+genProtocolParametersForPlutusScripts :: Gen C.ProtocolParameters
+genProtocolParametersForPlutusScripts =
+  C.ProtocolParameters
+    <$> ((,) <$> genNat <*> genNat)
+    <*> Gen.maybe CGen.genRational
+    <*> CGen.genMaybePraosNonce
+    <*> genNat
+    <*> genNat
+    <*> genNat
+    <*> genNat
+    <*> genNat
+    <*> Gen.maybe CGen.genLovelace
+    <*> CGen.genLovelace
+    <*> CGen.genLovelace
+    <*> CGen.genLovelace
+    <*> genEpochNo
+    <*> genNat
+    <*> genRationalInt64
+    <*> CGen.genRational
+    <*> CGen.genRational
+    <*> pure Nothing -- Obsolete from babbage onwards
+    <*> pure (Map.fromList
+      [ (C.AnyPlutusScriptVersion C.PlutusScriptV1, C.CostModel $ fromMaybe (error "Ledger.Params: defaultCostModelParams is broken") defaultCostModelParams)
+      , (C.AnyPlutusScriptVersion C.PlutusScriptV2, C.CostModel $ fromMaybe (error "Ledger.Params: defaultCostModelParams is broken") defaultCostModelParams) ])
+    <*> (Just <$> genExecutionUnitPrices)
+    <*> (Just <$> genExecutionUnits)
+    <*> (Just <$> genExecutionUnits)
+    <*> (Just <$> genNat)
+    <*> (Just <$> genNat)
+    <*> (Just <$> genNat)
+    <*> (Just <$> CGen.genLovelace)
+ where
+    -- Copied from cardano-api. Delete when this function is reexported
+    genRationalInt64 :: Gen Rational
+    genRationalInt64 =
+        (\d -> ratioToRational (1 % d)) <$> genDenominator
+      where
+        genDenominator :: Gen Int64
+        genDenominator = Gen.integral (Range.linear 1 maxBound)
+
+        ratioToRational :: Ratio Int64 -> Rational
+        ratioToRational = toRational
+
+    -- Copied from cardano-api. Delete when this function is reexported
+    genEpochNo :: Gen C.EpochNo
+    genEpochNo = C.EpochNo <$> Gen.word64 (Range.linear 0 10)
+
+    -- Copied from cardano-api. Delete when this function is reexported
+    genNat :: Gen Natural
+    genNat = Gen.integral (Range.linear 0 10)
+
+    -- Copied from cardano-api. Delete when this function is reexported
+    genExecutionUnitPrices :: Gen C.ExecutionUnitPrices
+    genExecutionUnitPrices = C.ExecutionUnitPrices <$> CGen.genRational <*> CGen.genRational
+
+-- Copied from cardano-api. Delete when this function is reexported
+genExecutionUnits :: Gen C.ExecutionUnits
+genExecutionUnits = C.ExecutionUnits <$> Gen.integral (Range.constant 0 1000)
+                                     <*> Gen.integral (Range.constant 0 1000)
+
+genTxOutValue :: C.CardanoEra era -> Gen (C.TxOutValue era)
+genTxOutValue era =
+  case C.multiAssetSupportedInEra era of
+    Left adaOnlyInEra     -> C.TxOutAdaOnly adaOnlyInEra <$> CGen.genLovelace
+    Right multiAssetInEra -> C.TxOutValue multiAssetInEra . C.lovelaceToValue <$> CGen.genLovelace
+
+isShelleyAddressInEra :: C.AddressInEra era -> Bool
+isShelleyAddressInEra (C.AddressInEra _ C.ShelleyAddress {}) = True
+isShelleyAddressInEra _                                      = False

--- a/marconi/test/Spec/Marconi/Index/AddressDatum/Generators.hs
+++ b/marconi/test/Spec/Marconi/Index/AddressDatum/Generators.hs
@@ -1,0 +1,61 @@
+module Spec.Marconi.Index.AddressDatum.Generators
+    ( genAddressInEra
+    , genSimpleScriptData
+    , genChainPoint
+    , genHashBlockHeader
+    )
+where
+
+import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as C
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Short qualified as BSS
+import Data.Word (Word64)
+
+import Gen.Cardano.Api.Typed qualified as CGen
+import Hedgehog (Gen)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+
+-- Copied from cardano-api. Delete when this function is reexported
+genAddressInEra :: C.CardanoEra era -> Gen (C.AddressInEra era)
+genAddressInEra era =
+  case C.cardanoEraStyle era of
+    C.LegacyByronEra ->
+      C.byronAddressInEra <$> CGen.genAddressByron
+
+    C.ShelleyBasedEra _ ->
+      Gen.choice
+        [ C.byronAddressInEra   <$> CGen.genAddressByron
+        , C.shelleyAddressInEra <$> CGen.genAddressShelley
+        ]
+
+-- Copied from cardano-api, but removed the recursive construction because it is time consuming ,
+-- about a factor of 20 when compared to this simple generator.
+genSimpleScriptData :: Gen C.ScriptData
+genSimpleScriptData =
+    Gen.choice
+        [ C.ScriptDataNumber <$> genInteger
+        , C.ScriptDataBytes  <$> genByteString
+        , C.ScriptDataConstructor <$> genInteger <*> pure []
+        , pure $ C.ScriptDataList []
+        , pure $ C.ScriptDataMap []
+        ]
+  where
+    genInteger :: Gen Integer
+    genInteger = Gen.integral
+                  (Range.linear
+                    0
+                    (fromIntegral (maxBound :: Word64) :: Integer))
+
+    genByteString :: Gen ByteString
+    genByteString = BS.pack <$> Gen.list (Range.linear 0 64)
+                                         (Gen.word8 Range.constantBounded)
+
+genChainPoint :: Gen C.ChainPoint
+genChainPoint = do
+    C.ChainPoint <$> CGen.genSlotNo <*> genHashBlockHeader
+
+genHashBlockHeader :: Gen (C.Hash C.BlockHeader)
+genHashBlockHeader = C.HeaderHash . BSS.toShort <$> Gen.bytes (Range.singleton 32)

--- a/marconi/test/Spec/Marconi/Index/AddressDatum/Utils.hs
+++ b/marconi/test/Spec/Marconi/Index/AddressDatum/Utils.hs
@@ -1,0 +1,9 @@
+module Spec.Marconi.Index.AddressDatum.Utils
+    ( addressInEraToAddressAny
+    )
+where
+
+import Cardano.Api qualified as C
+
+addressInEraToAddressAny :: C.AddressInEra era -> C.AddressAny
+addressInEraToAddressAny (C.AddressInEra _ addr) = C.toAddressAny addr

--- a/rewindable-index/src/RewindableIndex/Storable.hs
+++ b/rewindable-index/src/RewindableIndex/Storable.hs
@@ -62,6 +62,8 @@ import GHC.Generics (Generic)
 -}
 data family StorableEvent h
 
+-- | The resume and query functionality requires a way to specify points on the chain from which we
+-- want to resume, or points up to which we want to query.
 type family StorablePoint h
 
 data family StorableQuery h
@@ -114,7 +116,7 @@ data QueryInterval p =
         if there is a demand from the users of the API.
 -}
 class Buffered h where
-  -- This function persists the memory/buffer events to disk.
+  -- | This function persists the memory/buffer events to disk when the memory buffer is filled.
   persistToStorage :: Foldable f => f (StorableEvent h) -> h -> StorableMonad h h
 
   {- This function retrieves the events from the disk/events area.


### PR DESCRIPTION
* Indexes all datums for a given address 
  * takes about 3h starting at Alonzo era - which is the era that introduces datums
  * total disk db size of ~2GB

* Supports resuming

* Does *not* include the JSON-RPC interface on top of this indexer

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
    - [x] Important changes are reflected in changelog.d of the affected packages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
