### PR TITLE
plutus-e2e-tests on a public network

### DIFF
--- a/plutus-e2e-tests/README.md
+++ b/plutus-e2e-tests/README.md
@@ -9,8 +9,16 @@ This framework is still in early stages of development with only a handful of te
 - Spending funds locked at script using reference script, reference inputs and providing datum as witness in txbody.
 - Minting tokens using reference script and providing script witness in txbody.
 
+It is also possible to run these tests on a public testnet, see preconditions:
+- Have a directory containing at least these two directories:
+  - "utxo-keys" containing "test.skey" and "test.vkey" files. These must both be text envelope PaymentKey format, currently no support for PaymentExtendedKey.
+  - "ipc" containing the active node.socket
+- Cardano node is fully synced on a public network (e.g. preview testnet)
+- There is at least one ada-only UTxO at the test account. Each test will spend a few ada so make sure there's enough funds.
+- Modify the test options passed to each test to be run from `TestnetOptions` to `LocalNodeOptions`. E.g. swap `testnetOptionsBabbage8` for `localNodeOptionsPreview`.
+- Ensure the `LocalNodeOption`'s `localEnvDir` points to the directory containing your keys ("utxo-keys") and node socket ("ipc").
+
 There are plans to add the following features:
 - Shared instance of `cardano-testnet` for all tests targeting a common protocol version, e.g. Babbage PV8. This should make overall execution time shorter.
