### PR TITLE
Add calculateAndUpdateTxFee

### DIFF
--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -249,7 +249,6 @@ test-suite marconi-chain-index-test
   main-is:        Spec.hs
   hs-source-dirs: test
   other-modules:
-    Integration
     Spec.Marconi.ChainIndex.CLI
     Spec.Marconi.ChainIndex.Indexers.AddressDatum
     Spec.Marconi.ChainIndex.Indexers.AddressDatum.AddressDatumIndex

--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -80,12 +80,12 @@ genTxBodyContentFromTxIns
 genTxBodyContentFromTxIns inputs = do
     txBodyContent <-
         emptyTxBodyContent (C.TxValidityNoLowerBound, C.TxValidityNoUpperBound C.ValidityNoUpperBoundInBabbageEra)
-            <$> fmap (C.TxFeeExplicit C.TxFeesExplicitInBabbageEra) CGen.genLovelace
-            <*> CGen.genProtocolParameters
+            <$> CGen.genProtocolParameters
     txOuts <- Gen.list (Range.linear 1 5) $ genTxOutTxContext C.BabbageEra
     pure $ txBodyContent
         { C.txIns = fmap (, C.BuildTxWith $ C.KeyWitness C.KeyWitnessForSpending) inputs
         , C.txOuts = txOuts
+        , C.txFee = C.TxFeeExplicit C.TxFeesExplicitInAlonzoEra fee
         }
 
 -- TODO Must be reworked following implementation in 'genUtxoEvents'.
@@ -107,5 +107,3 @@ genUtxo' (C.TxIn _txId _txIx) _address = do
   _value            <- CGen.genValueForTxOut
   let (_inlineScript, _inlineScriptHash)=  Utxo.getRefScriptAndHash script
   pure $ Utxo.Utxo {..}
-
-

--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -85,7 +85,6 @@ genTxBodyContentFromTxIns inputs = do
     pure $ txBodyContent
         { C.txIns = fmap (, C.BuildTxWith $ C.KeyWitness C.KeyWitnessForSpending) inputs
         , C.txOuts = txOuts
-        , C.txFee = C.TxFeeExplicit C.TxFeesExplicitInAlonzoEra fee
         }
 
 -- TODO Must be reworked following implementation in 'genUtxoEvents'.

--- a/marconi-chain-index/test-lib/Helpers.hs
+++ b/marconi-chain-index/test-lib/Helpers.hs
@@ -86,18 +86,17 @@ readAs as path = do
 
 -- | An empty transaction
 emptyTxBodyContent
