### PR TITLE
PLT-1317 restructure marconi-mamba

### DIFF
--- a/marconi-chain-index/changelog.d/20230208_200224_konstantinos.lambrou_PLT_1317_restructure_marconi_and_rewindable_index_v2.md
+++ b/marconi-chain-index/changelog.d/20230208_200224_konstantinos.lambrou_PLT_1317_restructure_marconi_and_rewindable_index_v2.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added ToJSON/FromJSON instances for the UTXO indexer types like `UtxoRow` and `Utxo`

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -86,6 +86,7 @@ library
     , aeson
     , async
     , base
+    , base16-bytestring
     , bytestring
     , containers
     , filepath

--- a/marconi-mamba/README.md
+++ b/marconi-mamba/README.md
@@ -35,7 +35,7 @@ The interface for Marconi-Mamba uses [JSON-RPC](http://www.simple-is-better.org/
 * Enable [IOHK's binary cache](https://iohk.zendesk.com/hc/en-us/articles/900000673963-Installing-Nix-on-Linux-distribution-and-setting-up-IOHK-binaries)
 
 ## Building from source
-To build Marconi-Mamba from the source files, use the following commands: 
+To build Marconi-Mamba from the source files, use the following commands:
 
 ``` sh
 git clone git@github.com:input-output-hk/plutus-apps.git
@@ -53,7 +53,7 @@ The above process will build the executable in your local environment at this lo
 
 ## Command line summary
 
-The following is a general synopsis of the command line options: 
+The following is a general synopsis of the command line options:
 
 ``` sh
 $(cabal exec -- which marconi-mamba) --help
@@ -77,16 +77,16 @@ Available options:
 
 ## Example of using Marconi-Mamba
 
-To use Marconi-Mamba, follow these steps: 
+To use Marconi-Mamba, follow these steps:
 1. Invoke the JSON-RPC server
 2. Interrogate the JSON-RPC endpoints
 3. Interrogate the REST endpoints
 
-These steps are described in more detail below. 
+These steps are described in more detail below.
 
 ## Invoking the JSON-RPC server
 
-The following is an example shell script for executing Marconi-Mamba in [preview-testnet](https://book.world.dev.cardano.org/environments.html#preview-testnet). 
+The following is an example shell script for executing Marconi-Mamba in [preview-testnet](https://book.world.dev.cardano.org/environments.html#preview-testnet).
 
 ### Requirement
 
@@ -124,8 +124,8 @@ $(cabal exec -- which marconi-mamba) \
 |-----------+-----------+------------------------+---------------------------------------------|
 | HTTP Verb | Endpoints | RPC method             | Description                                 |
 |-----------+-----------+------------------------+---------------------------------------------|
-| POST      | json-rpc  | addresseesBech32Report | Retrieves user provided addresses           |
-| POST      | json-rpc  | utxoJsonReport         | Retrieves TxRefs for an address             |
+| POST      | json-rpc  | getTargetAddresses     | Retrieves user provided addresses           |
+| POST      | json-rpc  | getUtxoFromAddress     | Retrieves TxRefs for an address             |
 | POST      | JSON-rpc  | echo                   | echo's user input to console                |
 |-----------+-----------+------------------------+---------------------------------------------|
 ```
@@ -146,14 +146,14 @@ $(cabal exec -- which marconi-mamba) \
 Here is a curl script to exploit the JSON-RPC server:
 
 ``` sh
-curl -d '{"jsonrpc": "2.0" , "method": "utxoJsonReport" , "params": "addr_test1qzzxxkwnz4k60fjdjqspt58c8xe069kemfw4gljnnqtc4aarszs09x52vy8kfknj0rrr9400e39ufz5tuct74h52kcrqaytqk7", "id": 19}' -H 'Content-Type: application/json' -X POST http://localhost:3000/json-rpc | jq
+curl -d '{"jsonrpc": "2.0" , "method": "getUtxoFromAddress" , "params": "addr_test1qzzxxkwnz4k60fjdjqspt58c8xe069kemfw4gljnnqtc4aarszs09x52vy8kfknj0rrr9400e39ufz5tuct74h52kcrqaytqk7", "id": 19}' -H 'Content-Type: application/json' -X POST http://localhost:3000/json-rpc | jq
 
 {
   "id": 19,
   "jsonrpc": "2.0",
   "result": {
-    "urAddress": "addr_test1qzzxxkwnz4k60fjdjqspt58c8xe069kemfw4gljnnqtc4aarszs09x52vy8kfknj0rrr9400e39ufz5tuct74h52kcrqaytqk7",
-    "urReport": [
+    "uqAddress": "addr_test1qzzxxkwnz4k60fjdjqspt58c8xe069kemfw4gljnnqtc4aarszs09x52vy8kfknj0rrr9400e39ufz5tuct74h52kcrqaytqk7",
+    "uqResults": [
       {
         "_urBlockHash": "8ccc256dda1f8c499dd91beb9e19e0a794463e876c5602b74c82997e31f16bde",
         "_urBlockNo": {

--- a/marconi-mamba/app/Main.hs
+++ b/marconi-mamba/app/Main.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Control.Concurrent.Async (race_)
 import Marconi.Mamba.Api.Types (CliArgs (CliArgs))
-import Marconi.Mamba.Bootstrap (bootstrapHttp, bootstrapJsonRpc, bootstrapUtxoIndexers)
+import Marconi.Mamba.Bootstrap (bootstrapHttp, bootstrapIndexers, initializeIndexerEnv)
 import Marconi.Mamba.CLI (parseCli)
 
 -- | concurrently start:
@@ -13,7 +13,8 @@ import Marconi.Mamba.CLI (parseCli)
 main :: IO ()
 main = do
     cli@(CliArgs _ _ maybePort _ tAddress)  <- parseCli
-    rpcEnv <- bootstrapJsonRpc maybePort tAddress
+    rpcEnv <- initializeIndexerEnv maybePort tAddress
+
     race_
        (bootstrapHttp rpcEnv)                            -- start http server
-       (bootstrapUtxoIndexers cli rpcEnv)
+       (bootstrapIndexers cli rpcEnv)

--- a/marconi-mamba/changelog.d/20230208_200219_konstantinos.lambrou_PLT_1317_restructure_marconi_and_rewindable_index_v2.md
+++ b/marconi-mamba/changelog.d/20230208_200219_konstantinos.lambrou_PLT_1317_restructure_marconi_and_rewindable_index_v2.md
@@ -1,0 +1,9 @@
+### Removed
+
+- Removed the ToJSON/FromJSON instances of the UTXO indexer types (moved to `marconi-chain-index`)
+
+### Changed
+
+- Change the method names of the JSON-RPC endpoint:
+  - utxo-report -> getUtxoFromAddress
+  - target-addresses -> getTargetAddresses

--- a/marconi-mamba/examples/json-rpc-server/src/Main.hs
+++ b/marconi-mamba/examples/json-rpc-server/src/Main.hs
@@ -18,9 +18,9 @@ import Options.Applicative (Parser, execParser, help, helper, info, long, metava
 import Marconi.ChainIndex.CLI (multiString)
 import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 import Marconi.ChainIndex.Types (TargetAddresses)
-import Marconi.Mamba.Api.Types (UtxoIndexerEnv, queryEnv, uiIndexer)
-import Marconi.Mamba.Api.UtxoIndexersQuery qualified as UIQ
-import Marconi.Mamba.Bootstrap (bootstrapHttp, bootstrapJsonRpc)
+import Marconi.Mamba.Api.Query.UtxoIndexer qualified as UIQ
+import Marconi.Mamba.Api.Types (IndexerEnv, queryEnv, uiIndexer)
+import Marconi.Mamba.Bootstrap (bootstrapHttp, initializeIndexerEnv)
 
 
 data CliOptions = CliOptions
@@ -45,13 +45,13 @@ main = do
         <>"\nport =" <> show (3000 :: Int)
         <> "\nmarconi-db-dir =" <> dbpath
         <> "\nnumber of addresses to index = " <> show (length addresses)
-    env <- bootstrapJsonRpc Nothing addresses
+    env <- initializeIndexerEnv Nothing addresses
     race_ (bootstrapHttp env) (mocUtxoIndexer dbpath (env ^. queryEnv) )
 
 -- | moc marconi utxo indexer.
 -- This will allow us to use the UtxoIndexer query interface without having cardano-node or marconi online
 -- Effectively we are going to query SQLite only
-mocUtxoIndexer :: FilePath -> UtxoIndexerEnv -> IO ()
+mocUtxoIndexer :: FilePath -> IndexerEnv -> IO ()
 mocUtxoIndexer dbpath env =
         Utxo.open dbpath (Utxo.Depth 4) >>= callback >> innerLoop
     where

--- a/marconi-mamba/examples/test-json-rpc.http
+++ b/marconi-mamba/examples/test-json-rpc.http
@@ -12,41 +12,48 @@ POST http://localhost:3000/json-rpc
 Content-Type: application/json
 {"jsonrpc": "2.0", "method": "add", "params": [1,1], "id": 0}
 #
-# should print message on the console
-POST http://localhost:3000/json-rpc
-Content-Type: application/json-rpc
-{"jsonrpc": "2.0", "method": "print", "params": "print me", "id": 0}
-#
-#
-# lookup fot txoutrefs , should return result, low
+# should fail, Unknown method: unknownMethod
 POST http://localhost:3000/json-rpc
 Content-Type: application/json
 {
 "jsonrpc": "2.0"
-, "method": "utxoJsonReport"
+, "method": "unknownMethod"
 , "params": "addr_test1wz3937ykmlcaqxkf4z7stxpsfwfn4re7ncy48yu8vutcpxgnj28k0"
 , "id": 2
 }
 #
-# lookup fot txoutrefs , should return result, high
+# lookup for UTXOs , should return result lots of data
 POST http://localhost:3000/json-rpc
 Content-Type: application/json
 {
 "jsonrpc": "2.0"
-, "method": "utxoJsonReport"
+, "method": "getUtxoFromAddress"
 , "params": "addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc"
 , "id": 92
 }
 #
-# lookup fot txoutrefs, should generate error if the address is not in the target list
+# lookup for UTXOs, should generate error if the address is not in the target list
 POST http://localhost:3000/json-rpc
 Content-Type: application/json
 {
 "jsonrpc": "2.0"
-, "method": "utxoJsonReport"
+, "method": "getUtxoFromAddress"
 , "params": "addr_test1wqr4uz0tp75fu8wrg6gm83t20aphuc9vt6n8kvu09ctkugq6ch8kj"
 , "id":21
 }
+
+#
+# lookup for UTXOs, should generate error if the address is not in the target list
+POST http://localhost:3000/json-rpc
+Content-Type: application/json
+{
+"jsonrpc": "2.0"
+, "method": "getUtxoFromAddress"
+, "params": ["addr_test1wqr4uz0tp75fu8wrg6gm83t20aphuc9vt6n8kvu09ctkugq6ch8kj"]
+, "id":21
+}
+
+
 #
 # addresses with non null dautm
 #
@@ -61,13 +68,12 @@ Content-Type: application/json
 #addr_test1wz3937ykmlcaqxkf4z7stxpsfwfn4re7ncy48yu8vutcpxgnj28k0
 
 #
-# issue non-existing mthode
-# it should fail with code -32601, unknown method
+# it should fail, "Error in $: expected String, but encountered Number"
 POST http://localhost:3000/json-rpc
 Content-Type: application/json
 {
 "jsonrpc": "2.0"
-, "method": "utxoJsonReports"
+, "method": "getUtxoFromAddress"
 , "params": 100
 , "id": 14
 }
@@ -78,21 +84,11 @@ POST http://localhost:3000/json-rpc
 Content-Type: application/json
 {
 "jsonrpc": "2.0"
-, "method": "addressesBech32Report"
-, "params": 100
+, "method": "getTargetAddresses"
+, "params": ""
 , "id": 11
 }
 #
-#
-# get the top 100 utxos, sorted by ledger.Address
-POST http://localhost:3000/json-rpc
-Content-Type: application/json
-{
-"jsonrpc": "2.0"
-, "method": "utxosReport"
-, "params": 100
-, "id": 14
-}
 #
 ####  REST calls ####
 #

--- a/marconi-mamba/marconi-mamba.cabal
+++ b/marconi-mamba/marconi-mamba.cabal
@@ -45,9 +45,9 @@ library
   hs-source-dirs:  src
   exposed-modules:
     Marconi.Mamba.Api.HttpServer
+    Marconi.Mamba.Api.Query.UtxoIndexer
     Marconi.Mamba.Api.Routes
     Marconi.Mamba.Api.Types
-    Marconi.Mamba.Api.UtxoIndexersQuery
     Marconi.Mamba.Bootstrap
     Marconi.Mamba.CLI
 
@@ -71,10 +71,7 @@ library
   ------------------------
   build-depends:
     , aeson
-    , async
     , base                  >=4.9 && <5
-    , base16-bytestring
-    , bytestring
     , lens
     , optparse-applicative
     , prettyprinter
@@ -187,7 +184,7 @@ test-suite marconi-mamba-test
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
   hs-source-dirs: test
-  other-modules:  Spec.Marconi.Mamba.Api.UtxoIndexersQuery
+  other-modules:  Spec.Marconi.Mamba.Api.Query.UtxoIndexer
 
   --------------------
   -- Local components

--- a/marconi-mamba/src/Marconi/Mamba/Api/Query/UtxoIndexer.hs
+++ b/marconi-mamba/src/Marconi/Mamba/Api/Query/UtxoIndexer.hs
@@ -1,18 +1,15 @@
-module Marconi.Mamba.Api.UtxoIndexersQuery
-    ( bootstrap
-    , findByCardanoAddress
+module Marconi.Mamba.Api.Query.UtxoIndexer
+    ( initializeEnv
     , findByAddress
-    , findAll
+    , findByBech32Address
     , reportQueryAddresses
     , Utxo.UtxoRow(..)
     , Utxo.UtxoIndexer
-    , reportQueryCardanoAddresses
     , reportBech32Addresses
     , withQueryAction
     , writeTMVar
     , writeTMVar'
     ) where
-import Control.Concurrent.Async (forConcurrently)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TMVar (TMVar, newEmptyTMVar, putTMVar, takeTMVar, tryTakeTMVar)
 import Control.Exception (bracket)
@@ -20,63 +17,52 @@ import Control.Lens ((^.))
 import Control.Monad.STM (STM)
 import Data.Functor ((<&>))
 import Data.List.NonEmpty qualified as NonEmpty
-import Data.Text (Text, intercalate, pack, unpack)
+import Data.Text (Text, unpack)
 
 import Cardano.Api qualified as C
 import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 import Marconi.ChainIndex.Types (TargetAddresses)
 import Marconi.Core.Storable qualified as Storable
-import Marconi.Mamba.Api.Types (HasUtxoIndexerEnv (uiIndexer, uiQaddresses),
-                                QueryExceptions (AddressNotInListError, QueryError),
-                                UtxoIndexerEnv (UtxoIndexerEnv, _uiIndexer, _uiQaddresses),
-                                UtxoIndexerWrapper (UtxoIndexerWrapper, unWrap), UtxoReport (UtxoReport))
+import Marconi.Mamba.Api.Types (HasIndexerEnv (uiIndexer, uiQaddresses),
+                                IndexerEnv (IndexerEnv, _uiIndexer, _uiQaddresses),
+                                IndexerWrapper (IndexerWrapper, unWrapUtxoIndexer),
+                                QueryExceptions (AddressNotInListError, QueryError), UtxoQueryResult (UtxoQueryResult))
 
 -- | Bootstraps the utxo query environment.
 -- The module is responsible for accessing SQLite for quries.
 -- The main issue we try to avoid here is mixing inserts and quries in SQLite to avoid locking the database
-bootstrap
-    :: TargetAddresses          -- ^ user provided target addresses
-    -> IO UtxoIndexerEnv        -- ^ returns Query runtime environment
-bootstrap targetAddresses = do
+initializeEnv
+    :: TargetAddresses      -- ^ user provided target addresses
+    -> IO IndexerEnv        -- ^ returns Query runtime environment
+initializeEnv targetAddresses = do
     ix <- atomically (newEmptyTMVar :: STM (TMVar Utxo.UtxoIndexer) )
-    pure $ UtxoIndexerEnv
-        { _uiIndexer = UtxoIndexerWrapper ix
+    pure $ IndexerEnv
+        { _uiIndexer = IndexerWrapper ix
         , _uiQaddresses = targetAddresses
         }
--- | finds reports for all user-provided addresses.
--- TODO consider sqlite streaming, https://hackage.haskell.org/package/sqlite-simple-0.4.18.2/docs/Database-SQLite-Simple.html#g:14
---
-findAll
-    :: UtxoIndexerEnv          -- ^ Query run time environment
-    -> IO [UtxoReport]         -- ^ set of corresponding TxOutRefs
-findAll env = forConcurrently addresses f
-    where
-        addresses = NonEmpty.toList (env ^. uiQaddresses)
-        f  :: C.Address C.ShelleyAddr -> IO UtxoReport
-        f addr = (findByCardanoAddress env . C.toAddressAny $ addr) <&> UtxoReport (pack . show $ addr)
 
--- | Query utxos by Cardano Address
---  To Cardano error may occur
-findByCardanoAddress
-    :: UtxoIndexerEnv               -- ^ Query run time environment
+-- | Query utxos by Address
+--  Address conversion error from Bech32 may occur
+findByAddress
+    :: IndexerEnv               -- ^ Query run time environment
     -> C.AddressAny                 -- ^ Cardano address to query
     -> IO [Utxo.UtxoRow]
-findByCardanoAddress  = withQueryAction
+findByAddress  = withQueryAction
 
--- | Retrieve a Set of TxOutRefs associated with the given Cardano Era address
--- We return an empty Set if no address is found
-findByAddress
-    :: UtxoIndexerEnv                          -- ^ Query run time environment
+-- | Retrieve Utxos associated with the given address
+-- We return an empty list if no address is found
+findByBech32Address
+    :: IndexerEnv                          -- ^ Query run time environment
     -> Text                                    -- ^ Bech32 Address
-    -> IO (Either QueryExceptions UtxoReport)  -- ^ To Plutus address conversion error may occure
-findByAddress env addressText =
+    -> IO (Either QueryExceptions UtxoQueryResult)  -- ^ To Plutus address conversion error may occure
+findByBech32Address env addressText =
     let
-        f :: Either C.Bech32DecodeError (C.Address C.ShelleyAddr) -> IO (Either QueryExceptions UtxoReport)
+        f :: Either C.Bech32DecodeError (C.Address C.ShelleyAddr) -> IO (Either QueryExceptions UtxoQueryResult)
         f (Right address)
             | address `elem` (env ^. uiQaddresses) = -- allow for targetAddress search only
               (pure . C.toAddressAny $ address)
-              >>= findByCardanoAddress env
-              <&> Right . UtxoReport addressText
+              >>= findByAddress env
+              <&> Right . UtxoQueryResult addressText
             | otherwise = pure . Left . AddressNotInListError . QueryError $
               unpack addressText <> " not in the provided target addresses"
         f (Left e) = pure . Left $ QueryError (unpack  addressText
@@ -88,12 +74,12 @@ findByAddress env addressText =
 -- | Execute the query function
 -- We must stop the utxo inserts before doing the query
 withQueryAction
-    :: UtxoIndexerEnv       -- ^ Query run time environment
-    -> C.AddressAny         -- ^ Cardano address to query
+    :: IndexerEnv       -- ^ Query run time environment
+    -> C.AddressAny     -- ^ Cardano address to query
     -> IO [Utxo.UtxoRow]
 withQueryAction env address =
     let
-        utxoIndexer = unWrap  $ env ^. uiIndexer
+        utxoIndexer = unWrapUtxoIndexer $ env ^. uiIndexer
         action :: Utxo.UtxoIndexer -> IO [Utxo.UtxoRow]
         action indexer = do
             Utxo.UtxoResult rows <- Storable.query Storable.QEverything indexer (Utxo.UtxoAddress address)
@@ -107,20 +93,15 @@ withQueryAction env address =
 -- | report target addresses
 -- Used by JSON-RPC
 reportQueryAddresses
-    :: UtxoIndexerEnv
+    :: IndexerEnv
     -> IO [C.Address C.ShelleyAddr]
 reportQueryAddresses env
     = pure
     . NonEmpty.toList
     $ (env ^. uiQaddresses )
 
-reportQueryCardanoAddresses
-    :: UtxoIndexerEnv
-    -> Text
-reportQueryCardanoAddresses  = intercalate ", " . reportBech32Addresses
-
 reportBech32Addresses
-    :: UtxoIndexerEnv
+    :: IndexerEnv
     -> [Text]
 reportBech32Addresses env
     = NonEmpty.toList
@@ -135,5 +116,5 @@ reportBech32Addresses env
 writeTMVar :: TMVar a -> a -> STM ()
 writeTMVar t new = tryTakeTMVar t >> putTMVar t new
 
-writeTMVar' :: UtxoIndexerWrapper-> Utxo.UtxoIndexer -> STM ()
-writeTMVar' (UtxoIndexerWrapper t) =  writeTMVar t
+writeTMVar' :: IndexerWrapper-> Utxo.UtxoIndexer -> STM ()
+writeTMVar' (IndexerWrapper t) =  writeTMVar t

--- a/marconi-mamba/src/Marconi/Mamba/Api/Routes.hs
+++ b/marconi-mamba/src/Marconi/Mamba/Api/Routes.hs
@@ -1,34 +1,45 @@
+-- | Defines REST and JSON-RPC routes
+
 {-# LANGUAGE DataKinds     #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Marconi.Mamba.Api.Routes where
+module Marconi.Mamba.Api.Routes (
+  API
+  ) where
 
 import Data.Text (Text)
-import Marconi.Mamba.Api.Types (UtxoReport)
-import Network.JsonRpc.Types (JsonRpc, JsonRpcNotification, RawJsonRpc)
-import Servant.API (Get, JSON, NoContent, PlainText, Post, ReqBody, (:<|>), (:>))
+import Marconi.Mamba.Api.Types (UtxoQueryResult)
+import Network.JsonRpc.Types (JsonRpc, RawJsonRpc)
+import Servant.API (Get, JSON, PlainText, (:<|>), (:>))
 
-  --  RPC method parameter(s) return-type
-type Echo = JsonRpc "echo" String String String
+------------------------------------------
+  --  RPC types
+  --  methodName -> parameter(s) -> return-type
+------------------------------------------
+type RpcEcho = JsonRpc "echo" String String String
 
-type UtxoJsonReport = JsonRpc "utxoJsonReport" String String UtxoReport
+type RpcUtxoQueryResult = JsonRpc "getUtxoFromAddress" String String UtxoQueryResult
 
-type TargetAddressesReport  = JsonRpc "addressesBech32Report" Int String [Text]
+type RpcTargetAddresses = JsonRpc "getTargetAddresses" String String [Text]
 
-type Print    = JsonRpcNotification "print" String
+-- | Rpc routes
+type RpcAPI
+  = RpcEcho
+  :<|> RpcUtxoQueryResult
+  :<|> RpcTargetAddresses
 
-type RpcAPI = Echo :<|> UtxoJsonReport :<|> TargetAddressesReport :<|> Print
-
+-- | JSON-RPC API, endpoint
 type JsonRpcAPI = "json-rpc" :> RawJsonRpc RpcAPI
 
+--------------------
+--- REST related ---
+--------------------
 type GetTime = "time" :> Get '[PlainText] String
 
 type GetTargetAddresses = "addresses" :> Get '[JSON] [Text]
 
-type PrintMessage = "print" :> ReqBody '[PlainText] String :> Post '[PlainText] NoContent
+-- | REST API, endpoints
+type RestAPI = "rest" :> (GetTime :<|> GetTargetAddresses)
 
-type RestAPI = "rest" :> (GetTime :<|> GetTargetAddresses :<|> PrintMessage)
-
+-- | marconi-mamba APIs
 type API = JsonRpcAPI :<|> RestAPI
-
-type NonEndpoint = "json-rpc" :> RawJsonRpc (JsonRpc "launch-missles" Int String Bool)

--- a/marconi-mamba/src/Marconi/Mamba/Api/Types.hs
+++ b/marconi-mamba/src/Marconi/Mamba/Api/Types.hs
@@ -22,24 +22,16 @@ module Marconi.Mamba.Api.Types  where
 import Control.Concurrent.STM.TMVar (TMVar)
 import Control.Exception (Exception)
 import Control.Lens (makeClassy)
-import Data.Aeson (ToJSON (toEncoding, toJSON), defaultOptions, genericToEncoding, object, (.=))
-import Data.Aeson qualified as Aeson
-import Data.ByteString (ByteString)
-import Data.ByteString.Base16 qualified as Base16
-import Data.Char qualified as Char
+import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Data.Text (Text)
-import Data.Text qualified as Text
-import Data.Text.Encoding qualified as Text
 import GHC.Generics (Generic)
 import Network.Wai.Handler.Warp (Settings)
 
 import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as Shelley
 import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 import Marconi.ChainIndex.Types as Export (TargetAddresses)
 
 -- | Type represents http port for JSON-RPC
-type RpcPortNumber = Int
 
 data CliArgs = CliArgs
   { socket          :: FilePath             -- ^ POSIX socket file to communicate with cardano node
@@ -49,23 +41,23 @@ data CliArgs = CliArgs
   , targetAddresses :: TargetAddresses      -- ^ white-space sepparated list of Bech32 Cardano Shelley addresses
   } deriving (Show)
 
-newtype UtxoIndexerWrapper = UtxoIndexerWrapper
-    { unWrap :: TMVar Utxo.UtxoIndexer           -- ^ for query thread to access in-memory utxos
+-- | Should contain all the indexers required by Mamba
+newtype IndexerWrapper = IndexerWrapper
+    { unWrapUtxoIndexer :: TMVar Utxo.UtxoIndexer     -- ^ for query thread to access in-memory utxos
     }
 
-data UtxoIndexerEnv = UtxoIndexerEnv
-    { _uiIndexer    :: UtxoIndexerWrapper
+data IndexerEnv = IndexerEnv
+    { _uiIndexer    :: IndexerWrapper
     , _uiQaddresses :: TargetAddresses        -- ^ user provided addresses to filter
     }
-makeClassy ''UtxoIndexerEnv
+makeClassy ''IndexerEnv
 
--- | JSON-RPC configuration
-data JsonRpcEnv = JsonRpcEnv
+-- | JSON-RPC as well as the Query Indexer Env
+data MambaEnv = MambaEnv
     { _httpSettings :: Settings               -- ^ HTTP server setting
-    , _queryEnv     :: UtxoIndexerEnv         -- ^ used for query sqlite
+    , _queryEnv     :: IndexerEnv         -- ^ used for query sqlite
     }
-makeClassy ''JsonRpcEnv
-
+makeClassy ''MambaEnv
 
 data QueryExceptions
     = AddressNotInListError QueryExceptions
@@ -75,60 +67,10 @@ data QueryExceptions
     deriving stock Show
     deriving anyclass  Exception
 
--- from cardano-node: https://github.com/input-output-hk/cardano-node/blob/master/cardano-api/src/Cardano/Api/ScriptData.hs#L444-L447
--- | JSON strings that are base16 encoded and prefixed with 'bytesPrefix' will
--- be encoded as CBOR bytestrings.
-bytesPrefix :: Text
-bytesPrefix = "0x"
-
-instance ToJSON ByteString  where
-  toJSON bs
-      | Right s <- Text.decodeUtf8' bs, Text.all Char.isPrint s = Aeson.String s
-      | otherwise
-      = Aeson.String (bytesPrefix <> Text.decodeLatin1 (Base16.encode bs))
-
-instance ToJSON Utxo.Utxo where
-  toJSON (Utxo.Utxo addr tId tIx dtum dtumHash val scrpt scrptHash) = object
-    ["address"            .=  addr
-    , "txId"              .= tId
-    , "txIx"              .= tIx
-    , "datum"             .= (C.serialiseToCBOR <$> dtum)
-    , "datumHash"         .= dtumHash
-    , "value"             .= val
-    , "inlineScript"      .= (scriptToCBOR <$>scrpt)
-    , "inlineScriptHash"  .= scrptHash
-    ]
-
-data UtxoReport = UtxoReport
-    { urAddress :: Text
-    , urReport  :: [Utxo.UtxoRow]
+data UtxoQueryResult = UtxoQueryResult
+    { uqAddress :: Text
+    , uqResults :: ![Utxo.UtxoRow]
     } deriving (Eq, Ord, Generic)
 
-instance ToJSON UtxoReport where
+instance ToJSON UtxoQueryResult where
     toEncoding = genericToEncoding defaultOptions
-
-instance ToJSON C.AddressAny where
-    toJSON  = Aeson.String . C.serialiseAddress
-
-instance ToJSON (Utxo.StorableQuery Utxo.UtxoHandle) where
-  toJSON (Utxo.UtxoAddress addr) = toJSON addr
-
-instance ToJSON C.BlockNo
-
-instance ToJSON Utxo.UtxoRow where
-  toJSON (Utxo.UtxoRow u b s h) = object
-    [ "utxo" .= u
-    ,  "blockNo" .= b
-    ,  "slotNo" .= s
-    ,  "blockHeaderHash" .= h]
-
--- | convert to Script to CBOR bytestring
-scriptToCBOR :: Shelley.ScriptInAnyLang -> ByteString
-scriptToCBOR (Shelley.ScriptInAnyLang(C.SimpleScriptLanguage C.SimpleScriptV1) script) =
-  C.serialiseToCBOR script
-scriptToCBOR (Shelley.ScriptInAnyLang(C.SimpleScriptLanguage C.SimpleScriptV2) script) =
-  C.serialiseToCBOR script
-scriptToCBOR (Shelley.ScriptInAnyLang(C.PlutusScriptLanguage C.PlutusScriptV1) script) =
-  C.serialiseToCBOR script
-scriptToCBOR (Shelley.ScriptInAnyLang(C.PlutusScriptLanguage C.PlutusScriptV2) script) =
-  C.serialiseToCBOR script

--- a/marconi-mamba/test/Spec.hs
+++ b/marconi-mamba/test/Spec.hs
@@ -2,11 +2,11 @@ module Main (main) where
 
 import Test.Tasty (TestTree, defaultMain, testGroup)
 
-import Spec.Marconi.Mamba.Api.UtxoIndexersQuery qualified as Spec.UtxoIndexersQuery
+import Spec.Marconi.Mamba.Api.Query.UtxoIndexer qualified as Spec.Query.UtxoIndexer
 
 main :: IO ()
 main = defaultMain tests
 
 tests :: TestTree
 tests = testGroup "marconi-mamba"
-  [Spec.UtxoIndexersQuery.tests]
+  [Spec.Query.UtxoIndexer.tests]


### PR DESCRIPTION
   DRAFT, do not merge
---
 Restructure and re-organize Marconi modules

    - Renamed the module names from Marconi.JsonRpc to Network.JsonRpc
    - Renamed `marconi` to `marconi-chain-index`
    - Renamed  `rewindable-index` package to `marconi-core`  and changed
    corresponding module names accordingly
    - Renamed marconi-mamba module names to match those of corresponding
    package name

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
