### PR TITLE
Fix datum encoding in marconi indexer

### DIFF
--- a/marconi-mamba/marconi-mamba.cabal
+++ b/marconi-mamba/marconi-mamba.cabal
@@ -95,6 +95,8 @@ library
     , aeson
     , async
     , base                  >=4.9 && <5
+    , base16-bytestring
+    , bytestring
     , lens
     , optparse-applicative
     , prettyprinter

--- a/marconi/src/Marconi/Index/Utxo.hs
+++ b/marconi/src/Marconi/Index/Utxo.hs
@@ -297,22 +297,24 @@ open dbPath (Depth k) = do
                       ( address TEXT NOT NULL
                       , txId TEXT NOT NULL
                       , txIx INT NOT NULL
-                      , datum TEXT
-                      , datumHash TEXT
+                      , datum BLOB
+                      , datumHash BLOB
                       , value BLOB
-                      , inlineScript TEXT
-                      , inlineScriptHash TEXT
+                      , inlineScript BLOB
+                      , inlineScriptHash BLOB
                       , blockNo INT
                       , slotNo INT
                       , blockHash BLOB
                       , UNIQUE (txId, txIx))|]
   SQL.execute_ c [r|CREATE TABLE IF NOT EXISTS spent
-                      ( txInTxId TEXT PRIMARY KEY NOT NULL UNIQUE
+                      ( txInTxId TEXT PRIMARY KEY NOT NULL
                       , txInTxIx INT NOT NULL
                       , slotNo INT NOT NULL
-                      , blockHash BLOB NOT NULL)|]
+                      , blockHash BLOB NOT NULL
+                      , UNIQUE (txInTxId, txInTxIx))|]
+
   SQL.execute_ c [r|CREATE INDEX IF NOT EXISTS
-                      spent_txid ON spent (slotNo)|]
+                      spent_slotNo ON spent (slotNo)|]
   SQL.execute_ c [r|CREATE INDEX IF NOT EXISTS
                       unspent_transaction_address ON unspent_transactions (address)|]
   emptyState k (UtxoHandle c (k * 2))


### PR DESCRIPTION
Changed datum encoding in JSON-RPC from printing the ScriptData complete text in JSON to CBOR presentation
[PLT-320]

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested


[PLT-320]: https://input-output.atlassian.net/browse/PLT-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