### PR TITLE
Various small refactoring and fixes in `marconi-mamba`

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -304,7 +304,8 @@ startIndexers indexers = do
   -- We want to use the set of points that are common to all indexers
   -- giving priority to recent ones.
   pure ( foldl1' intersect startingPoints
-       , coordinator )
+       , coordinator
+       )
 
 mkIndexerStream
   :: Coordinator

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -127,7 +127,7 @@ data UtxoRow = UtxoRow
   { _urUtxo      :: Utxo
   , _urBlockNo   :: C.BlockNo
   , _urSlotNo    :: C.SlotNo
-  , _urBlockHash:: C.Hash C.BlockHeader
+  , _urBlockHash :: C.Hash C.BlockHeader
   } deriving (Show, Eq, Ord, Generic)
 
 $(makeLenses ''UtxoRow)
@@ -163,7 +163,7 @@ data Spent = Spent
   { _sTxInTxId  :: C.TxId                 -- ^ from TxIn, containts the Spent txId
   , _sTxInTxIx  :: C.TxIx
   , _sSlotNo    :: C.SlotNo
-  , _sBlockHash:: C.Hash C.BlockHeader
+  , _sBlockHash :: C.Hash C.BlockHeader
   } deriving (Show, Eq)
 
 $(makeLenses ''Spent)

