### PR TITLE
PLT-1064: Create a simple benchmark suite in marconi-chain-index

### DIFF
--- a/cardano-streaming/cardano-streaming.cabal
+++ b/cardano-streaming/cardano-streaming.cabal
@@ -45,33 +45,20 @@ library
   -- Non-IOG dependencies
   ------------------------
   build-depends:
-    , aeson
     , async
-    , base                          >=4.9 && <5
-    , bytestring
+    , base                         >=4.9 && <5
     , cardano-api
-    , cardano-binary
-    , cardano-crypto-class
     , cardano-crypto-wrapper
-    , cardano-data
-    , cardano-ledger-alonzo
     , cardano-ledger-byron
-    , cardano-ledger-core
     , cardano-ledger-shelley
-    , cardano-protocol-tpraos
     , cardano-slotting
     , containers
     , ouroboros-consensus
-    , ouroboros-consensus-byron
     , ouroboros-consensus-cardano
-    , ouroboros-consensus-protocol
     , ouroboros-consensus-shelley
-    , primitive
-    , small-steps
     , streaming
     , transformers
     , typed-protocols
-    , vector
 
 executable cardano-streaming-example-1
   import:         lang

--- a/marconi-chain-index/bench/BenchQueries.hs
+++ b/marconi-chain-index/bench/BenchQueries.hs
@@ -1,0 +1,210 @@
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE QuasiQuotes         #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+{-|
+Running the benchmarks assumes that you can a synced local Cardano node and a synced
+`marconi-chain-index` executable. For now, if you don't have a fully synced `marconi-chain-index`
+executable, then this benchmark will probably fail with SQLBusy failures.
+
+The benchmark will start by continuing the syncing of the Marconi indexers, and once fully synced,
+it will run the benchmark suite.
+
+Example command on how to run the benchmarks:
+
+@
+    MARCONI_DB_DIRECTORY_PATH=/home/username/cardano-node/preprod/marconi-chain-index CARDANO_NODE_SOCKET_PATH=/home/username/cardano-node/preprod/cardano-node.socket cabal bench marconi-chain-index
+@
+
+You can also run the benchmarks to estimate and report memory usage:
+
+@
+    MARCONI_DB_DIRECTORY_PATH=/home/kolam/cardano-node/preprod/marconi-chain-index CARDANO_NODE_SOCKET_PATH=/home/kolam/cardano-node/preprod/cardano-node.socket cabal bench --benchmark-options '+RTS -T' marconi-chain-index
+@
+-}
+module Main (main) where
+
+import Cardano.Api qualified as C
+import Cardano.Chain.Slotting (EpochSlots (EpochSlots))
+import Cardano.Streaming (withChainSyncEventStream)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (race_)
+import Control.Concurrent.STM (STM, TMVar, atomically, newEmptyTMVar, putTMVar, readTMVar, tryTakeTMVar)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy (ByteString)
+import Data.Maybe (fromMaybe, listToMaybe)
+import Data.Text qualified as Text
+import Data.Word (Word64)
+import Database.SQLite.Simple (FromRow (fromRow), field, toRow)
+import Database.SQLite.Simple qualified as SQL
+import Database.SQLite.Simple.FromField (FromField)
+import Database.SQLite.Simple.ToField (ToField)
+import Database.SQLite.Simple.ToRow (ToRow)
+import GHC.Generics (Generic)
+import Marconi.ChainIndex.Indexers (mkIndexerStream, startIndexers, utxoWorker)
+import Marconi.ChainIndex.Indexers.Utxo (StorableQuery (UtxoAddress), StorableResult (UtxoResult, getUtxoResult),
+                                         UtxoHandle, UtxoIndexer)
+import Marconi.Core.Storable (QueryInterval (QEverything))
+import Marconi.Core.Storable qualified as Storable
+import System.Environment (getEnv)
+import System.FilePath ((</>))
+import Test.Tasty.Bench (bench, bgroup, defaultMain, nfIO)
+import Text.RawString.QQ (r)
+
+data FrequencyRow a = FrequencyRow
+    { _frequencyRowValue :: !a
+    , _frequencyRowFreq  :: !Int
+    } deriving (Generic)
+
+instance (FromField a) => FromRow (FrequencyRow a) where
+    fromRow = FrequencyRow <$> field <*> field
+
+instance (ToField a) => ToRow (FrequencyRow a) where
+  toRow (FrequencyRow ad f) = toRow (ad, f)
+
+utxoDbFileName :: String
+utxoDbFileName = "utxo.db"
+
+main :: IO ()
+main = do
+    -- TODO Need a better way to pass those params in the benchmark.
+    -- Look into "Custom command-line options" in the tasty-bench README.
+    nodeSocketPath <- getEnv "CARDANO_NODE_SOCKET_PATH"
+    databaseDir <- getEnv "MARCONI_DB_DIRECTORY_PATH"
+
+    indexerTVar <- atomically (newEmptyTMVar :: STM (TMVar UtxoIndexer) )
+
+    -- Run concurrently the indexing and the testing. The testing is only run once the indexing is
+    -- fully synced with the local running node.
+    race_ (runIndexerSyncing databaseDir nodeSocketPath indexerTVar) $ do
+        putStrLn "Waiting for indexer to be fully synced..."
+        waitUntilSynced databaseDir nodeSocketPath
+        putStrLn "Finished syncing!"
+        tests databaseDir indexerTVar
+
+-- | Run the IO code which syncs the Marconi Utxo indexer with the local running Cardano node.
+runIndexerSyncing
+    :: FilePath
+    -- ^ Marconi indexer database directory
+    -> FilePath
+    -- ^ Local node socket file path
+    -> TMVar UtxoIndexer
+    -> IO ()
+runIndexerSyncing databaseDir nodeSocketPath indexerTVar = do
+    let callbackUtxoIndexer :: UtxoIndexer -> IO ()
+        callbackUtxoIndexer utxoIndexer = atomically $ writeTMVar indexerTVar utxoIndexer
+    (chainPointsToResumeFrom, coordinator) <-
+      startIndexers
+          [ ( utxoWorker callbackUtxoIndexer Nothing
+            , databaseDir </> utxoDbFileName
+            )
+          ]
+    let indexers = mkIndexerStream coordinator
+    withChainSyncEventStream
+        nodeSocketPath
+        (C.Testnet $ C.NetworkMagic 1) -- TODO Needs to be passed a CLI param
+        chainPointsToResumeFrom
+        indexers
+
+tests
+    :: FilePath
+    -- ^ Marconi indexers database directory path
+    -> TMVar UtxoIndexer
+    -> IO ()
+tests databaseDir indexerTVar = do
+    utxoIndexer <- atomically $ readTMVar indexerTVar
+
+    c <- SQL.open $ databaseDir </> utxoDbFileName
+
+    (addressesWithMostUtxos :: [FrequencyRow C.AddressAny]) <- SQL.query c
+        [r|SELECT address, COUNT(address) as frequency
+           FROM unspent_transactions u
+           LEFT JOIN spent s
+           ON u.txId = s.txInTxId
+             AND u.txIx = s.txInTxIx
+           GROUP BY address
+           ORDER BY frequency DESC
+           LIMIT 1|] ()
+    let (FrequencyRow addressWithMostUtxos _) =
+            fromMaybe
+                (error "There is no unspent transaction outputs in the Utxo indexer database")
+                $ listToMaybe addressesWithMostUtxos
+
+    let fetchUtxoOfAddressWithMostUtxos =
+            Storable.query @UtxoHandle
+                QEverything
+                utxoIndexer
+                (UtxoAddress addressWithMostUtxos)
+
+    noUtxos <- fmap (\(UtxoResult rows) -> length rows) fetchUtxoOfAddressWithMostUtxos
+    putStrLn
+        $ "Address "
+       <> Text.unpack (C.serialiseAddress addressWithMostUtxos)
+       <> " has the most UTXOs for a total of "
+       <> show noUtxos
+
+    defaultMain
+        [ bgroup "UTXO indexer query performance"
+            [ bench "Query address with most utxos and get result size" $
+                nfIO (fmap (length . getUtxoResult) fetchUtxoOfAddressWithMostUtxos)
+            , bench "Query address with most utxos and call 'show' on the result" $
+                nfIO (fmap (fmap show . getUtxoResult) fetchUtxoOfAddressWithMostUtxos)
+            , bench "Query address with most utxos and encode result in JSON" $
+                nfIO (fmap (fmap Aeson.encode . getUtxoResult) fetchUtxoOfAddressWithMostUtxos)
+            , bench "Query address with most utxos and JSON encode/decode roundtrip the result" $
+                nfIO (fmap (encodeDecodeRoundTrip . getUtxoResult) fetchUtxoOfAddressWithMostUtxos)
+            ]
+        ]
+
+-- | Queries the latest slot of the UTXO indexer, compares it to the current slot of the local node
+-- and loops indefinitely until the UTXO indexer is synced (or close enough) to the local node.
+waitUntilSynced
+    :: FilePath
+    -- ^ Marconi indexers database directory path
+    -> FilePath
+    -- ^ Node socket file path.
+    -> IO ()
+waitUntilSynced databaseDir nodeSocketPath = do
+    c <- SQL.open $ databaseDir </> "utxo.db"
+    go c
+ where
+     go c = do
+        threadDelay 10_000_000
+        C.ChainTip (C.SlotNo currentNodeSlot) _ _ <-
+            C.getLocalChainTip $ C.LocalNodeConnectInfo
+                { C.localConsensusModeParams = C.CardanoModeParams (EpochSlots 21600)
+                , C.localNodeNetworkId = C.Testnet $ C.NetworkMagic 1 -- TODO This should be provded as a CLI param
+                , C.localNodeSocketPath = nodeSocketPath
+                }
+        -- TODO This should change. We should not query the slotNo with SQLite directly, because:
+        --   * we're getting "SQLite3 returned ErrorBusy"
+        --   * we can't currently query the data that is stored in memory
+        -- Instead, we should add a new query on the UTXO indexer which returns the current query.
+        sns <- SQL.query c
+                [r|SELECT slotNo
+                   FROM unspent_transactions
+                   ORDER BY slotNo DESC
+                   LIMIT 1|] () :: IO [[Word64]]
+        let maybeCurrentSyncedSlot = listToMaybe =<< listToMaybe sns
+        case maybeCurrentSyncedSlot of
+          Nothing                                                                -> go c
+          Just currentSyncedSlot | currentNodeSlot - currentSyncedSlot < 100_000 -> pure ()
+          Just _                                                                 -> go c
+
+encodeDecodeRoundTrip
+    :: forall a. (ToJSON a, FromJSON a)
+    => a
+    -> Maybe ByteString
+encodeDecodeRoundTrip v = fmap Aeson.encode $ Aeson.decode @a $ Aeson.encode v
+
+-- | Non-blocking write of a new value to a 'TMVar'
+-- Puts if empty. Replaces if populated.
+--
+-- Only exists in GHC9, but we're on GHC8.
+-- TODO: Remove once we migrate to GHC9.
+writeTMVar :: TMVar a -> a -> STM ()
+writeTMVar t new = tryTakeTMVar t >> putTMVar t new