-- Some tests to also be run on a public testnet, e.g. `preview` or `pre-prod`.
 - Test reporting, e.g. [tasty-html](https://hackage.haskell.org/package/tasty-html) or [Allure](https://qameta.io/allure-report/).
 - Nightly CI test execution.

--- a/plutus-e2e-tests/test/Helpers.hs
+++ b/plutus-e2e-tests/test/Helpers.hs
@@ -567,12 +567,13 @@ waitForTxInAtAddress :: (MonadIO m, MonadTest m)
   -> C.LocalNodeConnectInfo C.CardanoMode
   -> C.Address C.ShelleyAddr
   -> C.TxIn
+  -> String -- temp debug text for intermittent timeout failure
   -> m ()
-waitForTxInAtAddress era localNodeConnectInfo address txIn = do
+waitForTxInAtAddress era localNodeConnectInfo address txIn debugStr = do
   let timeoutSeconds = 90 :: Int
       loop i = do
         if i == 0
-          then error "waitForTxInAtAddress timeout"
+          then error ("waitForTxInAtAddress timeout. Debug: " ++ debugStr)
           else HE.threadDelay 1000000
         utxos <- findUTxOByAddress era localNodeConnectInfo address
         when (Map.notMember txIn $ C.unUTxO utxos) (loop $ pred i)
@@ -584,9 +585,10 @@ getTxOutAtAddress :: (MonadIO m, MonadTest m)
   -> C.LocalNodeConnectInfo C.CardanoMode
   -> C.Address C.ShelleyAddr
   -> C.TxIn
+  -> String -- temp debug text for intermittent timeout failure (waitForTxInAtAddress)
   -> m (C.TxOut C.CtxUTxO era)
-getTxOutAtAddress era localNodeConnectInfo address txIn = do
-    maybeTxOut <- getTxOutAtAddress' era localNodeConnectInfo address txIn
+getTxOutAtAddress era localNodeConnectInfo address txIn debugStr = do
+    maybeTxOut <- getTxOutAtAddress' era localNodeConnectInfo address txIn debugStr
     return $ fromMaybe maybeTxOut
     where
       fromMaybe Nothing    = error $ "txIn " ++ show txIn ++ " is not at address " ++ show address
@@ -598,9 +600,10 @@ getTxOutAtAddress' :: (MonadIO m, MonadTest m)
   -> C.LocalNodeConnectInfo C.CardanoMode
   -> C.Address C.ShelleyAddr
   -> C.TxIn
+  -> String -- temp debug text for intermittent timeout failure (waitForTxInAtAddress)
   -> m (Maybe (C.TxOut C.CtxUTxO era))
-getTxOutAtAddress' era localNodeConnectInfo address txIn = do
-  waitForTxInAtAddress era localNodeConnectInfo address txIn
+getTxOutAtAddress' era localNodeConnectInfo address txIn debugStr = do
+  waitForTxInAtAddress era localNodeConnectInfo address txIn debugStr
   utxos <- findUTxOByAddress era localNodeConnectInfo address
   return $ Map.lookup txIn $ C.unUTxO utxos
 

--- a/plutus-e2e-tests/test/PlutusScripts.hs
+++ b/plutus-e2e-tests/test/PlutusScripts.hs
@@ -37,9 +37,8 @@ import Data.ByteString qualified as BS (ByteString)
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Short qualified as SBS
 import Plutus.Script.Utils.Typed (IsScriptContext (mkUntypedMintingPolicy))
-import Plutus.Script.Utils.V2.Address as PSU.V2
-import Plutus.V1.Ledger.Api (Address, MintingPolicy (MintingPolicy), Validator (Validator), mkMintingPolicyScript,
-                             mkValidatorScript, unMintingPolicyScript, unValidatorScript)
+import Plutus.V1.Ledger.Api (MintingPolicy, Validator, mkMintingPolicyScript, mkValidatorScript, unMintingPolicyScript,
+                             unValidatorScript)
 import Plutus.V1.Ledger.Api qualified as PlutusV1
 import Plutus.V1.Ledger.Bytes qualified as P (bytes, fromHex)
 import Plutus.V2.Ledger.Api qualified as PlutusV2

--- a/plutus-e2e-tests/test/Spec/BabbageFeatures.hs
+++ b/plutus-e2e-tests/test/Spec/BabbageFeatures.hs
@@ -26,15 +26,15 @@ tests :: TestTree
 tests = testGroup "reference script"
   [ testProperty "mint a token with a reference script in Babbage PV7" (referenceScriptMint testnetOptionsBabbage7)
   , testProperty "mint a token with a reference script in Babbage PV8" (referenceScriptMint testnetOptionsBabbage8)
-  --, testProperty "mint a token with a reference script in Babbage PV8" (referenceScriptMint localNodeOptionsPreview)
+  --, testProperty "mint a token with a reference script in Babbage PV8" (referenceScriptMint localNodeOptionsPreview) -- uncomment to use local node on preview testnet
 
   , testProperty "spend locked funds with a reference script using inline datum in Babbage PV7" (referenceScriptInlineDatumSpend testnetOptionsBabbage7)
   , testProperty "spend locked funds with a reference script using inline datum in Babbage PV8" (referenceScriptInlineDatumSpend testnetOptionsBabbage8)
-  --, testProperty "spend locked funds with a reference script using inline datum in Babbage PV8" (referenceScriptInlineDatumSpend localNodeOptionsPreview)
+  --, testProperty "spend locked funds with a reference script using inline datum in Babbage PV8" (referenceScriptInlineDatumSpend localNodeOptionsPreview) -- uncomment to use local node on preview testnet
 
   , testProperty "spend locked funds with a reference script providing datum in txbody in Babbage PV7" (referenceScriptDatumHashSpend testnetOptionsBabbage7)
   , testProperty "spend locked funds with a reference script providing datum in txbody in Babbage PV8" (referenceScriptDatumHashSpend testnetOptionsBabbage8)
-  --, testProperty "spend locked funds with a reference script providing datum in txbody in Babbage PV8" (referenceScriptDatumHashSpend localNodeOptionsPreview)
+  --, testProperty "spend locked funds with a reference script providing datum in txbody in Babbage PV8" (referenceScriptDatumHashSpend localNodeOptionsPreview) -- uncomment to use local node on preview testnet
   ]
 
 referenceScriptMint :: Either TN.LocalNodeOptions TN.TestnetOptions -> H.Property

--- a/plutus-e2e-tests/test/Spec/BabbageFeatures.hs
+++ b/plutus-e2e-tests/test/Spec/BabbageFeatures.hs
@@ -64,7 +64,7 @@ referenceScriptMint networkOptions = H.integration . HE.runFinallies . TN.worksp
   TN.submitTx era localNodeConnectInfo signedTx
   let refScriptTxIn = TN.txIn (TN.txId signedTx) 0
       otherTxIn   = TN.txIn (TN.txId signedTx) 1
-  TN.waitForTxInAtAddress era localNodeConnectInfo w1Address refScriptTxIn
+  TN.waitForTxInAtAddress era localNodeConnectInfo w1Address refScriptTxIn "TN.waitForTxInAtAddress"
 
   -- 3: build a transaction to mint token using reference script
 
@@ -86,7 +86,7 @@ referenceScriptMint networkOptions = H.integration . HE.runFinallies . TN.worksp
   TN.submitTx era localNodeConnectInfo signedTx2
   let expectedTxIn = TN.txIn (TN.txId signedTx2) 0
   -- Query for txo and assert it contains newly minted token
-  resultTxOut <- TN.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn
+  resultTxOut <- TN.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn "TN.getTxOutAtAddress"
   txOutHasTokenValue <- TN.txOutHasValue resultTxOut tokenValues
   H.assert txOutHasTokenValue
   H.success
@@ -122,7 +122,7 @@ referenceScriptInlineDatumSpend networkOptions = H.integration . HE.runFinallies
   let refScriptTxIn = TN.txIn (TN.txId signedTx) 0
       otherTxIn     = TN.txIn (TN.txId signedTx) 1
       txInAtScript  = TN.txIn (TN.txId signedTx) 2
-  TN.waitForTxInAtAddress era localNodeConnectInfo w1Address refScriptTxIn
+  TN.waitForTxInAtAddress era localNodeConnectInfo w1Address refScriptTxIn "TN.waitForTxInAtAddress"
 
   -- 3: build a transaction to mint token using reference script
 
@@ -143,7 +143,7 @@ referenceScriptInlineDatumSpend networkOptions = H.integration . HE.runFinallies
   TN.submitTx era localNodeConnectInfo signedTx2
   let expectedTxIn = TN.txIn (TN.txId signedTx2) 0
   -- Query for txo and assert it contains newly minted token
-  resultTxOut <- TN.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn
+  resultTxOut <- TN.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn "TN.getTxOutAtAddress"
   txOutHasAdaValue <- TN.txOutHasValue resultTxOut adaValue
   H.assert txOutHasAdaValue
   H.success
@@ -180,7 +180,7 @@ referenceScriptDatumHashSpend networkOptions = H.integration . HE.runFinallies .
   let refScriptTxIn = TN.txIn (TN.txId signedTx) 0
       otherTxIn     = TN.txIn (TN.txId signedTx) 1
       txInAtScript  = TN.txIn (TN.txId signedTx) 2
-  TN.waitForTxInAtAddress era localNodeConnectInfo w1Address refScriptTxIn
+  TN.waitForTxInAtAddress era localNodeConnectInfo w1Address refScriptTxIn "TN.waitForTxInAtAddress"
 
   -- 3: build a transaction to mint token using reference script
 
@@ -201,7 +201,7 @@ referenceScriptDatumHashSpend networkOptions = H.integration . HE.runFinallies .
   TN.submitTx era localNodeConnectInfo signedTx2
   let expectedTxIn = TN.txIn (TN.txId signedTx2) 0
   -- Query for txo and assert it contains newly minted token
-  resultTxOut <- TN.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn
+  resultTxOut <- TN.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn "TN.getTxOutAtAddress"
   txOutHasAdaValue <- TN.txOutHasValue resultTxOut adaValue
   H.assert txOutHasAdaValue
   H.success

--- a/plutus-e2e-tests/test/Spec/Builtins/SECP256k1.hs
+++ b/plutus-e2e-tests/test/Spec/Builtins/SECP256k1.hs
@@ -27,7 +27,7 @@ tests = testGroup "SECP256k1"
   [ testProperty "unable to use SECP256k1 builtins in Alonzo PV6" (verifySchnorrAndEcdsa testnetOptionsAlonzo6)
   , testProperty "unable to use SECP256k1 builtins in Babbage PV7" (verifySchnorrAndEcdsa testnetOptionsBabbage7)
   , testProperty "can use SECP256k1 builtins in Babbage PV8" (verifySchnorrAndEcdsa testnetOptionsBabbage8)
-  --, testProperty "can use SECP256k1 builtins in Babbage PV8 (on preview testnet)" (verifySchnorrAndEcdsa localNodeOptionsPreview)
+  --, testProperty "can use SECP256k1 builtins in Babbage PV8 (on preview testnet)" (verifySchnorrAndEcdsa localNodeOptionsPreview) -- uncomment to use local node on preview testnet
   ]
 
 {- | Test that builtins: verifySchnorrSecp256k1Signature and verifyEcdsaSecp256k1Signature can only

--- a/plutus-e2e-tests/test/Spec/Builtins/SECP256k1.hs
+++ b/plutus-e2e-tests/test/Spec/Builtins/SECP256k1.hs
@@ -78,7 +78,7 @@ verifySchnorrAndEcdsa networkOptions = H.integration . HE.runFinallies . TN.work
       , C.txOuts = [txOut]
       }
 
-  case (pv < 8) of
+  case pv < 8 of
     True -> do
       -- Assert that "forbidden" error occurs when attempting to use either SECP256k1 builtin
       eitherTx <- TN.buildTx' era txBodyContent w1Address w1SKey networkId
@@ -95,7 +95,7 @@ verifySchnorrAndEcdsa networkOptions = H.integration . HE.runFinallies . TN.work
       let expectedTxIn = TN.txIn (TN.txId signedTx) 0
 
       -- Query for txo and assert it contains newly minting tokens to prove successfuluse of SECP256k1 builtins
-      resultTxOut <- TN.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn
+      resultTxOut <- TN.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn "TN.getTxOutAtAddress"
       txOutHasTokenValue <- TN.txOutHasValue resultTxOut tokenValues
       H.assert txOutHasTokenValue
       H.success

--- a/plutus-e2e-tests/test/Spec/Builtins/SECP256k1.hs
+++ b/plutus-e2e-tests/test/Spec/Builtins/SECP256k1.hs
@@ -39,19 +39,20 @@ tests = testGroup "SECP256k1"
         "forbidden builtin" error when building tx
 -}
 verifySchnorrAndEcdsa :: TN.TestnetOptions -> H.Property