-    :: (C.TxValidityLowerBound era, C.TxValidityUpperBound era)
-    -> C.TxFee era
-    -> C.ProtocolParameters
-    -> C.TxBodyContent C.BuildTx era
-emptyTxBodyContent validityRange fee pparams = C.TxBodyContent
+  :: (C.TxValidityLowerBound era, C.TxValidityUpperBound era, C.IsShelleyBasedEra era)
+  -> C.ProtocolParameters
+  -> C.TxBodyContent C.BuildTx era
+emptyTxBodyContent validityRange pparams = C.TxBodyContent
   { C.txIns              = []
   , C.txInsCollateral    = C.TxInsCollateralNone
   , C.txInsReference     = C.TxInsReferenceNone
   , C.txOuts             = []
   , C.txTotalCollateral  = C.TxTotalCollateralNone
   , C.txReturnCollateral = C.TxReturnCollateralNone
-  , C.txFee              = fee
+  , C.txFee              = C.TxFeeExplicit (txFeesExplicitInShelleyBasedEra C.shelleyBasedEra) 0
   , C.txValidityRange    = validityRange
   , C.txMetadata         = C.TxMetadataNone
   , C.txAuxScripts       = C.TxAuxScriptsNone
@@ -205,11 +204,9 @@ mkTransferTx networkId con validityRange from to keyWitnesses howMuch = do
   pparams <- getProtocolParams @era con
   (txIns, totalLovelace) <- getAddressTxInsValue @era con from
   let
-    fee0 = 0
-    txFee0Explicit = C.TxFeeExplicit (txFeesExplicitInShelleyBasedEra C.shelleyBasedEra) fee0
-    tx0 = (emptyTxBodyContent validityRange txFee0Explicit pparams)
+    tx0 = (emptyTxBodyContent validityRange pparams)
       { C.txIns = map (, C.BuildTxWith $ C.KeyWitness C.KeyWitnessForSpending) txIns
-      , C.txOuts = [mkAddressAdaTxOut to $ totalLovelace - fee0]
+      , C.txOuts = [mkAddressAdaTxOut to totalLovelace]
       }
   txBody0 :: C.TxBody era <- HE.leftFail $ C.makeTransactionBody tx0
   let fee = calculateFee
@@ -230,12 +227,10 @@ mkTransferTx networkId con validityRange from to keyWitnesses howMuch = do
   txBody :: C.TxBody era <- HE.leftFail $ C.makeTransactionBody tx
   return (C.signShelleyTransaction txBody keyWitnesses, txBody)
 
-mkAddressAdaTxOut
-    :: (C.IsShelleyBasedEra era)
-    => C.Address C.ShelleyAddr
-    -> C.Lovelace
-    -> C.TxOut ctx era
-mkAddressAdaTxOut address lovelace =
+mkAddressValueTxOut
+  :: (C.IsShelleyBasedEra era)
+  => C.Address C.ShelleyAddr -> C.Value -> C.TxOut ctx era
+mkAddressValueTxOut address value =
     let txOutValue =
             case C.multiAssetSupportedInEra $ C.shelleyBasedToCardanoEra C.shelleyBasedEra of
               Left adaOnlyInEra     -> C.TxOutAdaOnly adaOnlyInEra lovelace
@@ -245,6 +240,9 @@ mkAddressAdaTxOut address lovelace =
             txOutValue
             C.TxOutDatumNone
             C.ReferenceScriptNone
+
+mkAddressAdaTxOut :: C.Address C.ShelleyAddr -> C.Lovelace -> C.TxOut ctx C.AlonzoEra
+mkAddressAdaTxOut address lovelace = mkAddressValueTxOut address $ C.lovelaceToValue lovelace
 
 -- | Adapted from:
 -- https://github.com/input-output-hk/cardano-node/blob/d15ff2b736452857612dd533c1ddeea2405a2630/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs#L1105-L1112
@@ -257,6 +255,20 @@ calculateFee pparams nInputs nOutputs nByronKeyWitnesses nShelleyKeyWitnesses ne
   (C.makeSignedTransaction [] txBody)
   nInputs nOutputs
   nByronKeyWitnesses nShelleyKeyWitnesses
+
+-- | Add fee to transaction body, return transaction with the fee
+-- applied, and also the fee in lovelace.
+calculateAndUpdateTxFee
+  :: H.MonadTest m
+  => C.ProtocolParameters -> C.NetworkId -> Int -> Int
+  -> C.TxBodyContent C.BuildTx C.AlonzoEra -> m (C.Lovelace, C.TxBodyContent C.BuildTx C.AlonzoEra)
+calculateAndUpdateTxFee pparams networkId lengthTxIns lengthKeyWitnesses txbc = do
+  txb <- HE.leftFail $ C.makeTransactionBody txbc
+  let
+    feeLovelace = calculateFee pparams lengthTxIns (length $ C.txOuts txbc) 0 lengthKeyWitnesses networkId txb :: C.Lovelace
+    fee = C.TxFeeExplicit C.TxFeesExplicitInAlonzoEra feeLovelace
+    txbc' = txbc { C.txFee = fee }
+  return (feeLovelace, txbc')
 
 -- | This is a copy of the workspace from
 -- hedgehog-extras:Hedgehog.Extras.Test.Base, which for darwin sets

--- a/marconi-chain-index/test/Spec.hs
+++ b/marconi-chain-index/test/Spec.hs
@@ -9,7 +9,6 @@ import Spec.Marconi.ChainIndex.Indexers.AddressDatum qualified as Indexers.Addre
 import Spec.Marconi.ChainIndex.Indexers.ScriptTx qualified as Indexers.ScriptTx
 -- TODO see tests below
 -- import Spec.Marconi.ChainIndex.Indexers.EpochStakepoolSize qualified as Indexers.EpochStakepoolSize
-import Integration qualified
 import Spec.Marconi.ChainIndex.Indexers.MintBurn qualified as Indexers.MintBurn
 import Spec.Marconi.ChainIndex.Indexers.Utxo qualified as Indexers.Utxo
 import Spec.Marconi.ChainIndex.Orphans qualified as Orphans
@@ -25,7 +24,6 @@ tests = testGroup "Marconi"
   , Indexers.AddressDatum.tests
   , Indexers.MintBurn.tests
   , CLI.tests
-  , Integration.tests
   -- TODO Enable when test environemnt is reconfigured
   -- , EpochStakepoolSize.tests
   ]

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/EpochStakepoolSize.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/EpochStakepoolSize.hs
@@ -213,7 +213,7 @@ registerStakeAddress networkId con pparams payerAddress payerSKey stakeCredentia
   -- cardano-cli transaction build
   -- cardano-cli transaction sign
   -- cardano-cli transaction submit
-  (txIns, totalLovelace) <- TN.getAddressTxInsValue con payerAddress
+  (txIns, totalLovelace) <- TN.getAddressTxInsValue @C.AlonzoEra con payerAddress
   let keyWitnesses = [C.WitnessGenesisUTxOKey payerSKey]
       mkTxOuts lovelace = [TN.mkAddressAdaTxOut payerAddress lovelace]
       validityRange = (C.TxValidityNoLowerBound, C.TxValidityNoUpperBound C.ValidityNoUpperBoundInAlonzoEra)
@@ -275,7 +275,7 @@ registerPool con networkId pparams tempAbsPath   keyWitnesses stakeCredentials p
   -- Create transaction
   do (txIns, totalLovelace) <- TN.getAddressTxInsValue @C.AlonzoEra con payerAddress
      let mkTxOuts lovelace = [TN.mkAddressAdaTxOut payerAddress lovelace]
-         validityRange = C.TxValidityNoLowerBound, C.TxValidityNoUpperBound C.ValidityNoUpperBoundInAlonzoEra
+         validityRange = (C.TxValidityNoLowerBound, C.TxValidityNoUpperBound C.ValidityNoUpperBoundInAlonzoEra)
      (feeLovelace, txbc) <- TN.calculateAndUpdateTxFee pparams networkId (length txIns) (length keyWitnesses) (TN.emptyTxBodyContent validityRange pparams)
        { C.txIns = map (, C.BuildTxWith $ C.KeyWitness C.KeyWitnessForSpending) txIns
        , C.txOuts = mkTxOuts 0

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
@@ -227,8 +227,9 @@ endToEnd = H.withShrinks 0 $ H.integration $ (liftIO TN.setDarwinTmpdir >>) $ HE
   (txIns, lovelace) <- TN.getAddressTxInsValue @C.AlonzoEra localNodeConnectInfo address
 
   let keyWitnesses = [C.WitnessPaymentKey $ C.castSigningKey genesisSKey]
-      mkTxOuts lovelace' = [TN.mkAddressValueTxOut @C.AlonzoEra address $ C.lovelaceToValue lovelace' <> value]
-  (feeLovelace, txbc) <- TN.calculateAndUpdateTxFee pparams networkId (length txIns) (length keyWitnesses) (TN.emptyTxBodyContent pparams)
+      mkTxOuts lovelace' = [TN.mkAddressValueTxOut address $ C.TxOutValue C.MultiAssetInAlonzoEra $ C.lovelaceToValue lovelace' <> value]
+      validityRange = (C.TxValidityNoLowerBound, C.TxValidityNoUpperBound C.ValidityNoUpperBoundInAlonzoEra)
+  (feeLovelace, txbc) <- TN.calculateAndUpdateTxFee pparams networkId (length txIns) (length keyWitnesses) (TN.emptyTxBodyContent validityRange pparams)
     { C.txIns = map (\txIn -> (txIn, C.BuildTxWith $ C.KeyWitness C.KeyWitnessForSpending)) txIns
     , C.txOuts = mkTxOuts 0
     , C.txProtocolParams = C.BuildTxWith $ Just pparams

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
@@ -225,33 +225,21 @@ endToEnd = H.withShrinks 0 $ H.integration $ (liftIO TN.setDarwinTmpdir >>) $ HE
 
   value <- H.fromJustM $ getValue txMintValue
   (txIns, lovelace) <- TN.getAddressTxInsValue @C.AlonzoEra localNodeConnectInfo address
-  let fee = 500 :: C.Lovelace
-      amountReturned = lovelace - fee :: C.Lovelace
-      txOut :: C.TxOut ctx C.AlonzoEra
-      txOut =
-        C.TxOut
-          (C.AddressInEra (C.ShelleyAddressInEra C.ShelleyBasedEraAlonzo) address)
-          (C.TxOutValue C.MultiAssetInAlonzoEra $ C.lovelaceToValue amountReturned <> value)
-          C.TxOutDatumNone
-          C.ReferenceScriptNone
-      txBodyContent :: C.TxBodyContent C.BuildTx C.AlonzoEra
-      txBodyContent =
-          (TN.emptyTxBodyContent
-              (C.TxValidityNoLowerBound, C.TxValidityNoUpperBound C.ValidityNoUpperBoundInAlonzoEra)
-              (C.TxFeeExplicit C.TxFeesExplicitInAlonzoEra fee)
-              pparams
-          ) { C.txIns = map (, C.BuildTxWith $ C.KeyWitness C.KeyWitnessForSpending) txIns
-            , C.txOuts = [txOut]
-            , C.txProtocolParams = C.BuildTxWith $ Just pparams
-            , C.txMintValue = txMintValue
-            , C.txInsCollateral = C.TxInsCollateral C.CollateralInAlonzoEra txIns
-            }
-  txBody :: C.TxBody C.AlonzoEra <- H.leftFail $ C.makeTransactionBody txBodyContent
-  let
-    kw :: C.KeyWitness C.AlonzoEra
-    kw = C.makeShelleyKeyWitness txBody (C.WitnessPaymentKey $ C.castSigningKey genesisSKey)
-    tx = C.makeSignedTransaction [kw] txBody
-  TN.submitTx localNodeConnectInfo tx
+
+  let keyWitnesses = [C.WitnessPaymentKey $ C.castSigningKey genesisSKey]
+      mkTxOuts lovelace' = [TN.mkAddressValueTxOut @C.AlonzoEra address $ C.lovelaceToValue lovelace' <> value]
+  (feeLovelace, txbc) <- TN.calculateAndUpdateTxFee pparams networkId (length txIns) (length keyWitnesses) (TN.emptyTxBodyContent pparams)
+    { C.txIns = map (\txIn -> (txIn, C.BuildTxWith $ C.KeyWitness C.KeyWitnessForSpending)) txIns
+    , C.txOuts = mkTxOuts 0
+    , C.txProtocolParams = C.BuildTxWith $ Just pparams
+    , C.txMintValue = txMintValue
+    , C.txInsCollateral = C.TxInsCollateral C.CollateralInAlonzoEra txIns
+    }
+  txBody :: C.TxBody C.AlonzoEra <- H.leftFail $ C.makeTransactionBody $ txbc
+    { C.txOuts = mkTxOuts $ lovelace - feeLovelace }
+  let keyWitnesses' :: [C.KeyWitness C.AlonzoEra]
+      keyWitnesses' = map (C.makeShelleyKeyWitness txBody) keyWitnesses
+  TN.submitTx localNodeConnectInfo $ C.makeSignedTransaction keyWitnesses' txBody
 
   -- Receive event from the indexer, compare the mint that we
   -- submitted above with the one we got from the indexer.

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/ScriptTx.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/ScriptTx.hs
@@ -236,15 +236,16 @@ endToEnd = H.integration $ (liftIO TN.setDarwinTmpdir >>) $ HE.runFinallies $ H.
 
       tx2ins = [(scriptTxIn, C.BuildTxWith scriptWitness)]
       mkTx2Outs lovelace = [TN.mkAddressAdaTxOut address lovelace]