--- a/marconi-chain-index/changelog.d/20230217_094612_konstantinos.lambrou_PLT_1064_create_a_benchmark_suite_in_marconi_chain_index_for_analyzing_query_response_time_of_the_address_with_the_most_utxos.md
+++ b/marconi-chain-index/changelog.d/20230217_094612_konstantinos.lambrou_PLT_1064_create_a_benchmark_suite_in_marconi_chain_index_for_analyzing_query_response_time_of_the_address_with_the_most_utxos.md
@@ -1,0 +1,7 @@
+### Added
+
+- Bootstrapped a benchmark suite for evaluating performance of `marconi-chain-index`
+
+- Added a simple benchmark for evaluating query performance for the address with the most UTXOs.
+
+- Adding 'PRAGMA journal_mode=WAL' for all indexers that are opening a SQLite database

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -200,6 +200,48 @@ library marconi-chain-index-test-lib
     , streaming
     , temporary
 
+benchmark marconi-chain-index-bench
+  import:         lang
+  main-is:        BenchQueries.hs
+  hs-source-dirs: bench
+  type:           exitcode-stdio-1.0
+
+  if impl(ghc >=8.10)
+    ghc-options: "-with-rtsopts=-A32m --nonmoving-gc"
+
+  else
+    ghc-options: -with-rtsopts=-A32m
+
+  --------------------
+  -- Local components
+  --------------------
+  build-depends:
+    , cardano-streaming
+    , marconi-chain-index
+    , marconi-core
+
+  --------------------------
+  -- Other IOG dependencies
+  --------------------------
+  build-depends:
+    , cardano-api
+    , cardano-ledger-byron
+
+  ------------------------
+  -- Non-IOG dependencies
+  ------------------------
+  build-depends:
+    , aeson
+    , async
+    , base
+    , bytestring
+    , filepath
+    , raw-strings-qq
+    , sqlite-simple
+    , stm
+    , tasty-bench
+    , text
+
 test-suite marconi-chain-index-test
   import:         lang
   ghc-options:    -Wno-unused-packages

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/AddressDatum.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/AddressDatum.hs
@@ -490,7 +490,7 @@ open
   -> IO AddressDatumIndex
 open dbPath (AddressDatumDepth k) = do
     c <- SQL.open dbPath