--- a/marconi-mamba/app/Main.hs
+++ b/marconi-mamba/app/Main.hs
@@ -1,20 +1,22 @@
+{-# LANGUAGE NamedFieldPuns #-}
 module Main where
 
 import Control.Concurrent.Async (race_)
-import Marconi.Mamba.Api.Types (CliArgs (CliArgs))
+import Marconi.Mamba.Api.Types (CliArgs (CliArgs, httpPort, targetAddresses))
 import Marconi.Mamba.Bootstrap (bootstrapHttp, bootstrapIndexers, initializeIndexerEnv)
 import Marconi.Mamba.CLI (parseCli)
 
--- | concurrently start:
--- JSON-RPC server
--- marconi utxo worker
--- Exceptions in either thread will end the program
+-- | Concurrently start:
 --
+-- * JSON-RPC server
+-- * marconi indexer workers
+--
+-- Exceptions in either thread will end the program
 main :: IO ()
 main = do
-    cli@(CliArgs _ _ maybePort _ tAddress)  <- parseCli
-    rpcEnv <- initializeIndexerEnv maybePort tAddress
+    cli@CliArgs { httpPort, targetAddresses }  <- parseCli
+    rpcEnv <- initializeIndexerEnv httpPort targetAddresses
 
     race_
-       (bootstrapHttp rpcEnv)                            -- start http server
-       (bootstrapIndexers cli rpcEnv)
+       (bootstrapHttp rpcEnv) -- Start HTTP server
+       (bootstrapIndexers cli rpcEnv) -- Start the Mamba indexers

--- a/marconi-mamba/changelog.d/20230209_141628_konstantinos.lambrou_PLT_1480_make_mps_tx_indexer_queryable_through_the_json_rpc_server_of_marconi_mamba.md
+++ b/marconi-mamba/changelog.d/20230209_141628_konstantinos.lambrou_PLT_1480_make_mps_tx_indexer_queryable_through_the_json_rpc_server_of_marconi_mamba.md
@@ -1,0 +1,16 @@
+### Removed
+
+- Remove the `--utxo-db` CLI parameter in favor of `--utxo-db-fname`
+
+### Added
+
+- Added a CLI param (`--db-dir`) for specifiying the directory in which to store the SQLite database files.
+- Added a CLI param (`--utxo-db-fname`) for specifying the database file name of the UTXO indexer.
+
+### Changed
+
+- Providing target addresses in the CLI through `--addresses-to-index` is now optional
+
+### Fixed
+
+- Fixed the resuming capability of the UTXO indexer

--- a/marconi-mamba/db-utils/README.md
+++ b/marconi-mamba/db-utils/README.md
@@ -24,8 +24,9 @@ addr1qxyxudgzljnnaqghm8hlnpp36uvfr68a8k6uemumgjdcua4y7d04xcx9hnk05lnl6m9ptd9h3pj
 addr1qytr6ma495fkqpfnd7gk5kwmtfdh084xvzn7rv83ha87qq6yfm3y8yv39lcrqc6ej3zdzvef4aj3dv3pq2snakkcwscsfyrn3g|2317
 addr1qxt2ggq005kfm3uwe89emy3ka2zgdtrpxfarvz6033l3fqvk5ssq7lfvnhrcajwtnkfrd65ys6kxzvn6xc95lrrlzjqsjttk32|1353
 addr1qyhat6v7w65799pkc8ff3mjcwk79kqs8gv8t4expd67f9seqksv3earfx6skxkdhe4hcekjkj0x333dd76u8re8cmg2qwrdzn2|1155
-
 ```
+
+The data above were acquired from the Cardano mainnet.
 
 ### Why do we need this
 The need for this utility is from the desire to test marconi-mamba in a live network with valid addresses that may potentially correspond to a large list of Utxos.  Here are the high level requirements:

--- a/marconi-mamba/examples/json-rpc-server/src/Main.hs
+++ b/marconi-mamba/examples/json-rpc-server/src/Main.hs
@@ -13,7 +13,7 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race_)
 import Control.Concurrent.STM (atomically)
 import Control.Lens.Operators ((^.))
-import Options.Applicative (Parser, execParser, help, helper, info, long, metavar, short, strOption, (<**>))
+import Options.Applicative (Parser, execParser, help, helper, info, long, metavar, optional, short, strOption, (<**>))
 
 import Marconi.ChainIndex.CLI (multiString)
 import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
@@ -24,8 +24,8 @@ import Marconi.Mamba.Bootstrap (bootstrapHttp, initializeIndexerEnv)
 
 
 data CliOptions = CliOptions
-    { _utxoPath  :: FilePath -- ^ path to utxo sqlite database
-    , _addresses :: TargetAddresses
+    { _utxoPath  :: FilePath -- ^ Filepath to utxo sqlite database
+    , _addresses :: Maybe TargetAddresses
     }
 
 cliParser :: Parser CliOptions
@@ -34,9 +34,12 @@ cliParser = CliOptions
                               <> short 'd'
                               <> metavar "FILENAME"
                               <> help "Path to the utxo SQLite database.")
-     <*> multiString (long "addresses-to-index"
-                        <> help ("Bech32 Shelley addresses to index."
-                                 <> " i.e \"--address-to-index address-1 --address-to-index address-2 ...\"" ) )
+     <*> (optional . multiString)
+            ( long "addresses-to-index"
+           <> help ( "Bech32 Shelley addresses to index."
+                  <> " i.e \"--address-to-index address-1 --address-to-index address-2 ...\""
+                   )
+            )
 
 main :: IO ()
 main = do

--- a/marconi-mamba/marconi-mamba.cabal
+++ b/marconi-mamba/marconi-mamba.cabal
@@ -72,6 +72,7 @@ library
   build-depends:
     , aeson
     , base                  >=4.9 && <5
+    , filepath
     , lens
     , optparse-applicative
     , prettyprinter

--- a/marconi-mamba/src/Marconi/Mamba/Api/Types.hs
+++ b/marconi-mamba/src/Marconi/Mamba/Api/Types.hs
@@ -34,11 +34,12 @@ import Marconi.ChainIndex.Types as Export (TargetAddresses)
 -- | Type represents http port for JSON-RPC
 
 data CliArgs = CliArgs
-  { socket          :: FilePath             -- ^ POSIX socket file to communicate with cardano node
-  , dbPath          :: FilePath             -- ^ filepath to local sqlite for utxo index table
-  , httpPort        :: Maybe Int            -- ^ optional tcp/ip port number for JSON-RPC http server
-  , networkId       :: C.NetworkId          -- ^ cardano network id
-  , targetAddresses :: TargetAddresses      -- ^ white-space sepparated list of Bech32 Cardano Shelley addresses
+  { socket          :: FilePath -- ^ POSIX socket file to communicate with cardano node
+  , dbDir           :: FilePath -- ^ Directory path containing the SQLite database files
+  , utxoDbFileName  :: Maybe FilePath -- ^ File name of the local SQLite for the UTXO index table
+  , httpPort        :: Maybe Int -- ^ optional tcp/ip port number for JSON-RPC http server
+  , networkId       :: C.NetworkId -- ^ cardano network id
+  , targetAddresses :: Maybe TargetAddresses -- ^ white-space sepparated list of Bech32 Cardano Shelley addresses
   } deriving (Show)
 
 -- | Should contain all the indexers required by Mamba
@@ -48,7 +49,7 @@ newtype IndexerWrapper = IndexerWrapper
 
 data IndexerEnv = IndexerEnv
     { _uiIndexer    :: IndexerWrapper
-    , _uiQaddresses :: TargetAddresses        -- ^ user provided addresses to filter
+    , _uiQaddresses :: Maybe TargetAddresses        -- ^ user provided addresses to filter
     }
 makeClassy ''IndexerEnv
 
@@ -60,9 +61,7 @@ data MambaEnv = MambaEnv
 makeClassy ''MambaEnv
 
 data QueryExceptions
-    = AddressNotInListError QueryExceptions
-    | AddressConversionError QueryExceptions
-    | TxRefConversionError QueryExceptions
+    = AddressConversionError QueryExceptions
     | QueryError String
     deriving stock Show
     deriving anyclass  Exception

--- a/marconi-mamba/src/Marconi/Mamba/CLI.hs
+++ b/marconi-mamba/src/Marconi/Mamba/CLI.hs
@@ -13,14 +13,34 @@ import Marconi.Mamba.Api.Types (CliArgs (CliArgs))
 --
 parserCliArgs :: Parser CliArgs
 parserCliArgs = CliArgs
-  <$> strOption (long "socket-path" <> metavar "FILE-PATH" <> help "Socket path to node")
-  <*> strOption (long "utxo-db" <> metavar "FILE-PATH" <> help "Path to the utxo database.")
-  <*> (optional . option  auto) (
-        long "http-port" <> metavar "HTTP-PORT" <> help "JSON-RPC http port number, default is port 3000.")
+  <$> strOption
+      (  long "socket-path"
+      <> metavar "FILE-PATH"
+      <> help "Socket path to node"
+      )
+  <*> strOption
+      (  long "db-dir"
+      <> metavar "DIR"
+      <> help "Directory path that will contain all the SQLite databases"
+      )
+  <*> (optional . strOption)
+      (  long "utxo-db-fname"
+      <> metavar "FILE-NAME"
+      <> help "File name of the utxo database."
+      )
+  <*> (optional . option  auto)
+      (  long "http-port"
+      <> metavar "HTTP-PORT"
+      <> help "JSON-RPC http port number, default is port 3000."
+      )
   <*> pNetworkId
-  <*> multiString (long "addresses-to-index" <> metavar "BECH32-ADDRESS "
-                   <> help ("Bech32 Shelley addresses to index."
-                            <> " i.e \"--address-to-index address-1 --address-to-index address-2 ...\"" ) )
+  <*> (optional . multiString)
+        (  long "addresses-to-index"
+        <> metavar "BECH32-ADDRESS"
+        <> help (  "Bech32 Shelley addresses to index."
+                <> " i.e \"--address-to-index address-1 --address-to-index address-2 ...\""
+                )
+        )
 
 parserOpts  :: String -> ParserInfo CliArgs
 parserOpts sha =
@@ -33,9 +53,10 @@ parserOpts sha =
           "marconi - a lightweight customizable solution for indexing and querying the Cardano blockchain"
     )
     where
-        versionOption  =
-            infoOption sha (long "version"
-                            <> help "Show git SHA")
+        versionOption =
+            infoOption sha ( long "version"
+                          <> help "Show git SHA"
+                           )
 
 parseCli :: IO CliArgs
 parseCli = do

--- a/marconi-mamba/test/Spec.hs
+++ b/marconi-mamba/test/Spec.hs
@@ -11,4 +11,5 @@ main = defaultMain tests
 tests :: TestTree
 tests = testGroup "marconi-mamba"
   [ Api.Query.Indexers.Utxo.tests
-  , CLI.tests]
+  , CLI.tests
+  ]

--- a/marconi-mamba/test/Spec/Golden/Cli/marconi.help
+++ b/marconi-mamba/test/Spec/Golden/Cli/marconi.help
@@ -1,8 +1,7 @@
 Missing: 
---socket-path FILE-PATH --utxo-db FILE-PATH 
-  (--mainnet | --testnet-magic NATURAL) (--addresses-to-index BECH32-ADDRESS )
+--socket-path FILE-PATH --db-dir DIR (--mainnet | --testnet-magic NATURAL)
 
-Usage: marconi-mamba --socket-path FILE-PATH --utxo-db FILE-PATH 
-                     [--http-port HTTP-PORT] 
-                     (--mainnet | --testnet-magic NATURAL)
-                     (--addresses-to-index BECH32-ADDRESS )
+Usage: marconi-mamba --socket-path FILE-PATH --db-dir DIR 
+                     [--utxo-db-fname FILE-NAME] [--http-port HTTP-PORT] 
+                     (--mainnet | --testnet-magic NATURAL) 
+                     [(--addresses-to-index BECH32-ADDRESS)]

--- a/marconi-mamba/test/Spec/Golden/Cli/marconi___addresses_to_index.help
+++ b/marconi-mamba/test/Spec/Golden/Cli/marconi___addresses_to_index.help
@@ -1,6 +1,6 @@
 The option `--addresses-to-index` expects an argument.
 
-Usage: marconi-mamba --socket-path FILE-PATH --utxo-db FILE-PATH 
-                     [--http-port HTTP-PORT] 
-                     (--mainnet | --testnet-magic NATURAL)
-                     (--addresses-to-index BECH32-ADDRESS )
+Usage: marconi-mamba --socket-path FILE-PATH --db-dir DIR 
+                     [--utxo-db-fname FILE-NAME] [--http-port HTTP-PORT] 
+                     (--mainnet | --testnet-magic NATURAL) 
+                     [(--addresses-to-index BECH32-ADDRESS)]

--- a/marconi-mamba/test/Spec/Golden/Cli/marconi___help.help
+++ b/marconi-mamba/test/Spec/Golden/Cli/marconi___help.help
@@ -1,6 +1,6 @@
 Invalid option `--help'
 
-Usage: marconi-mamba --socket-path FILE-PATH --utxo-db FILE-PATH 
-                     [--http-port HTTP-PORT] 
-                     (--mainnet | --testnet-magic NATURAL)
-                     (--addresses-to-index BECH32-ADDRESS )
+Usage: marconi-mamba --socket-path FILE-PATH --db-dir DIR 
+                     [--utxo-db-fname FILE-NAME] [--http-port HTTP-PORT] 
+                     (--mainnet | --testnet-magic NATURAL) 
+                     [(--addresses-to-index BECH32-ADDRESS)]

--- a/marconi-mamba/test/Spec/Golden/Cli/marconi___http_port.help
+++ b/marconi-mamba/test/Spec/Golden/Cli/marconi___http_port.help
@@ -1,6 +1,6 @@
 The option `--http-port` expects an argument.
 
-Usage: marconi-mamba --socket-path FILE-PATH --utxo-db FILE-PATH 
-                     [--http-port HTTP-PORT] 
-                     (--mainnet | --testnet-magic NATURAL)
-                     (--addresses-to-index BECH32-ADDRESS )
+Usage: marconi-mamba --socket-path FILE-PATH --db-dir DIR 
+                     [--utxo-db-fname FILE-NAME] [--http-port HTTP-PORT] 
+                     (--mainnet | --testnet-magic NATURAL) 
+                     [(--addresses-to-index BECH32-ADDRESS)]

--- a/marconi-mamba/test/Spec/Golden/Cli/marconi___socket.help
+++ b/marconi-mamba/test/Spec/Golden/Cli/marconi___socket.help
@@ -1,6 +1,6 @@
 Invalid option `--socket'
 
-Usage: marconi-mamba --socket-path FILE-PATH --utxo-db FILE-PATH 
-                     [--http-port HTTP-PORT] 
-                     (--mainnet | --testnet-magic NATURAL)
-                     (--addresses-to-index BECH32-ADDRESS )
+Usage: marconi-mamba --socket-path FILE-PATH --db-dir DIR 
+                     [--utxo-db-fname FILE-NAME] [--http-port HTTP-PORT] 
+                     (--mainnet | --testnet-magic NATURAL) 
+                     [(--addresses-to-index BECH32-ADDRESS)]

--- a/marconi-mamba/test/Spec/Golden/Cli/marconi___utxo_db.help
+++ b/marconi-mamba/test/Spec/Golden/Cli/marconi___utxo_db.help
@@ -1,6 +1,6 @@
-The option `--utxo-db` expects an argument.
+Invalid option `--utxo-db'
 
-Usage: marconi-mamba --socket-path FILE-PATH --utxo-db FILE-PATH 
-                     [--http-port HTTP-PORT] 
-                     (--mainnet | --testnet-magic NATURAL)
-                     (--addresses-to-index BECH32-ADDRESS )
+Usage: marconi-mamba --socket-path FILE-PATH --db-dir DIR 
+                     [--utxo-db-fname FILE-NAME] [--http-port HTTP-PORT] 
+                     (--mainnet | --testnet-magic NATURAL) 
+                     [(--addresses-to-index BECH32-ADDRESS)]

--- a/marconi-mamba/test/Spec/Marconi/Mamba/Api/Query/Indexers/Utxo.hs
+++ b/marconi-mamba/test/Spec/Marconi/Mamba/Api/Query/Indexers/Utxo.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
 
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -11,7 +10,7 @@ import Control.Concurrent.STM (atomically)
 import Control.Lens.Operators ((^.))
 import Control.Monad.IO.Class (liftIO)
 import Data.List (nub)
-import Data.List.NonEmpty (fromList)
+import Data.List.NonEmpty (nonEmpty, toList)
 import Data.Maybe (mapMaybe)
 import Data.Set qualified as Set
 
@@ -59,9 +58,9 @@ queryTargetAddressTest = property $ do
   events <- forAll $ Gen.list (Range.linear 2 5) genEvents
   depth <- forAll $ Gen.int (Range.linear 5 7)
   let
-    targetAddresses :: TargetAddresses
+    targetAddresses :: Maybe TargetAddresses
     targetAddresses
-      = fromList
+      = nonEmpty
       . mapMaybe addressAnyToShelley
       . nub -- required to remove the potential duplicate addresses
       . fmap Utxo._address
@@ -77,6 +76,7 @@ queryTargetAddressTest = property $ do
     . fmap concat
     . traverse (UIQ.findByAddress env)
     . fmap C.toAddressAny
+    . maybe [] toList
     $ targetAddresses
   let rows = concatMap Utxo.eventsToRows events
   fetchedRows === rows


### PR DESCRIPTION
* Remove the `--utxo-db` CLI parameter in favor of `--utxo-db-fname` which takes the file name instead of the full path

* Added a CLI param (`--db-dir`) for specifiying the directory in which to store the SQLite database files.

* Providing target addresses in the CLI through `--addresses-to-index` is now optional

* Querying the UTXOs for a given address does not limit the address to the
  target addresses provided in the CLI.

* Fixed the resuming capability of the indexers in `marconi-mamba`

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
    - [x] Important changes are reflected in changelog.d of the affected packages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
