### PR TITLE
Utxo JSON-RPC unit tests

### DIFF
--- a/marconi-chain-index/changelog.d/20230222_182400_kayvan_json_rpc_test.md
+++ b/marconi-chain-index/changelog.d/20230222_182400_kayvan_json_rpc_test.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- minor changes, mainly adding `show` instances for debugging purposes

--- a/marconi-chain-index/json-rpc/src/Network/JsonRpc/Client/Types.hs
+++ b/marconi-chain-index/json-rpc/src/Network/JsonRpc/Client/Types.hs
@@ -11,9 +11,7 @@
 --
 -- Note: This client implementation runs over HTTP and the semantics of HTTP
 -- remove the need for the message id.
-module Network.JsonRpc.Client.Types (
-    JsonRpcResponse
-    ) where
+module Network.JsonRpc.Client.Types  where
 
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Proxy (Proxy (Proxy))

--- a/marconi-chain-index/json-rpc/src/Network/JsonRpc/Types.hs
+++ b/marconi-chain-index/json-rpc/src/Network/JsonRpc/Types.hs
@@ -23,8 +23,8 @@ module Network.JsonRpc.Types
 
     -- * JSON-RPC messages
     , Request (..)
-    , JsonRpcResponse (..)
     , JsonRpcErr (..)
+    , JsonRpcResponse (..)
 
     -- ** Standard error codes
     , parseErrorCode

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -28,9 +28,6 @@
 -}
 module Marconi.ChainIndex.Indexers.Utxo where
 
-import Cardano.Api ()
-import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as Shelley
 import Control.Concurrent.Async (concurrently_)
 import Control.Exception (bracket_)
 import Control.Lens.Combinators (imap)
@@ -50,6 +47,12 @@ import Database.SQLite.Simple.FromRow (FromRow (fromRow), field)
 import Database.SQLite.Simple.ToField (ToField (toField))
 import Database.SQLite.Simple.ToRow (ToRow (toRow))
 import GHC.Generics (Generic)