-
+    SQL.execute_ c "PRAGMA journal_mode=WAL"
     SQL.execute_ c
         [r|CREATE TABLE IF NOT EXISTS address_datums
             ( address TEXT NOT NULL

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Datum.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Datum.hs
@@ -75,6 +75,7 @@ open
 open dbPath (Depth k) = do
   ix <- fromJust <$> Ix.newBoxed query store onInsert k ((k + 1) * 2) dbPath
   let c = ix ^. Ix.handle
+  SQL.execute_ c "PRAGMA journal_mode=WAL"
   SQL.execute_ c "CREATE TABLE IF NOT EXISTS kv_datumhsh_datum (datumHash TEXT PRIMARY KEY, datum BLOB, slotNo INT)"
   pure ix
 

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/MintBurn.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/MintBurn.hs
@@ -304,6 +304,7 @@ instance RI.Rewindable MintBurnHandle where
 
 open :: FilePath -> Int -> IO MintBurnIndexer
 open dbPath bufferSize = do
-  sqlCon <- SQL.open dbPath
-  sqliteInit sqlCon
-  RI.emptyState bufferSize (MintBurnHandle sqlCon bufferSize)
+  c <- SQL.open dbPath
+  SQL.execute_ c "PRAGMA journal_mode=WAL"
+  sqliteInit c
+  RI.emptyState bufferSize (MintBurnHandle c bufferSize)

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/ScriptTx.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/ScriptTx.hs
@@ -301,6 +301,7 @@ instance Resumable ScriptTxHandle where
 open :: FilePath -> Depth -> IO ScriptTxIndexer
 open dbPath (Depth k) = do
   c <- SQL.open dbPath
+  SQL.execute_ c "PRAGMA journal_mode=WAL"
   SQL.execute_ c "CREATE TABLE IF NOT EXISTS script_transactions (scriptAddress TEXT NOT NULL, txCbor BLOB NOT NULL, slotNo INT NOT NULL, blockHash BLOB NOT NULL)"
   -- Add this index for normal queries.
   SQL.execute_ c "CREATE INDEX IF NOT EXISTS script_address ON script_transactions (scriptAddress)"

--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Types.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Types.hs
@@ -174,8 +174,8 @@ genAddressInEra era =
 genTxOutValue :: C.CardanoEra era -> Gen (C.TxOutValue era)
 genTxOutValue era =
   case C.multiAssetSupportedInEra era of
-    Left adaOnlyInEra     -> C.TxOutAdaOnly adaOnlyInEra <$> CGen.genLovelace
-    Right multiAssetInEra -> C.TxOutValue multiAssetInEra . C.lovelaceToValue <$> CGen.genLovelace
+    Left adaOnlyInEra     -> C.TxOutAdaOnly adaOnlyInEra <$> fmap (<> 1) CGen.genLovelace
+    Right multiAssetInEra -> C.TxOutValue multiAssetInEra . C.lovelaceToValue <$> fmap (<> 1) CGen.genLovelace
 
 -- Copied from cardano-api, but removed the recursive construction because it is time consuming,
 -- about a factor of 20 when compared to this simple generator.

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
@@ -92,7 +92,6 @@ tests = testGroup "Spec.Marconi.ChainIndex.Indexers.Utxo"
           propResumingShouldReturnOrderedListOfPoints
     ]
 
-
 eventsToRowsRoundTripTest :: Property
 eventsToRowsRoundTripTest  = property $ do
   events <- forAll genUtxoEvents

--- a/marconi-mamba/src/Marconi/Mamba/Api/Query/Indexers/Utxo.hs
+++ b/marconi-mamba/src/Marconi/Mamba/Api/Query/Indexers/Utxo.hs
@@ -98,7 +98,7 @@ reportBech32Addresses env =
 -- | Non-blocking write of a new value to a 'TMVar'
 -- Puts if empty. Replaces if populated.
 --
--- Only exists in GHC9, but were on GHC8.
+-- Only exists in GHC9, but we're on GHC8.
 -- TODO: Remove once we migrate to GHC9.
 writeTMVar :: TMVar a -> a -> STM ()
 writeTMVar t new = tryTakeTMVar t >> putTMVar t new


### PR DESCRIPTION
Create a simple benchmark suite in marconi-chain-index for analyzing query response time of the address with the most utxos

* Created benchmark suite in `marconi-chain-index`
* The benchmark will sync the Marconi indexer with the local node, then run the benchmark suite.
* The first benchmark implemented is the performance of the query to fetch the UTXOs of the address which has the most UTXOs.

Running `MARCONI_DB_DIRECTORY_PATH=/home/kolam/cardano-node/preprod/marconi-chain-index CARDANO_NODE_SOCKET_PATH=/home/kolam/cardano-node/preprod/cardano-node.socket cabal bench --benchmark-options '+RTS -T' marconi-chain-index`

produces the output:

```
Running 1 benchmarks...
Benchmark marconi-chain-index-bench: RUNNING...
Waiting for indexer to be fully synced...
Finished syncing!
Address addr_test1vzpwq95z3xyum8vqndgdd9mdnmafh3djcxnc6jemlgdmswcve6tkw has the most UTXOs for a total of 70974
All
  UTXO indexer query performance
    Query address with most utxos and get result size:                         OK (2.41s)
      771  ms ±  38 ms, 761 MB allocated,  61 MB copied, 204 MB peak memory
    Query address with most utxos and call 'show' on the result:               OK (89.87s)
      5.144 s ±  29 ms, 4.8 GB allocated, 979 MB copied, 3.3 GB peak memory
    Query address with most utxos and encode result in JSON:                   OK (20.82s)
      2.752 s ±  31 ms, 5.9 GB allocated,  71 MB copied, 3.3 GB peak memory
    Query address with most utxos and JSON encode/decode roundtrip the result: OK (28.37s)
      9.414 s ± 121 ms,  17 GB allocated, 583 MB copied, 3.3 GB peak memory

All 4 tests passed (141.47s)
Benchmark marconi-chain-index-bench: FINISH
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
    - [x] Important changes are reflected in changelog.d of the affected packages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