-verifySchnorrAndEcdsa testnetOptions = H.integration . HE.runFinallies . TN.workspace "." $ \tempAbsPath -> do
+verifySchnorrAndEcdsa testnetOptions = H.integration . HE.runFinallies . TN.workspace "jamesman" $ \tempAbsPath -> do
 
   let pv = TN.protocolVersion testnetOptions
   C.AnyCardanoEra era <- return $ TN.era testnetOptions
 
 -- 1: spin up a testnet
-  base <- TN.getProjectBase
-  (localNodeConnectInfo, pparams, networkId) <- TN.startTestnet era testnetOptions base tempAbsPath
+--   base <- TN.getProjectBase
+--   (localNodeConnectInfo, pparams, networkId) <- TN.startTestnet era testnetOptions base tempAbsPath
+  (localNodeConnectInfo, pparams, networkId) <- TN.connectToLocalNode era tempAbsPath
   (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
 
 -- 2: build a transaction
 
-  txIn <- TN.firstTxIn era localNodeConnectInfo w1Address
+  txIn <- TN.adaOnlyTxInFromUtxo era localNodeConnectInfo w1Address
 
   let
     (verifySchnorrAssetId, verifyEcdsaAssetId, verifySchnorrMintWitness, verifyEcdsaMintWitness) =


### PR DESCRIPTION
Can now run the `plutus-e2e-tests` on any cardano network by connecting to a local node instead of starting a private network. The CI will continue to run only using private testnet for now.