+import System.Random.MWC (createSystemRandom, uniformR)
+import Text.RawString.QQ (r)
+
+import Cardano.Api ()
+import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as Shelley
 import Marconi.ChainIndex.Orphans ()
 import Marconi.ChainIndex.Types (CurrentEra, TargetAddresses, TxOut, pattern CurrentEra)
 import Marconi.Core.Storable (Buffered (getStoredEvents, persistToStorage), HasPoint (getPoint),
@@ -57,8 +60,6 @@ import Marconi.Core.Storable (Buffered (getStoredEvents, persistToStorage), HasP
                               Resumable (resumeFromStorage), Rewindable (rewindStorage), StorableEvent, StorableMonad,
                               StorablePoint, StorableQuery, StorableResult, emptyState, filterWithQueryInterval)
 import Marconi.Core.Storable qualified as Storable
-import System.Random.MWC (createSystemRandom, uniformR)
-import Text.RawString.QQ (r)
 
 type UtxoIndexer = Storable.State UtxoHandle
 

--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -4,7 +4,8 @@
 
 module Gen.Marconi.ChainIndex.Indexers.Utxo
     ( genUtxoEvents
-    , genEventAtChainPoint
+    , genShelleyEraUtxoEvents
+    , genEventWithShelleyAddressAtChainPoint
     )
 where
 
@@ -20,7 +21,7 @@ import Cardano.Api.Shelley qualified as C
 import Gen.Cardano.Api.Typed qualified as CGen
 import Gen.Marconi.ChainIndex.Types (genChainPoints, genTxOutTxContext, nonEmptySubset)
 import Helpers (emptyTxBodyContent)
-import Marconi.ChainIndex.Indexers.Utxo (StorableEvent (UtxoEvent), Utxo (Utxo), UtxoHandle)
+import Marconi.ChainIndex.Indexers.Utxo (StorableEvent (UtxoEvent), Utxo (Utxo), UtxoHandle, _address)
 import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 
 -- | Generates a list of UTXO events.
@@ -30,8 +31,13 @@ import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 --   * that any generated UTXO is unique
 --   * for any spent tx output, there must be a UTXO created in a previous event
 genUtxoEvents :: Gen [StorableEvent UtxoHandle]
-genUtxoEvents = do
-    chainPoints <- genChainPoints 1 5
+genUtxoEvents = genUtxoEvents' convertTxOutToUtxo
+
+genUtxoEvents'
+  :: (C.TxId -> C.TxIx -> C.TxOut C.CtxTx C.BabbageEra -> Utxo)
+  -> Gen [StorableEvent UtxoHandle]
+genUtxoEvents' txOutToUtxo = do
+    chainPoints <- genChainPoints 1 3
     txIns <- Set.singleton <$> CGen.genTxIn
     snd <$> foldM f (txIns, []) chainPoints
   where
@@ -43,7 +49,7 @@ genUtxoEvents = do
         txBodyContent <- genTxBodyContentFromTxIns $ Set.toList utxosAsTxInput
         txBody <- either (fail . show) pure $ C.makeTransactionBody txBodyContent
         let txId = C.getTxId txBody
-        let newUtxos = fmap (\(txIx, txOut) -> convertTxOutToUtxo txId (C.TxIx txIx) txOut)
+        let newUtxos = fmap (\(txIx, txOut) -> txOutToUtxo txId (C.TxIx txIx) txOut)
                 $ zip [0..]
                 $ C.txOuts txBodyContent
             newUtxoRefs = Set.fromList $ fmap (\Utxo { _txId, _txIx } -> C.TxIn _txId _txIx) newUtxos
@@ -63,7 +69,6 @@ convertTxOutToUtxo txId txIx (C.TxOut (C.AddressInEra _ addr) val txOutDatum ref
               C.ReferenceScriptNone -> (Nothing, Nothing)
               C.ReferenceScript _ scriptInAnyLang@(C.ScriptInAnyLang _ s) ->
                   (Just $ C.hashScript s, Just scriptInAnyLang)
-
      in Utxo
             (C.toAddressAny addr)
             txId
@@ -73,6 +78,20 @@ convertTxOutToUtxo txId txIx (C.TxOut (C.AddressInEra _ addr) val txOutDatum ref
             (C.txOutValueToValue val)
             script
             scriptHash
+-- | Override the Utxo address with ShelleyEra address
+-- This is used to generate ShelleyEra Utxo events
+utxoAddressOverride
+  :: C.Address C.ShelleyAddr
+  -> Utxo
+  -> Utxo
+utxoAddressOverride addr utxo =  utxo {_address=C.toAddressAny addr}
+
+-- | Generate ShelleyEra Utxo Events
+genShelleyEraUtxoEvents :: Gen [StorableEvent UtxoHandle]
+genShelleyEraUtxoEvents = do
+  addr <- CGen.genAddressShelley
+  genUtxoEvents' (\_id _ix _tx ->
+                    utxoAddressOverride addr $ convertTxOutToUtxo _id _ix _tx)
 
 genTxBodyContentFromTxIns
     :: [C.TxIn]
@@ -87,12 +106,13 @@ genTxBodyContentFromTxIns inputs = do
         , C.txOuts = txOuts
         }
 
+
 -- TODO Must be reworked following implementation in 'genUtxoEvents'.
-genEventAtChainPoint :: C.ChainPoint -> Gen (Utxo.StorableEvent Utxo.UtxoHandle)
-genEventAtChainPoint ueChainPoint = do
-  txOutRefs <- Gen.list (Range.linear 1 10) CGen.genTxIn
+genEventWithShelleyAddressAtChainPoint :: C.ChainPoint -> Gen (Utxo.StorableEvent Utxo.UtxoHandle)
+genEventWithShelleyAddressAtChainPoint ueChainPoint = do
+  txOutRefs <- Gen.list (Range.linear 1 5) CGen.genTxIn
   ueUtxos <- Set.fromList <$> forM txOutRefs genUtxo
-  ueInputs <- Gen.set (Range.linear 1 10) CGen.genTxIn
+  ueInputs <- Gen.set (Range.linear 1 5) CGen.genTxIn
   pure $ Utxo.UtxoEvent {..}
 
 genUtxo :: C.TxIn -> Gen Utxo.Utxo

--- a/marconi-chain-index/test-lib/Helpers.hs
+++ b/marconi-chain-index/test-lib/Helpers.hs
@@ -322,3 +322,9 @@ txFeesExplicitInShelleyBasedEra shelleyBased =
       C.ShelleyBasedEraMary    -> C.TxFeesExplicitInMaryEra
       C.ShelleyBasedEraAlonzo  -> C.TxFeesExplicitInAlonzoEra
       C.ShelleyBasedEraBabbage -> C.TxFeesExplicitInBabbageEra
+
+addressAnyToShelley
+  :: C.AddressAny
+  -> Maybe (C.Address C.ShelleyAddr)
+addressAnyToShelley  (C.AddressShelley a) = Just a
+addressAnyToShelley  _                    = Nothing

--- a/marconi-sidechain/changelog.d/20230223_182500_kayvan_json_rpc_test.md
+++ b/marconi-sidechain/changelog.d/20230223_182500_kayvan_json_rpc_test.md
@@ -1,0 +1,7 @@
+### Add
+
+- add json-rpc test to test the payload serialization through RPC routes
+
+### Fixed
+
+- update the client/server examples for the recent changes in the UTXO payload and query interface

--- a/marconi-sidechain/examples/json-rpc-client/src/Main.hs
+++ b/marconi-sidechain/examples/json-rpc-client/src/Main.hs
@@ -1,56 +1,59 @@
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators    #-}
+{-# LANGUAGE DataKinds #-}
 
--- | A sample servant json-rpc client
+-- | A sample servant json-rpc client for marconi-sidechain
 
 module Main where
 
-import Control.Monad (void)
-import Control.Monad.IO.Class (liftIO)
 import Data.Proxy (Proxy (Proxy))
-import Marconi.ChainIndex.Types (TxOutRef)
+import Marconi.Sidechain.Api.Routes (JsonRpcAPI)
 import Network.HTTP.Client (defaultManagerSettings, newManager)
-import Network.JsonRpc.Client.Types (JsonRpcResponse)
-import Network.JsonRpc.Types (JsonRpc, JsonRpcNotification, RawJsonRpc)
-import Servant.API (Get, NoContent, PlainText, Post, ReqBody, (:<|>) ((:<|>)), (:>))
-import Servant.Client (ClientM, client, mkClientEnv, parseBaseUrl, runClientM)
+import Network.JsonRpc.Client.Types ()
+import Network.JsonRpc.Types (JsonRpcResponse (Ack, Errors, Result))
+import Servant.API ((:<|>) ((:<|>)))
+import Servant.Client (BaseUrl (BaseUrl), ClientEnv, HasClient (Client), Scheme (Http), client, hoistClient,
+                       mkClientEnv, runClientM)
+
+-- | an address to test
+bech32Address :: String
+bech32Address =
+  "addr_test1vryusxht8rgz4g6twrjz4y8gss66w202vtfyk84wahmguzgh5mejc"
+
+-- | We assume the json-rpc server is running on local machine, port 3000
+url :: BaseUrl
+url = BaseUrl Http "localhost" 3000 ""
 
 -- | start json-rpc client
 -- Note, we use default port, 3000,  [defaultSettings](https://hackage.haskell.org/package/warp-3.3.23/docs/Network-Wai-Handler-Warp.html#v:defaultSettings)
 main :: IO ()
 main = do
-    env <- mkClientEnv <$>
-        newManager defaultManagerSettings <*>
-        parseBaseUrl "http://localhost:3000"
-    void . flip runClientM env $ do
-        void . jsonRpcPrint $ "Starting RPC calls"
-        liftIO . print =<< add (2, 10)
-        liftIO . print =<< findTxOutRef "0654321"
+  putStrLn "Starting servant client "
+  manager' <- newManager defaultManagerSettings
+  let env = mkClientEnv manager' url
+  let (rpcEcho :<|> rpcTargets :<|> rpcUtxos) = getClients env
+  -- RPC calls
+  msg <- rpcEcho "marconi client calling ???" --  return the echo message
+  addresses <- rpcTargets ""                  --  get the targetAddresss
+  utxos <- rpcUtxos bech32Address             --  get utxos for this address
+  printResults msg
+  printResults addresses
+  printResults utxos
 
-        void . printMessage $ "Starting REST calls"
-        liftIO . print =<< getTime
+  putStrLn "servant client has completed its work."
 
-add :: (Int, Int) -> ClientM (JsonRpcResponse String Int)
-getTime :: ClientM String
-findTxOutRef :: String -> ClientM (JsonRpcResponse String TxOutRef)
-jsonRpcPrint :: String -> ClientM NoContent
-printMessage :: String -> ClientM NoContent
-(add :<|> findTxOutRef :<|>  jsonRpcPrint) :<|> ( getTime :<|> printMessage) = client $ Proxy @API
+-- | Print results of the RPC call
+printResults :: (Show e , Show r) => JsonRpcResponse r e -> IO ()
+printResults (Result _ r) = print r
+printResults (Ack w)      =  putStrLn $ "Unexpected `Ack` Received from server: " <> show w
+printResults (Errors _ e) =  putStrLn $ "Unexpected error: " <> show e
 
-type Add            = JsonRpc "add"      (Int, Int) String Int
-type FindTxOutRef   = JsonRpc "txOutRef" String String TxOutRef
-type Print          = JsonRpcNotification "print" String
+hoistClientApi :: Proxy JsonRpcAPI -- RPC Api end points
+hoistClientApi = Proxy
 
-type RpcAPI = Add :<|> FindTxOutRef :<|> Print
-
-type JsonRpcAPI = "json-rpc" :> RawJsonRpc RpcAPI
-
-type GetTime = "time" :> Get '[PlainText] String
-type PrintMessage = "print" :> ReqBody '[PlainText] String :> Post '[PlainText] NoContent
-
-type RestAPI = "rest" :> (GetTime :<|> PrintMessage)
-
-type API = JsonRpcAPI :<|> RestAPI
-
-type NonEndpoint = "json-rpc" :> RawJsonRpc (JsonRpc "launch-missles" Int String Bool)
+-- hoist to IO monad for running the client
+getClients :: ClientEnv -> Client IO JsonRpcAPI
+getClients clientEnv
+  = hoistClient hoistClientApi
+                ( fmap (either (error . show) id)
+                . flip runClientM clientEnv
+                )
+                (client hoistClientApi)

--- a/marconi-sidechain/examples/start-json-rpc-server.sh
+++ b/marconi-sidechain/examples/start-json-rpc-server.sh
@@ -1,32 +1,18 @@
 #!/usr/bin/env sh
 
-PLUTUS_APPS_DIR=../..
+DB_DIR="~/dev/var/iohk/marconi/1675803710"
+UTXO_FILE="utxodb"
 
-DB="$PLUTUS_APPS_DIR/.marconidb/7"
-mkdir -p $DB
-ls -la $DB
+DB="$DB_DIR/$UTXO_FILE"
+mkdir -p $DB_DIR
+ls -la $DB_DIR
 
 ## Noes
 ## We use db-utils-exe/exe/Main.hs to get a list of most re occuring addresses from utxo-db
 ## Therefor these addresses my not always be the best addresses to use.
 ##
 cabal run examples-json-rpc-server -- \
-    --utxo-db "$DB/utxo-db" \
-    --addresses-to-index addr_test1qqwh05w69g95065zlr4fef4yfpjkv8r3dr9h3pu0egy5n7pwhxp4f95svdjr9dmtqumqcs6v49s6pe7ap4h2nv8rcaasgrkndk \
-    --addresses-to-index addr_test1wr9gquc23wc7h8k4chyaad268mjft7t0c08wqertwms70sc0fvx8w \
-    --addresses-to-index addr_test1qpp0xdvdexl4t3ur4svdkv3jjs2gy8fu6h9mrrsgvm7r20cmrhy4p5ukjknv23jy95nhsjsnud6fxkjqxp5ehvn8h0es2su3gt \
-    --addresses-to-index addr_test1qzu6at6s7r7yzpvw3mm2tsas34mc9nzrhda89w59wd78lfaw8084xldqyrvxe38z4wxqqdr9h86t8ruut8rrfezdftpstsnrd8 \
-    --addresses-to-index addr_test1vqslp49gcrvah8c9vjpxm4x9j7s2m4zw0gkscqh0pqjg4wcjzvcfr \
-    --addresses-to-index addr_test1wrn2wfykuhswv4km08w0zcl5apmnqha0j24fa287vueknasq6t4hc \
-    --addresses-to-index addr_test1qr30nkfx28r452r3006kytnpvn39zv7c2m5uqt4zrg35mly35pesdyk43wnxk3edkkw74ak56n4zh67reqjhcfp3mm7qtyekt4 \
-    --addresses-to-index addr_test1qrr6urmwy2nle3xppnjg9xcukasrwfyfjv9eqh97km84ra53q4hau90tjeldx0mv9eka2z73t9727xl8jny3cy8zetqsdjctpd \
---addresses-to-index addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc \
---addresses-to-index addr_test1wz3937ykmlcaqxkf4z7stxpsfwfn4re7ncy48yu8vutcpxgnj28k0 \
---addresses-to-index addr_test1vqeux7xwusdju9dvsj8h7mca9aup2k439kfmwy773xxc2hcu7zy99 \
---addresses-to-index addr_test1qpxtftdcvh55twn2lum4uylxshzls6489q89pft3feesq2m8an0x234jtsqra93hcefmut6cyd6cdn535nkjukhph47ql6uvg7 \
---addresses-to-index addr_test1qz8q8ymsty33sw7mh4s2wxj2pe4mcrlchxxa37z70l348cyjd3dlf08q9usapw5gt5t8cp8lju7wtwqzk5cj0gxaxyss6w8n66 \
---addresses-to-index addr_test1vrvf7yfr2h79mtzqrpcn0ql98xrhs63k85w64u8py7709zsm6tsr6 \
---addresses-to-index addr_test1vz8q8ymsty33sw7mh4s2wxj2pe4mcrlchxxa37z70l348cqk95hdw \
---addresses-to-index addr_test1wqgden0j2d7pkqy3hu6kcj32swazzy6wg93a8c46pndptncdmz6tq \
---addresses-to-index addr_test1qpe6s9amgfwtu9u6lqj998vke6uncswr4dg88qqft5d7f67kfjf77qy57hqhnefcqyy7hmhsygj9j38rj984hn9r57fswc4wg0 \
---addresses-to-index addr_test1qz4ll7yrah8h5t3cv2qptn4mw22judsm9j9zychhmtuuzmszd3hm6w02uxx6h0s3qgd4hxgpvd0qzklnmahcx7v0mcysptyj8l
+    --utxo-db "$DB" \
+    --addresses-to-index addr_test1wrpn0ad8rj3pgfpzae5tghpf325nyvh94zfkj3kzgvxzvcc2zuac6 \
+    --addresses-to-index addr_test1vryusxht8rgz4g6twrjz4y8gss66w202vtfyk84wahmguzgh5mejc \
+    --addresses-to-index addr_test1wpzewuy339m9l8ax7gz8g08q2j9478lgntzv9qhmwvy3hwg0cwsaf

--- a/marconi-sidechain/marconi-sidechain.cabal
+++ b/marconi-sidechain/marconi-sidechain.cabal
@@ -118,6 +118,7 @@ executable examples-json-rpc-server
   build-depends:
     , async
     , base                  >=4.9 && <5
+    , filepath
     , lens
     , optparse-applicative
     , stm
@@ -130,16 +131,19 @@ executable examples-json-rpc-client
   --------------------
   -- Local components
   --------------------
-  build-depends:  marconi-chain-index:{marconi-chain-index, json-rpc}
+  build-depends:
+    , marconi-chain-index:json-rpc
+    , marconi-sidechain
 
   ------------------------
   -- Non-IOG dependencies
   ------------------------
   build-depends:
-    , base            >=4.9 && <5
+    , base                 >=4.9 && <5
     , http-client
     , servant
     , servant-client
+    , servant-client-core
 
 library db-utils
   import:          lang
@@ -193,7 +197,7 @@ test-suite marconi-sidechain-test
   -- Local components
   --------------------
   build-depends:
-    , marconi-chain-index:{marconi-chain-index, marconi-chain-index-test-lib}
+    , marconi-chain-index:{marconi-chain-index, json-rpc, marconi-chain-index-test-lib}
     , marconi-core
     , marconi-sidechain
 
@@ -212,10 +216,15 @@ test-suite marconi-sidechain-test
     , bytestring
     , containers
     , hedgehog
+    , http-client
     , lens
     , optparse-applicative
+    , servant
+    , servant-client
+    , servant-server
     , stm
     , tasty
     , tasty-golden
     , tasty-hedgehog
     , text
+    , warp

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
@@ -3,9 +3,7 @@
 {-# LANGUAGE DataKinds     #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Marconi.Sidechain.Api.Routes (
-  API
-  ) where
+module Marconi.Sidechain.Api.Routes where
 
 import Data.Text (Text)
 import Marconi.Sidechain.Api.Types (UtxoQueryResult)
@@ -23,10 +21,7 @@ type RpcUtxoQueryResult = JsonRpc "getUtxoFromAddress" String String UtxoQueryRe
 type RpcTargetAddresses = JsonRpc "getTargetAddresses" String String [Text]
 
 -- | Rpc routes
-type RpcAPI
-  = RpcEcho
-  :<|> RpcUtxoQueryResult
-  :<|> RpcTargetAddresses
+type RpcAPI = RpcEcho :<|> RpcTargetAddresses :<|> RpcUtxoQueryResult
 
 -- | JSON-RPC API, endpoint
 type JsonRpcAPI = "json-rpc" :> RawJsonRpc RpcAPI

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Types.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Types.hs
@@ -22,7 +22,7 @@ module Marconi.Sidechain.Api.Types  where
 import Control.Concurrent.STM.TMVar (TMVar)
 import Control.Exception (Exception)
 import Control.Lens (makeClassy)
-import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
+import Data.Aeson (FromJSON, ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import Network.Wai.Handler.Warp (Settings)
@@ -68,7 +68,9 @@ data QueryExceptions
 data UtxoQueryResult = UtxoQueryResult
     { uqAddress :: Text
     , uqResults :: ![Utxo.UtxoRow]
-    } deriving (Eq, Ord, Generic)
+    } deriving (Eq, Ord, Generic, Show)
 
 instance ToJSON UtxoQueryResult where
     toEncoding = genericToEncoding defaultOptions
+
+instance FromJSON UtxoQueryResult

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings  #-}
@@ -6,9 +7,9 @@
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
+
 module Spec.Marconi.Sidechain.Api.Query.Indexers.Utxo (tests) where
 
-import Cardano.Api qualified as C
 import Control.Concurrent.STM (atomically)
 import Control.Lens.Operators ((^.))
 import Control.Monad.IO.Class (liftIO)
@@ -16,21 +17,69 @@ import Data.Aeson qualified as Aeson
 import Data.Aeson.Encode.Pretty qualified as Aeson
 import Data.ByteString.Lazy (ByteString)
 import Data.Foldable (fold)
-import Data.List (nub)
+import Data.Maybe (mapMaybe)
 import Data.Proxy (Proxy (Proxy))
+import Data.Set (Set)
 import Data.Set qualified as Set
-import Gen.Marconi.ChainIndex.Indexers.Utxo (genUtxoEvents)
+import Data.Text (unpack)
+import Data.Traversable (for)
+import Network.HTTP.Client (defaultManagerSettings, newManager)
+import Network.JsonRpc.Client.Types ()
+import Network.Wai.Handler.Warp qualified as Warp
+import Servant.API ((:<|>) ((:<|>)))
+import Servant.Client (BaseUrl (BaseUrl), ClientEnv, HasClient (Client), Scheme (Http), client, hoistClient,
+                       mkClientEnv, runClientM)
+
 import Hedgehog (Property, forAll, property, (===))
-import Hedgehog.Gen qualified as Gen
-import Hedgehog.Range qualified as Range
+import Test.Tasty (TestTree, testGroup, withResource)
+import Test.Tasty.Golden (goldenVsStringDiff)
+import Test.Tasty.Hedgehog (testPropertyNamed)
+
+import Cardano.Api qualified as C
+import Gen.Marconi.ChainIndex.Indexers.Utxo (genShelleyEraUtxoEvents, genUtxoEvents)
+import Helpers (addressAnyToShelley)
 import Marconi.ChainIndex.Indexers.Utxo (Utxo (Utxo), UtxoRow (UtxoRow))
 import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 import Marconi.Core.Storable qualified as Storable
+import Marconi.Sidechain.Api.HttpServer (marconiApp)
 import Marconi.Sidechain.Api.Query.Indexers.Utxo qualified as UIQ
-import Marconi.Sidechain.Api.Types (HasIndexerEnv (uiIndexer))
-import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.Golden (goldenVsStringDiff)
-import Test.Tasty.Hedgehog (testPropertyNamed)
+import Marconi.Sidechain.Api.Routes (JsonRpcAPI)
+import Marconi.Sidechain.Api.Types (HasIndexerEnv (uiIndexer), IndexerEnv, UtxoQueryResult (UtxoQueryResult))
+import Network.JsonRpc.Types (JsonRpcResponse (Result))
+
+-- | A type for Storable Action to store events
+newtype RpcEnv = RpcEnv ([Utxo.StorableEvent Utxo.UtxoHandle] -> IO ()) --  callback
+
+-- | Alias for the storable-action and RPC-client-Action pair, to simplify the type signatures
+type RpcClientAction = IO ( RpcEnv, String -> IO (JsonRpcResponse String UtxoQueryResult) )
+
+mkRpcEnv :: IndexerEnv -> RpcEnv
+mkRpcEnv ixenv =
+  let cb :: Utxo.UtxoIndexer -> IO ()
+      cb = atomically . UIQ.writeTMVar' (ixenv ^. uiIndexer)
+  in RpcEnv (mocUtxoWorker cb)
+
+-- | Initialize RPC server on a free available port
+initRpcTestEnv :: RpcClientAction
+initRpcTestEnv = do
+  ixenv <- UIQ.initializeEnv Nothing
+  let f= \s -> Warp.testWithApplication (pure $ marconiApp ixenv)(queryUtxoFromRpcServer s)
+  pure (mkRpcEnv ixenv, f)
+
+-- | JSON-RPC Testtree
+-- We put all the JSON-RPC tests under this `TestTree`
+utxoJsonRpcTestTree :: TestTree
+utxoJsonRpcTestTree = withResource initRpcTestEnv (\_ -> pure ()) runUtxoJsonRpcTests
+
+runUtxoJsonRpcTests
+  :: RpcClientAction -- ^ the IO hoisted RPC client action that call the RPC Server
+  -> TestTree
+runUtxoJsonRpcTests rpcenv = testGroup "marconi-sidechain -utxo JSON-RPC test-group"
+    [ testPropertyNamed
+        "marconi-sidechain-utxo JSON-RPC test:stores UtxoEvents, and retrieve them through the RPC server using an RPC client"
+        "Spec. JSON-RPC, retreive inserted events through RPC endoints"
+        (propUtxoEventInsertionAndJsonRpcQueryRoundTrip rpcenv )
+    ]
 
 tests :: TestTree
 tests = testGroup "marconi-sidechain-utxo query Api Specs"
@@ -44,35 +93,37 @@ tests = testGroup "marconi-sidechain-utxo query Api Specs"
         (\expected actual -> ["diff", "--color=always", expected, actual])
         "test/Spec/Marconi/Sidechain/Api/Query/Indexers/address-utxo-response.json"
         generateUtxoRowJson
+
+    , utxoJsonRpcTestTree
     ]
 
+depth :: Utxo.Depth
+depth = Utxo.Depth 5
+
 -- | Insert events, and perform the callback
+-- Note, the in-memory DB provides the isolation we need per property test as the memory cache
+-- is owned and visible only o the process that opened the connection
 mocUtxoWorker
   :: (UIQ.UtxoIndexer -> IO ())
   -> [Utxo.StorableEvent Utxo.UtxoHandle]
-  -> Utxo.Depth
   -> IO ()
-mocUtxoWorker callback events depth =
+mocUtxoWorker callback events  =
   Utxo.open ":memory:" depth >>= Storable.insertMany events >>= callback
 
 -- | generate some Utxo events, store them and fetch them.
---
 queryTargetAddressTest :: Property
 queryTargetAddressTest = property $ do
   events <- forAll genUtxoEvents
-  depth <- forAll $ Gen.int (Range.linear 1 $ length events * 2)
-
   env <- liftIO . UIQ.initializeEnv $ Nothing
-
   let
     callback :: Utxo.UtxoIndexer -> IO ()
     callback = atomically . UIQ.writeTMVar' (env ^. uiIndexer) -- update the indexer
-  liftIO . mocUtxoWorker callback events $ Utxo.Depth depth
+  liftIO $ mocUtxoWorker callback events
   fetchedRows <-
     liftIO
     . fmap concat
     . traverse (UIQ.findByAddress env)
-    . nub -- required to remove the potential duplicate addresses
+    . Set.toList . Set.fromList  -- required to remove the potential duplicate addresses
     . fmap Utxo._address
     . concatMap (Set.toList . Utxo.ueUtxos)
     $ events
@@ -115,7 +166,7 @@ generateUtxoRowJson = do
         either
             (error . show)
             pure
-            $ C.deserialiseFromRawBytesHex C.AsTxId $ txIdRawBytes
+            $ C.deserialiseFromRawBytesHex C.AsTxId txIdRawBytes
 
     let blockHeaderHashRawBytes = "6161616161616161616161616161616161616161616161616161616161616161"
     blockHeaderHash <-
@@ -136,3 +187,59 @@ generateUtxoRowJson = do
                 (Just $ C.hashScript script)
         utxoRow = UtxoRow utxo (C.SlotNo 1) blockHeaderHash
     pure $ Aeson.encodePretty utxoRow
+
+-- | Create http JSON-RPC client function to test RPC route and handlers
+queryUtxoFromRpcServer
+  :: String     -- ^ bech32 ShelleyEra address to fetch Utxo's for
+  -> Warp.Port  -- ^ http port
+  -> IO (JsonRpcResponse String UtxoQueryResult)  -- ^  response to the client RPC http call
+queryUtxoFromRpcServer address port = do
+  manager' <- newManager defaultManagerSettings
+  let env = mkClientEnv manager' (baseUrl port)
+  let (rpcEcho :<|> rpcTargets :<|> rpcUtxos) = mkHoistedHttpRpcClient env
+  -- test will fail if these RPC methods fail.
+  _ <- rpcEcho "client calling "
+  _ <- rpcTargets ""
+  rpcUtxos address
+
+-- | Test round trip Utxos thruough JSON-RPC http server
+-- We compare a represenation of the generated UtxoEvents
+-- with those fetched from the JSON-RPC  server. The purpose of this is:
+--   + RPC server routes the request to the correct handler
+--   + Events are serialized/deserialized thru the RPC layer and it various wrappers correctly
+propUtxoEventInsertionAndJsonRpcQueryRoundTrip
+  :: RpcClientAction
+  -> Property
+propUtxoEventInsertionAndJsonRpcQueryRoundTrip action = property $ do
+  (RpcEnv storableAction, rpcClient) <- liftIO action
+  events <- forAll genShelleyEraUtxoEvents
+  liftIO $ storableAction events
+  let (qAddresses :: [String]) =
+        Set.toList . Set.fromList . fmap (unpack . C.serialiseAddress)
+        . mapMaybe (addressAnyToShelley . Utxo._address)
+        . concatMap  (Set.toList . Utxo.ueUtxos)
+        $ events
+  rpcResponses <- liftIO $ for qAddresses rpcClient
+  let
+    inserted :: Set Utxo.UtxoRow = Set.fromList . concatMap Utxo.eventsToRows $ events
+    fetched :: Set Utxo.UtxoRow =  Set.fromList . concatMap fromQueryResult $ rpcResponses
+  fetched === inserted
+
+hoistClientApi :: Proxy JsonRpcAPI
+hoistClientApi = Proxy
+
+-- hoist http servant client from clientM to IO
+mkHoistedHttpRpcClient :: ClientEnv -> Client IO JsonRpcAPI
+mkHoistedHttpRpcClient cEnv
+  = hoistClient hoistClientApi
+                ( fmap (either (error . show) id)
+                . flip runClientM cEnv
+                )
+                (client hoistClientApi)
+
+baseUrl :: Warp.Port -> BaseUrl
+baseUrl port = BaseUrl Http "localhost" port ""
+
+fromQueryResult :: JsonRpcResponse e UtxoQueryResult -> [Utxo.UtxoRow]
+fromQueryResult (Result _ (UtxoQueryResult _ rows) ) = rows
+fromQueryResult _                                    = []


### PR DESCRIPTION
Create client/server servant the json-rpc test
- add a http JSON-RPC  test the RPC routes and round trip payload seiralisation
-  update the marconi-chain-index/exmples/json-rpc related modules for the recent changes
- separate the RPC routes from REST routes so that we may reuse the RPC handlers client code 
- NOTE, there is TODO that comments a failing test till we have a fix for the ScriptData round trip serialization
-
[PLT-94]

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x ] Tests are provided (if possible)
    - [ x] Commit sequence broadly makes sense
    - [x ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [x ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [x ] Self-reviewed the diff
    - [ x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ x] Reviewer requested


[PLT-94]: https://input-output.atlassian.net/browse/PLT-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