### PR TITLE
Remove references to spago from nix setup

### DIFF
--- a/__std__/cells/plutus-apps/packages/pre-commit-check.nix
+++ b/__std__/cells/plutus-apps/packages/pre-commit-check.nix
@@ -33,7 +33,6 @@ inputs.pre-commit-hooks-nix.lib.run {
       excludes =
         [
           ".*nix/pkgs/haskell/materialized.*/.*"
-          ".*/spago-packages.nix$"
           ".*/packages.nix$"
         ];
     };

--- a/flake.lock
+++ b/flake.lock
@@ -542,26 +542,9 @@
         "nixpkgs": "nixpkgs",
         "plutus-core": "plutus-core",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
-        "spago2nix": "spago2nix",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock",
         "stackage-nix": "stackage-nix",
         "tullia": "tullia"
-      }
-    },
-    "spago2nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641236534,
-        "narHash": "sha256-a5cBQdkFg98NC8mpKzfVm5Iv2DtMSLlr9IclWp5D8mI=",
-        "owner": "justinwoo",
-        "repo": "spago2nix",
-        "rev": "1c834738a8216a4c89d9defac9bf1c331d302a6a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "justinwoo",
-        "repo": "spago2nix",
-        "type": "github"
       }
     },
     "sphinxcontrib-haddock": {

--- a/flake.nix
+++ b/flake.nix
@@ -53,10 +53,6 @@
       url = "github:cachix/pre-commit-hooks.nix";
       flake = false;
     };
-    spago2nix = {
-      url = "github:justinwoo/spago2nix";
-      flake = false;
-    };
     sphinxcontrib-haddock = {
       url = "github:michaelpj/sphinxcontrib-haddock";
       flake = false;

--- a/shell.nix
+++ b/shell.nix
@@ -66,7 +66,7 @@ let
         # While nixpkgs-fmt does exclude patterns specified in `.ignore` this
         # does not appear to work inside the hook. For now we have to thus
         # maintain excludes here *and* in `./.ignore` and *keep them in sync*.
-        excludes = [ ".*nix/pkgs/haskell/materialized.*/.*" ".*/spago-packages.nix$" ];
+        excludes = [ ".*nix/pkgs/haskell/materialized.*/.*" ];
       };
       cabal-fmt.enable = true;
       shellcheck.enable = true;


### PR DESCRIPTION
Another leftover from the removal of plutus-playground