+      tx2witnesses = [C.WitnessGenesisUTxOKey genesisSKey]
 
-  (tx2fee, tx2bodyContent) <- TN.calculateAndUpdateTxFee pparams networkId (length tx2ins + 1) (length keyWitnesses) (TN.emptyTxBodyContent pparams)
+  (tx2fee, tx2bodyContent) <- TN.calculateAndUpdateTxFee pparams networkId (length tx2ins + 1) (length tx2witnesses) (TN.emptyTxBodyContent pparams)
     { C.txIns              = tx2ins
     , C.txInsCollateral    = C.TxInsCollateral C.CollateralInAlonzoEra [tx2collateralTxIn]
     , C.txOuts             = mkTx2Outs lovelaceAtScript
     }
   tx2body :: C.TxBody C.AlonzoEra <- H.leftFail $ C.makeTransactionBody tx2bodyContent
     { C.txOuts = mkTx2Outs $ lovelaceAtScript - tx2fee }
-  let tx2 = C.signShelleyTransaction tx2body [C.WitnessGenesisUTxOKey genesisSKey]
+  let tx2 = C.signShelleyTransaction tx2body tx2witnesses
 
   TN.submitTx localNodeConnectInfo tx2
 

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/ScriptTx.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/ScriptTx.hs
@@ -237,7 +237,7 @@ endToEnd = H.integration $ (liftIO TN.setDarwinTmpdir >>) $ HE.runFinallies $ H.
       tx2ins = [(scriptTxIn, C.BuildTxWith scriptWitness)]
       mkTx2Outs lovelace = [TN.mkAddressAdaTxOut address lovelace]
 
-  (tx2fee, tx2bodyContent) <- TN.calculateAndUpdateTxFee pparams networkId (length tx2ins) (length keyWitnesses) (TN.emptyTxBodyContent pparams)
+  (tx2fee, tx2bodyContent) <- TN.calculateAndUpdateTxFee pparams networkId (length tx2ins + 1) (length keyWitnesses) (TN.emptyTxBodyContent pparams)
     { C.txIns              = tx2ins
     , C.txInsCollateral    = C.TxInsCollateral C.CollateralInAlonzoEra [tx2collateralTxIn]
     , C.txOuts             = mkTx2Outs lovelaceAtScript

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/ScriptTx.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/ScriptTx.hs
@@ -1,27 +1,74 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE TemplateHaskell    #-}
+{-# OPTIONS_GHC -Wno-orphans    #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
-module Spec.Marconi.ChainIndex.Indexers.ScriptTx ( tests) where
+module Spec.Marconi.ChainIndex.Indexers.ScriptTx (tests) where
 
-import Control.Monad (replicateM)
+import Codec.Serialise (serialise)
+import Control.Concurrent qualified as IO
+import Control.Concurrent.STM qualified as IO
+import Control.Exception (catch)
+import Control.Monad (replicateM, void)
+import Control.Monad.IO.Class (liftIO)
+import Data.ByteString.Lazy qualified as LBS
+import Data.ByteString.Short qualified as SBS
 import Data.Coerce (coerce)
+import Data.Functor (($>))
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.List.NonEmpty qualified as NE
+import Data.Map qualified as Map
 import Data.Set qualified as S
+import Streaming.Prelude qualified as S
+import System.Directory qualified as IO
+import System.FilePath ((</>))
 
-import Hedgehog (Property, assert, forAll, property)
+import Hedgehog (Property, assert, forAll, property, (===))
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test qualified as HE
+import Hedgehog.Extras.Test.Base qualified as H
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 
 import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as C
+import Cardano.BM.Setup (withTrace)
+import Cardano.BM.Trace (logError)
+import Cardano.BM.Tracing (defaultConfigStdout)
+import Cardano.Streaming (ChainSyncEventException (NoIntersectionFound), withChainSyncEventStream)
 import Gen.Cardano.Api.Typed qualified as CGen
 import Gen.Marconi.ChainIndex.Types (genTxBodyWithTxIns, genWitnessAndHashInEra)
+import Marconi.ChainIndex.Indexers qualified as M
 import Marconi.ChainIndex.Indexers.ScriptTx qualified as ScriptTx
+import Marconi.ChainIndex.Logging ()
+import Marconi.Core.Storable qualified as Storable
+import Plutus.V1.Ledger.Scripts qualified as Plutus
+import PlutusTx qualified
+import Prettyprinter (defaultLayoutOptions, layoutPretty, pretty, (<+>))
+import Prettyprinter.Render.Text (renderStrict)
+import Test.Base qualified as H
+
+import Helpers qualified as TN
+import Testnet.Cardano qualified as TN
+-- ^ Although these are defined in this cabal component, they are
+-- helpers for interacting with the testnet, thus TN
+
 
 tests :: TestTree
-tests = testGroup "Spec.Marconi.ChainIndex.Indexers.ScriptTx are:"
+tests = testGroup "Spec.Marconi.ChainIndex.Indexers.ScriptTx"
   [ testPropertyNamed
-    "prop_script_hashes_in_tx_match" "getTxBodyScriptsRoundtrip"
-    getTxBodyScriptsRoundtrip
+    "Transaction with script hash survives `makeTransactionBody`"
+    "getTxBodyScriptsRoundtrip" getTxBodyScriptsRoundtrip
+  , testPropertyNamed
+    "Submitted transactions with script address show up in indexer"
+    "endToEnd" endToEnd
   ]
 
 -- | Create @nScripts@ scripts, add them to a transaction body, then
@@ -44,3 +91,190 @@ getTxBodyScriptsRoundtrip = property $ do
   txBody <- forAll $ genTxBodyWithTxIns era (zip txIns $ map C.BuildTxWith witnesses) collateral
   let hashesFound = map coerce $ ScriptTx.getTxBodyScripts txBody :: [C.ScriptHash]
   assert $ S.fromList scriptHashes == S.fromList hashesFound
+
+{- | We test the script transaction indexer by setting up a testnet,
+   adding a script to it and then spending it, and then see if the
+   script shows up on the indexer.
+
+   Specifically, we:
+
+    - spin up a testnet and the script transaction indexer
+
+    - create a plutus script, then submit a transaction which contains
+      an UTxO where this script is the validator
+
+    - submit a second transaction that spends this UTxO, then query
+      the indexer to see if it was indexed properly
+-}
+endToEnd :: Property
+endToEnd = H.integration $ (liftIO TN.setDarwinTmpdir >>) $ HE.runFinallies $ H.workspace "." $ \tempAbsPath -> do
+  base <- HE.noteM $ liftIO . IO.canonicalizePath =<< HE.getProjectBase
+
+  (localNodeConnectInfo, conf, runtime) <- TN.startTestnet TN.defaultTestnetOptions base tempAbsPath
+  let networkId = TN.getNetworkId runtime
+  socketPathAbs <- TN.getSocketPathAbs conf runtime
+
+  -- Create a channel that is passed into the indexer, such that it
+  -- can write index updates to it and we can await for them (also
+  -- making us not need threadDelay)
+  indexedTxs <- liftIO IO.newChan
+  let writeScriptUpdate (ScriptTx.ScriptTxEvent txScripts _slotNo) = case txScripts of
+        (x : xs) -> IO.writeChan indexedTxs $ x :| xs
+        _        -> pure ()
+
+  -- Start indexer
+  let sqliteDb = tempAbsPath </> "script-tx.db"
+  indexer <- liftIO $ do
+
+    coordinator <- M.initialCoordinator 1
+    ch <- IO.atomically . IO.dupTChan $ M._channel coordinator
+    (loop, indexer) <- M.scriptTxWorker_ (\update -> writeScriptUpdate update $> []) (ScriptTx.Depth 1) coordinator ch sqliteDb
+
+    -- Receive ChainSyncEvents and pass them on to indexer's channel
+    void $ IO.forkIO $ do
+      let chainPoint = C.ChainPointAtGenesis :: C.ChainPoint
+      c <- defaultConfigStdout
+      withTrace c "marconi" $ \trace -> let
+        indexerWorker = withChainSyncEventStream socketPathAbs networkId [chainPoint] $ S.mapM_ $
+          \chainSyncEvent -> IO.atomically $ IO.writeTChan ch chainSyncEvent
+        handleException NoIntersectionFound = logError trace $ renderStrict $ layoutPretty defaultLayoutOptions $
+          "No intersection found for chain point" <+> pretty chainPoint <> "."
+        in indexerWorker `catch` handleException :: IO ()
+
+    -- Start indexer worker loop
+    void $ IO.forkIO loop
+
+    return indexer
+
+  let
+    -- Create an always succeeding validator script
+    plutusScript :: C.PlutusScript C.PlutusScriptV1
+    plutusScript = C.PlutusScriptSerialised $ SBS.toShort . LBS.toStrict $ serialise $ Plutus.unValidatorScript validator
+      where
+        validator :: Plutus.Validator
+        validator = Plutus.mkValidatorScript $$(PlutusTx.compile [|| \_ _ _ -> () ||])
+
+    plutusScriptHash = C.hashScript $ C.PlutusScript C.PlutusScriptV1 plutusScript :: C.ScriptHash
+    plutusScriptAddr :: C.Address C.ShelleyAddr
+    plutusScriptAddr = C.makeShelleyAddress networkId (C.PaymentCredentialByScript plutusScriptHash) C.NoStakeAddress
+
+  -- Step 1: Create a tx ouput with a datum hash at the script address. In order for a tx ouput to be locked
+  -- by a plutus script, it must have a datahash. We also need collateral tx inputs so we split the utxo
+  -- in order to accomodate this.
+
+  genesisVKey :: C.VerificationKey C.GenesisUTxOKey <-
+    TN.readAs (C.AsVerificationKey C.AsGenesisUTxOKey) $ tempAbsPath </> "shelley/utxo-keys/utxo1.vkey"
+  genesisSKey :: C.SigningKey C.GenesisUTxOKey <-
+    TN.readAs (C.AsSigningKey C.AsGenesisUTxOKey) $ tempAbsPath </> "shelley/utxo-keys/utxo1.skey"
+
+  let
+    paymentKey = C.castVerificationKey genesisVKey :: C.VerificationKey C.PaymentKey
+    address :: C.Address C.ShelleyAddr
+    address = C.makeShelleyAddress
+      networkId
+      (C.PaymentCredentialByKey (C.verificationKeyHash paymentKey :: C.Hash C.PaymentKey))
+      C.NoStakeAddress :: C.Address C.ShelleyAddr
+
+  (tx1in, C.TxOut _ v _ _) <- do
+    utxo <- TN.findUTxOByAddress localNodeConnectInfo address
+    H.headM $ Map.toList $ C.unUTxO utxo
+  let totalLovelace = C.txOutValueToLovelace v
+
+  pparams <- TN.getAlonzoProtocolParams localNodeConnectInfo
+  let scriptDatum = C.ScriptDataNumber 42 :: C.ScriptData
+      scriptDatumHash = C.hashScriptData scriptDatum
+      amountPaid = 10_000_000 :: C.Lovelace -- 10 ADA
+      -- Must return everything that was not paid to script and that didn't went to fees:
+      amountReturned = totalLovelace - amountPaid :: C.Lovelace
+      txOut1 :: C.TxOut ctx C.AlonzoEra
+      txOut1 = C.TxOut
+        (C.AddressInEra (C.ShelleyAddressInEra C.ShelleyBasedEraAlonzo) plutusScriptAddr)
+        (C.TxOutValue C.MultiAssetInAlonzoEra $ C.lovelaceToValue amountPaid)
+        (C.TxOutDatumHash C.ScriptDataInAlonzoEra scriptDatumHash)
+        C.ReferenceScriptNone
+      mkTxOut2 :: C.Lovelace -> C.TxOut ctx C.AlonzoEra
+      mkTxOut2 lovelace = TN.mkAddressAdaTxOut address lovelace
+      keyWitnesses = [C.WitnessPaymentKey $ C.castSigningKey genesisSKey]
+      tx1ins = [(tx1in, C.BuildTxWith $ C.KeyWitness C.KeyWitnessForSpending)]
+  (tx1fee, txbc0) <- TN.calculateAndUpdateTxFee pparams networkId (length tx1ins) (length keyWitnesses) (TN.emptyTxBodyContent pparams)
+    { C.txIns = tx1ins
+    , C.txOuts = [txOut1, mkTxOut2 amountReturned]
+    , C.txProtocolParams = C.BuildTxWith $ Just pparams
+    }
+  let txbc1 = txbc0 { C.txOuts = [txOut1, mkTxOut2 $ amountReturned - tx1fee] }
+  tx1body :: C.TxBody C.AlonzoEra <- H.leftFail $ C.makeTransactionBody txbc1
+  TN.submitTx localNodeConnectInfo $ C.makeSignedTransaction (map (C.makeShelleyKeyWitness tx1body) keyWitnesses) tx1body
+
+
+
+  -- Second transaction: spend the UTXO specified in the first transaction
+
+  _ <- liftIO $ IO.readChan indexedTxs -- wait for the first transaction to be accepted
+
+  tx2collateralTxIn <- H.headM . Map.keys . C.unUTxO =<< TN.findUTxOByAddress localNodeConnectInfo address
+
+  (scriptTxIn, C.TxOut _ valueAtScript _ _) <- do
+    scriptUtxo <- TN.findUTxOByAddress localNodeConnectInfo plutusScriptAddr
+    H.headM $ Map.toList $ C.unUTxO scriptUtxo
+
+  let lovelaceAtScript = C.txOutValueToLovelace valueAtScript
+  assert $ lovelaceAtScript == 10_000_000 -- script has the 10 ADA we put there in tx1
+
+  redeemer <- H.forAll CGen.genScriptData -- The script always returns true so any redeemer will do
+  let
+      -- The following execution unit and fee values were found by
+      -- trial and error. When the transaction which we are in the
+      -- process of creating, fails, then it will report the values it
+      -- wants. And although they change again after you correct them,
+      -- then the procedure converges quickly.
+      executionUnits = C.ExecutionUnits {C.executionSteps = 500_000, C.executionMemory = 10_000 }
+
+      scriptWitness :: C.Witness C.WitCtxTxIn C.AlonzoEra
+      scriptWitness = C.ScriptWitness C.ScriptWitnessForSpending $
+        C.PlutusScriptWitness C.PlutusScriptV1InAlonzo C.PlutusScriptV1 (C.PScript plutusScript)
+        (C.ScriptDatumForTxIn scriptDatum) redeemer executionUnits
+
+      tx2ins = [(scriptTxIn, C.BuildTxWith scriptWitness)]
+      mkTx2Outs lovelace = [TN.mkAddressAdaTxOut address lovelace]
+
+  (tx2fee, tx2bodyContent) <- TN.calculateAndUpdateTxFee pparams networkId (length tx2ins) (length keyWitnesses) (TN.emptyTxBodyContent pparams)
+    { C.txIns              = tx2ins
+    , C.txInsCollateral    = C.TxInsCollateral C.CollateralInAlonzoEra [tx2collateralTxIn]
+    , C.txOuts             = mkTx2Outs lovelaceAtScript
+    }
+  tx2body :: C.TxBody C.AlonzoEra <- H.leftFail $ C.makeTransactionBody tx2bodyContent
+    { C.txOuts = mkTx2Outs $ lovelaceAtScript - tx2fee }
+  let tx2 = C.signShelleyTransaction tx2body [C.WitnessGenesisUTxOKey genesisSKey]
+
+  TN.submitTx localNodeConnectInfo tx2
+
+  {- Test if what the indexer got is what we sent.
+
+  We test both of (1) what we get from `onInsert` callback and (2)
+  with `query` (what ends up in the sqlite database). For the `query`
+  we currently need to use threadDelay and poll to query the database
+  because the indexer runs in a separate thread and there is no way
+  of awaiting the data to be flushed into the database. -}
+
+  indexedWithScriptHashes <- liftIO $ IO.readChan indexedTxs
+
+  -- We have to filter out the txs the empty scripts hashes because
+  -- sometimes the RollForward event contains a block with the first transaction 'tx1'
+  -- which has no scripts. The test fails because of that in 'headM indexedScriptHashes'.
+  -- For more details see https://github.com/input-output-hk/plutus-apps/issues/775
+  let (ScriptTx.TxCbor tx, indexedScriptHashes) = head $ NE.filter (\(_, hashes) -> hashes /= []) indexedWithScriptHashes
+
+  ScriptTx.ScriptTxAddress indexedScriptHash <- H.headM indexedScriptHashes
+
+  indexedTx2 :: C.Tx C.AlonzoEra <- H.leftFail $ C.deserialiseFromCBOR (C.AsTx C.AsAlonzoEra) tx
+
+  plutusScriptHash === indexedScriptHash
+  tx2 === indexedTx2
+
+  queriedTx2 :: C.Tx C.AlonzoEra <- do
+    ScriptTx.ScriptTxResult (ScriptTx.TxCbor txCbor : _) <- liftIO $ do
+      ix <- IO.readMVar indexer
+      Storable.query Storable.QEverything ix (ScriptTx.ScriptTxAddress plutusScriptHash)
+    H.leftFail $ C.deserialiseFromCBOR (C.AsTx C.AsAlonzoEra) txCbor
+
+  tx2 === queriedTx2


### PR DESCRIPTION
This PR was triggered by a `FeeTooSmallUTxO` CI error in the MintBurn test. The fix was to calculate it automatically.

In addition to the above, some more refactoring was done:
- Calculate the fee automatically for all transactions for all tests (except for the second one in ScriptTx e2e test which I couldn't figure out);
- Remove fee argument from `emptyTxBodyContent` as it's calculated automatically;
- Move tests from Integration to Spec.Marconi.ChainIndex.Indexers.ScriptTx (the integration test was mis-named, it was actually an end to end test for the ScriptTx indexer to begin with);
- Add `mkAddressValueTxOut`, a more general version of `mkAddressAdaTxOut`.

Apart from automatic fee calculation the other changes should functionally be no-ops.

All tests continue to pass.

~Question: I guess in the `emptyTxBodyContent` the fee argument should be removed as it's added automatically? [In plutus-e2e-tests](https://github.com/input-output-hk/plutus-apps/blob/c9337a1ad205a31e92de5675f913449fe08915ba/plutus-e2e-tests/test/Helpers.hs#L453) it's actually done that way already.~

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
