### PR TITLE
Drop Tx and EmulatorTx types

### DIFF
--- a/cardano-node-emulator/changelog.d/20230302_122332_ak3n_drop_emulator_tx.md
+++ b/cardano-node-emulator/changelog.d/20230302_122332_ak3n_drop_emulator_tx.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Remove `estimateTransactionFee`, `signTx`, `fromPlutusTx`, `fromPlutusTxSigned`, `fromPlutusTxSigned'` as the `Tx` was removed from `plutus-ledger`.

--- a/cardano-node-emulator/src/Cardano/Node/Emulator/Fee.hs
+++ b/cardano-node-emulator/src/Cardano/Node/Emulator/Fee.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE TypeFamilies       #-}
 -- | Calculating transaction fees in the emulator.
 module Cardano.Node.Emulator.Fee(
-  estimateTransactionFee,
   estimateCardanoBuildTxFee,
   makeAutoBalancedTransaction,
   makeAutoBalancedTransactionWithUtxoProvider,
@@ -23,7 +22,7 @@ import Cardano.Api.Shelley qualified as C.Api
 import Cardano.Ledger.BaseTypes (Globals (systemStart))
 import Cardano.Ledger.Core qualified as C.Ledger (Tx)
 import Cardano.Ledger.Shelley.API qualified as C.Ledger hiding (Tx)
-import Cardano.Node.Emulator.Params (EmulatorEra, PParams, Params (emulatorPParams, pNetworkId), emulatorEraHistory,
+import Cardano.Node.Emulator.Params (EmulatorEra, PParams, Params (emulatorPParams), emulatorEraHistory,
                                      emulatorGlobals, pProtocolParams)
 import Cardano.Node.Emulator.Validation (CardanoLedgerError, UTxO (..), makeTransactionBody)
 import Control.Arrow ((&&&))
@@ -36,25 +35,15 @@ import Data.Map qualified as Map
 import Data.Maybe (isNothing, listToMaybe)
 import Data.Ord (Down (Down))
 import GHC.Generics (Generic)
-import Ledger.Address (CardanoAddress, PaymentPubKeyHash)
+import Ledger.Address (CardanoAddress)
 import Ledger.Index (UtxoIndex (UtxoIndex), ValidationError (..), ValidationPhase (Phase1), adjustCardanoTxOut,
                      minAdaTxOutEstimated)
-import Ledger.Tx (ToCardanoError (TxBodyError), Tx, TxOut, TxOutRef)
+import Ledger.Tx (ToCardanoError (TxBodyError), TxOut, TxOutRef)
 import Ledger.Tx qualified as Tx
 import Ledger.Tx.CardanoAPI (CardanoBuildTx (..), fromPlutusIndex, getCardanoBuildTx, toCardanoFee,
-                             toCardanoReturnCollateral, toCardanoTotalCollateral, toCardanoTxBodyContent)
+                             toCardanoReturnCollateral, toCardanoTotalCollateral)
 import Ledger.Tx.CardanoAPI qualified as CardanoAPI
 import Ledger.Value.CardanoAPI (isZero, lovelaceToValue, split, valueGeq)
-
-estimateTransactionFee
-  :: Params
-  -> UTxO EmulatorEra
-  -> [PaymentPubKeyHash]
-  -> Tx
-  -> Either CardanoLedgerError C.Lovelace
-estimateTransactionFee params utxo requiredSigners tx = do
-  txBodyContent <- first Right $ toCardanoTxBodyContent (pNetworkId params) (emulatorPParams params) requiredSigners tx
-  estimateCardanoBuildTxFee params utxo txBodyContent
 
 estimateCardanoBuildTxFee
   :: Params

--- a/cardano-node-emulator/src/Cardano/Node/Emulator/Generators.hs
+++ b/cardano-node-emulator/src/Cardano/Node/Emulator/Generators.hs
@@ -90,10 +90,9 @@ import Control.Lens.Lens ((<&>))
 import Data.Functor (($>))
 import Data.String (fromString)
 import Gen.Cardano.Api.Typed (genTxIn)
-import Ledger (CardanoTx (CardanoApiTx), Interval, MintingPolicy (getMintingPolicy),
-               POSIXTime (POSIXTime, getPOSIXTime), POSIXTimeRange, Passphrase (Passphrase),
-               PaymentPrivateKey (unPaymentPrivateKey), PaymentPubKey, Slot (Slot), SlotRange,
-               SomeCardanoApiTx (CardanoApiEmulatorEraTx),
+import Ledger (CardanoTx (CardanoTx), Interval, MintingPolicy (getMintingPolicy), POSIXTime (POSIXTime, getPOSIXTime),
+               POSIXTimeRange, Passphrase (Passphrase), PaymentPrivateKey (unPaymentPrivateKey), PaymentPubKey,
+               Slot (Slot), SlotRange, SomeCardanoApiTx (CardanoApiEmulatorEraTx),
                TxInType (ConsumePublicKeyAddress, ConsumeSimpleScriptAddress, ScriptAddress), TxInput, TxInputType,
                TxOut, TxOutRef (TxOutRef), ValidationErrorInPhase, addCardanoTxSignature, maxFee, minAdaTxOutEstimated,
                minLovelaceTxOutEstimated, pubKeyTxOut, txOutValue, validatorHash)
@@ -267,7 +266,7 @@ makeTx
     -> m CardanoTx
 makeTx bodyContent = do
     txBody <- either (fail . ("Can't create TxBody" <>) . show) pure $ C.makeTransactionBody bodyContent
-    pure $ signAll $ CardanoApiTx $ CardanoApiEmulatorEraTx $ C.Tx txBody []
+    pure $ signAll $ CardanoTx $ CardanoApiEmulatorEraTx $ C.Tx txBody []
 
 -- | Generate a valid transaction, using the unspent outputs provided.
 --   Fails if the there are no unspent outputs, or if the total value

--- a/cardano-node-emulator/src/Cardano/Node/Emulator/Generators.hs
+++ b/cardano-node-emulator/src/Cardano/Node/Emulator/Generators.hs
@@ -91,9 +91,9 @@ import Control.Lens.Lens ((<&>))
 import Data.Functor (($>))
 import Data.String (fromString)
 import Gen.Cardano.Api.Typed (genTxIn)
-import Ledger (CardanoTx (CardanoTx), Interval, MintingPolicy (getMintingPolicy), POSIXTime (POSIXTime, getPOSIXTime),
-               POSIXTimeRange, Passphrase (Passphrase), PaymentPrivateKey (unPaymentPrivateKey), PaymentPubKey,
-               Slot (Slot), SlotRange, SomeCardanoApiTx (CardanoApiEmulatorEraTx),
+import Ledger (CardanoTx (CardanoEmulatorEraTx), Interval, MintingPolicy (getMintingPolicy),
+               POSIXTime (POSIXTime, getPOSIXTime), POSIXTimeRange, Passphrase (Passphrase),
+               PaymentPrivateKey (unPaymentPrivateKey), PaymentPubKey, Slot (Slot), SlotRange,
                TxInType (ConsumePublicKeyAddress, ConsumeSimpleScriptAddress, ScriptAddress), TxInput, TxInputType,
                TxOut, TxOutRef (TxOutRef), ValidationErrorInPhase, addCardanoTxSignature, maxFee, minAdaTxOutEstimated,
                minLovelaceTxOutEstimated, pubKeyTxOut, txOutValue, validatorHash)
@@ -270,7 +270,7 @@ makeTx
     -> m CardanoTx
 makeTx bodyContent = do
     txBody <- either (fail . ("Can't create TxBody" <>) . show) pure $ C.makeTransactionBody bodyContent
-    pure $ signAll $ CardanoTx $ CardanoApiEmulatorEraTx $ C.Tx txBody []
+    pure $ signAll $ CardanoEmulatorEraTx $ C.Tx txBody []
 
 -- | Generate a valid transaction, using the unspent outputs provided.
 --   Fails if the there are no unspent outputs, or if the total value

--- a/cardano-node-emulator/src/Cardano/Node/Emulator/Validation.hs
+++ b/cardano-node-emulator/src/Cardano/Node/Emulator/Validation.hs
@@ -21,9 +21,6 @@ module Cardano.Node.Emulator.Validation(
   hasValidationErrors,
   makeTransactionBody,
   validateCardanoTx,
-  fromPlutusTx,
-  fromPlutusTxSigned,
-  fromPlutusTxSigned',
   -- * Modifying the state
   makeBlock,
   setSlot,
@@ -39,7 +36,6 @@ module Cardano.Node.Emulator.Validation(
   emulatorGlobals,
   ) where
 
-import Cardano.Api qualified as C
 import Cardano.Api.Shelley qualified as C.Api
 import Cardano.Ledger.Alonzo.PlutusScriptApi (collectTwoPhaseScriptInputs, evalScripts)
 import Cardano.Ledger.Alonzo.Rules.Utxos (UtxosPredicateFailure (CollectErrors))
@@ -60,29 +56,22 @@ import Cardano.Ledger.Shelley.LedgerState (LedgerState (..), UTxOState (..), sma
 import Cardano.Ledger.Shelley.Rules.Utxo (UtxoEnv (..))
 import Cardano.Ledger.Shelley.TxBody (DCert, Wdrl)
 import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval)
-import Cardano.Node.Emulator.Params (EmulatorEra, Params (emulatorPParams, pNetworkId), emulatorGlobals,
-                                     emulatorPParams)
+import Cardano.Node.Emulator.Params (EmulatorEra, Params (emulatorPParams), emulatorGlobals, emulatorPParams)
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Lens (makeLenses, over, (&), (.~), (^.))
 import Control.Monad.Except (MonadError (throwError))
 import Data.Array (array)
 import Data.Bifunctor (Bifunctor (..))
 import Data.Default (def)
-import Data.Foldable (foldl')
 import Data.Map qualified as Map
-import Data.Maybe (mapMaybe)
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import Data.Text qualified as Text
 import GHC.Records (HasField (..))
-import Ledger.Address qualified as P
-import Ledger.Crypto qualified as Crypto
 import Ledger.Index.Internal qualified as P
 import Ledger.Slot (Slot)
-import Ledger.Tx (CardanoTx (CardanoTx), SomeCardanoApiTx (CardanoApiEmulatorEraTx, SomeTx), _cardanoTx,
-                  addCardanoTxSignature)
+import Ledger.Tx (CardanoTx, SomeCardanoApiTx (CardanoApiEmulatorEraTx), _cardanoTx)
 import Ledger.Tx.CardanoAPI qualified as P
-import Ledger.Tx.Internal qualified as P
 import Plutus.V1.Ledger.Api qualified as V1 hiding (TxOut (..))
 import Plutus.V1.Ledger.Scripts qualified as P
 
@@ -292,41 +281,3 @@ makeTransactionBody params utxo txBodyContent = do
   txTmp <- bimap Right (C.Api.makeSignedTransaction []) $ P.makeTransactionBody (Just $ emulatorPParams params) mempty txBodyContent
   exUnits <- bimap Left (Map.map snd) $ getTxExUnitsWithLogs params utxo txTmp
   first Right $ P.makeTransactionBody (Just $ emulatorPParams params) exUnits txBodyContent
-
-fromPlutusTx
-  :: Params
-  -> UTxO EmulatorEra
-  -> [P.PaymentPubKeyHash]
-  -> P.Tx
-  -> Either CardanoLedgerError (C.Tx C.BabbageEra)
-fromPlutusTx params utxo requiredSigners tx = do
-  txBodyContent <- first Right $ P.toCardanoTxBodyContent (pNetworkId params) (emulatorPParams params) requiredSigners tx
-  C.Api.makeSignedTransaction [] <$> makeTransactionBody params utxo txBodyContent
-
-fromPlutusTxSigned
-  :: Params
-  -> UTxO EmulatorEra
-  -> P.Tx
-  -> Map.Map P.PaymentPubKey P.PaymentPrivateKey
-  -> CardanoTx
-fromPlutusTxSigned params utxo tx knownPaymentKeys = case fromPlutusTxSigned' params utxo tx knownPaymentKeys of
-  Left e  -> error ("fromPlutusTxSigned: failed to convert " ++ show e)
-  Right t -> t
-
-fromPlutusTxSigned'
-  :: Params
-  -> UTxO EmulatorEra
-  -> P.Tx
-  -> Map.Map P.PaymentPubKey P.PaymentPrivateKey
-  -> Either CardanoLedgerError CardanoTx
-fromPlutusTxSigned' params utxo tx knownPaymentKeys =
-  let
-    getPrivateKey = fmap P.unPaymentPrivateKey . flip Map.lookup knownPaymentKeys . P.PaymentPubKey
-    getPublicKeys = Map.keys . P.txSignatures
-    privateKeys = mapMaybe getPrivateKey $ getPublicKeys tx
-    signTx txn = foldl' (flip addCardanoTxSignature) txn privateKeys
-    convertTx t =
-        flip SomeTx C.BabbageEraInCardanoMode
-        <$> fromPlutusTx params utxo (P.PaymentPubKeyHash . Crypto.pubKeyHash <$> getPublicKeys t) t
-  in
-    signTx . CardanoTx <$> convertTx tx

--- a/cardano-node-emulator/src/Cardano/Node/Emulator/Validation.hs
+++ b/cardano-node-emulator/src/Cardano/Node/Emulator/Validation.hs
@@ -79,7 +79,7 @@ import Ledger.Address qualified as P
 import Ledger.Crypto qualified as Crypto
 import Ledger.Index.Internal qualified as P
 import Ledger.Slot (Slot)
-import Ledger.Tx (CardanoTx (CardanoApiTx), SomeCardanoApiTx (CardanoApiEmulatorEraTx, SomeTx), _cardanoApiTx,
+import Ledger.Tx (CardanoTx (CardanoTx), SomeCardanoApiTx (CardanoApiEmulatorEraTx, SomeTx), _cardanoTx,
                   addCardanoTxSignature)
 import Ledger.Tx.CardanoAPI qualified as P
 import Ledger.Tx.Internal qualified as P
@@ -263,7 +263,7 @@ validateCardanoTx
   -> UTxO EmulatorEra
   -> CardanoTx
   -> Either P.ValidationErrorInPhase P.ValidationSuccess
-validateCardanoTx params slot utxo@(UTxO utxoMap) (_cardanoApiTx -> CardanoApiEmulatorEraTx tx) =
+validateCardanoTx params slot utxo@(UTxO utxoMap) (_cardanoTx -> CardanoApiEmulatorEraTx tx) =
   if Map.null utxoMap then Right Map.empty else
     hasValidationErrors params (fromIntegral slot) utxo tx
 
@@ -329,4 +329,4 @@ fromPlutusTxSigned' params utxo tx knownPaymentKeys =
         flip SomeTx C.BabbageEraInCardanoMode
         <$> fromPlutusTx params utxo (P.PaymentPubKeyHash . Crypto.pubKeyHash <$> getPublicKeys t) t
   in
-    signTx . CardanoApiTx <$> convertTx tx
+    signTx . CardanoTx <$> convertTx tx

--- a/cardano-node-emulator/src/Cardano/Node/Emulator/Validation.hs
+++ b/cardano-node-emulator/src/Cardano/Node/Emulator/Validation.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TupleSections      #-}
 {-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE ViewPatterns       #-}
+
 {-| Transaction validation using 'cardano-ledger-specs'
 -}
 module Cardano.Node.Emulator.Validation(
@@ -77,8 +79,8 @@ import Ledger.Address qualified as P
 import Ledger.Crypto qualified as Crypto
 import Ledger.Index.Internal qualified as P
 import Ledger.Slot (Slot)
-import Ledger.Tx (CardanoTx (CardanoApiTx), SomeCardanoApiTx (CardanoApiEmulatorEraTx, SomeTx), addCardanoTxSignature,
-                  onCardanoTx)
+import Ledger.Tx (CardanoTx (CardanoApiTx), SomeCardanoApiTx (CardanoApiEmulatorEraTx, SomeTx), _cardanoApiTx,
+                  addCardanoTxSignature)
 import Ledger.Tx.CardanoAPI qualified as P
 import Ledger.Tx.Internal qualified as P
 import Plutus.V1.Ledger.Api qualified as V1 hiding (TxOut (..))
@@ -261,11 +263,9 @@ validateCardanoTx
   -> UTxO EmulatorEra
   -> CardanoTx
   -> Either P.ValidationErrorInPhase P.ValidationSuccess
-validateCardanoTx params slot utxo@(UTxO utxoMap) =
-  onCardanoTx
-      (\_ -> error "validateCardanoTx: EmulatorTx is not supported")
-      (\(CardanoApiEmulatorEraTx tx) -> if Map.null utxoMap then Right Map.empty else
-        hasValidationErrors params (fromIntegral slot) utxo tx)
+validateCardanoTx params slot utxo@(UTxO utxoMap) (_cardanoApiTx -> CardanoApiEmulatorEraTx tx) =
+  if Map.null utxoMap then Right Map.empty else
+    hasValidationErrors params (fromIntegral slot) utxo tx
 
 getTxExUnitsWithLogs :: Params -> UTxO EmulatorEra -> C.Api.Tx C.Api.BabbageEra -> Either P.ValidationErrorInPhase P.ValidationSuccess
 getTxExUnitsWithLogs params utxo (C.Api.ShelleyTx _ tx) =

--- a/cardano-node-emulator/src/Cardano/Node/Emulator/Validation.hs
+++ b/cardano-node-emulator/src/Cardano/Node/Emulator/Validation.hs
@@ -70,7 +70,7 @@ import Data.Text qualified as Text
 import GHC.Records (HasField (..))
 import Ledger.Index.Internal qualified as P
 import Ledger.Slot (Slot)
-import Ledger.Tx (CardanoTx, SomeCardanoApiTx (CardanoApiEmulatorEraTx), _cardanoTx)
+import Ledger.Tx (CardanoTx (CardanoEmulatorEraTx))
 import Ledger.Tx.CardanoAPI qualified as P
 import Plutus.V1.Ledger.Api qualified as V1 hiding (TxOut (..))
 import Plutus.V1.Ledger.Scripts qualified as P
@@ -252,7 +252,7 @@ validateCardanoTx
   -> UTxO EmulatorEra
   -> CardanoTx
   -> Either P.ValidationErrorInPhase P.ValidationSuccess
-validateCardanoTx params slot utxo@(UTxO utxoMap) (_cardanoTx -> CardanoApiEmulatorEraTx tx) =
+validateCardanoTx params slot utxo@(UTxO utxoMap) (CardanoEmulatorEraTx tx) =
   if Map.null utxoMap then Right Map.empty else
     hasValidationErrors params (fromIntegral slot) utxo tx
 

--- a/cardano-streaming/examples/Example2.hs
+++ b/cardano-streaming/examples/Example2.hs
@@ -26,7 +26,7 @@ main = do
       flip map txs $ \tx@(Cardano.Api.Tx txBody _) ->
         let scriptData = Ledger.Tx.CardanoAPI.scriptDataFromCardanoTxBody txBody
             txId = Ledger.Tx.CardanoAPI.fromCardanoTxId $ Cardano.Api.getTxId txBody
-            txOutRefs = Ledger.Tx.CardanoAPI.txOutRefs (workaround (Ledger.Tx.CardanoAPI.SomeTx tx) eim)
+            txOutRefs = Ledger.Tx.CardanoAPI.txOutRefs (workaround (Ledger.Tx.CardanoAPI.CardanoTx tx) eim)
          in Aeson.object
               [ "txId" .= txId,
                 "txOutRefs" .= txOutRefs,

--- a/doc/plutus/tutorials/basic-apps-trace.txt
+++ b/doc/plutus/tutorials/basic-apps-trace.txt
@@ -1,4 +1,4 @@
-[INFO] Slot 0: TxnValidate 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84 [  ]
+[INFO] Slot 0: TxnValidate d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d [  ]
 [INFO] Slot 1: 00000000-0000-4000-8000-000000000000 {Wallet W[1]}:
                  Contract instance started
 [INFO] Slot 1: 00000000-0000-4000-8000-000000000000 {Wallet W[1]}:
@@ -29,11 +29,11 @@
                        Requires signatures:
                        Utxo index:
 [INFO] Slot 1: W[1]: Finished balancing:
-                       Tx 4971ec8310b413ee54d21e1d62dd0cda373c6cec41cf159d832bdf7cfc1c266f:
+                       Tx 3aed0c9c37edee742d00559de3471f4ad6b791522ba224c17fe188a0efcdcda5:
                          {inputs:
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!50
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!50
 
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!51
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!51
 
                          reference inputs:
                          collateral inputs:
@@ -54,17 +54,17 @@
                            <>>,
                            10000000> )
                          redeemers:}
-[INFO] Slot 1: W[1]: Signing tx: 4971ec8310b413ee54d21e1d62dd0cda373c6cec41cf159d832bdf7cfc1c266f
-[INFO] Slot 1: W[1]: Submitting tx: 4971ec8310b413ee54d21e1d62dd0cda373c6cec41cf159d832bdf7cfc1c266f
-[INFO] Slot 1: W[1]: TxSubmit: 4971ec8310b413ee54d21e1d62dd0cda373c6cec41cf159d832bdf7cfc1c266f
-[INFO] Slot 1: TxnValidate 4971ec8310b413ee54d21e1d62dd0cda373c6cec41cf159d832bdf7cfc1c266f [  ]
+[INFO] Slot 1: W[1]: Signing tx: 3aed0c9c37edee742d00559de3471f4ad6b791522ba224c17fe188a0efcdcda5
+[INFO] Slot 1: W[1]: Submitting tx: 3aed0c9c37edee742d00559de3471f4ad6b791522ba224c17fe188a0efcdcda5
+[INFO] Slot 1: W[1]: TxSubmit: 3aed0c9c37edee742d00559de3471f4ad6b791522ba224c17fe188a0efcdcda5
+[INFO] Slot 1: TxnValidate 3aed0c9c37edee742d00559de3471f4ad6b791522ba224c17fe188a0efcdcda5 [  ]
 [INFO] Slot 2: 00000000-0000-4000-8000-000000000000 {Wallet W[1]}:
                  Receive endpoint call on 'unlock' for Object (fromList [("contents",Array [Object (fromList [("getEndpointDescription",String "unlock")]),Object (fromList [("unEndpointValue",Object (fromList [("recipient1Address",String "addr_test1vz3vyrrh3pavu8xescvnunn4h27cny70645etn2ulnnqnssrz8utc"),("recipient2Address",String "addr_test1vzq2fazm26ug6yfemg3mcnpuwhkx6v558sy87fgtscvnefckqs3wk"),("totalAda",Object (fromList [("getLovelace",Number 1.0e7)]))]))])]),("tag",String "ExposeEndpointResp")])
 [INFO] Slot 2: W[1]: Balancing an unbalanced transaction:
                        Tx:
-                         Tx 726adfb9e7c9773f7639540b564cbf67dbb897efcb011739e38e2816ff08e1e5:
+                         Tx 91ed39867cbcc307d0beb619215e1c138e726105024dbb6668e5ffbfdd2fd754:
                            {inputs:
-                              - 4971ec8310b413ee54d21e1d62dd0cda373c6cec41cf159d832bdf7cfc1c266f!0
+                              - 3aed0c9c37edee742d00559de3471f4ad6b791522ba224c17fe188a0efcdcda5!0
 
                            reference inputs:
                            collateral inputs:
@@ -89,20 +89,20 @@
                              PlutusScript PlutusV1 ScriptHash "3e4f54085c2eb253b81fb958f3c3369ab6139c12964ee894ae57a908"}
                        Requires signatures:
                        Utxo index:
-                         ( 4971ec8310b413ee54d21e1d62dd0cda373c6cec41cf159d832bdf7cfc1c266f!0
+                         ( 3aed0c9c37edee742d00559de3471f4ad6b791522ba224c17fe188a0efcdcda5!0
                          , - 10000000 lovelace addressed to
                              ScriptCredential: 3e4f54085c2eb253b81fb958f3c3369ab6139c12964ee894ae57a908 (no staking credential)
                              with datum hash 43492163ee71f886ebc65c85f3dfa8db313f00d701b433b539811464d4355873 )
 [INFO] Slot 2: W[1]: Finished balancing:
-                       Tx fcef4d121ba88cef5c12d689427e73aec161154190e270c953b1a652037c7533:
+                       Tx 6156586126d719203a5e22e67360550c8dd3d1565c2afeee576349b7ea84bc09:
                          {inputs:
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!52
+                            - 3aed0c9c37edee742d00559de3471f4ad6b791522ba224c17fe188a0efcdcda5!0
 
-                            - 4971ec8310b413ee54d21e1d62dd0cda373c6cec41cf159d832bdf7cfc1c266f!0
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!52
 
                          reference inputs:
                          collateral inputs:
-                           - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!52
+                           - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!52
 
                          outputs:
                            - 5000000 lovelace addressed to
@@ -126,13 +126,13 @@
                            <>>,
                            10000000> )
                          redeemers:
-                           RedeemerPtr Spend 1 : Constr 0 []
+                           RedeemerPtr Spend 0 : Constr 0 []
                          attached scripts:
                            PlutusScript PlutusV1 ScriptHash "3e4f54085c2eb253b81fb958f3c3369ab6139c12964ee894ae57a908"}
-[INFO] Slot 2: W[1]: Signing tx: fcef4d121ba88cef5c12d689427e73aec161154190e270c953b1a652037c7533
-[INFO] Slot 2: W[1]: Submitting tx: fcef4d121ba88cef5c12d689427e73aec161154190e270c953b1a652037c7533
-[INFO] Slot 2: W[1]: TxSubmit: fcef4d121ba88cef5c12d689427e73aec161154190e270c953b1a652037c7533
-[INFO] Slot 2: TxnValidate fcef4d121ba88cef5c12d689427e73aec161154190e270c953b1a652037c7533 [ Data decoded successfully
+[INFO] Slot 2: W[1]: Signing tx: 6156586126d719203a5e22e67360550c8dd3d1565c2afeee576349b7ea84bc09
+[INFO] Slot 2: W[1]: Submitting tx: 6156586126d719203a5e22e67360550c8dd3d1565c2afeee576349b7ea84bc09
+[INFO] Slot 2: W[1]: TxSubmit: 6156586126d719203a5e22e67360550c8dd3d1565c2afeee576349b7ea84bc09
+[INFO] Slot 2: TxnValidate 6156586126d719203a5e22e67360550c8dd3d1565c2afeee576349b7ea84bc09 [ Data decoded successfully
                                                                                             , Redeemer decoded successfully
                                                                                             , Script context decoded successfully ]
 Final balances

--- a/doc/plutus/tutorials/basic-apps-trace.txt
+++ b/doc/plutus/tutorials/basic-apps-trace.txt
@@ -84,7 +84,7 @@
                              <>>,
                              10000000> )
                            redeemers:
-                             RedeemerPtr Spend 0 : Redeemer {getRedeemer = Constr 0 []}
+                             RedeemerPtr Spend 0 : Constr 0 []
                            attached scripts:
                              PlutusScript PlutusV1 ScriptHash "3e4f54085c2eb253b81fb958f3c3369ab6139c12964ee894ae57a908"}
                        Requires signatures:
@@ -126,7 +126,7 @@
                            <>>,
                            10000000> )
                          redeemers:
-                           RedeemerPtr Spend 1 : Redeemer {getRedeemer = Constr 0 []}
+                           RedeemerPtr Spend 1 : Constr 0 []
                          attached scripts:
                            PlutusScript PlutusV1 ScriptHash "3e4f54085c2eb253b81fb958f3c3369ab6139c12964ee894ae57a908"}
 [INFO] Slot 2: W[1]: Signing tx: fcef4d121ba88cef5c12d689427e73aec161154190e270c953b1a652037c7533

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Tx.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Tx.hs
@@ -46,7 +46,7 @@ import Data.Tuple (swap)
 import Ledger (OnChainTx (..), SomeCardanoApiTx (SomeTx), TxOutRef (..))
 import Ledger.Address (CardanoAddress)
 import Ledger.Scripts (Redeemer, RedeemerHash)
-import Ledger.Tx (_cardanoApiTx)
+import Ledger.Tx (_cardanoTx)
 import Plutus.ChainIndex.Types
 import Plutus.Contract.CardanoAPI (fromCardanoTx, setValidity)
 import Plutus.Script.Utils.Scripts (redeemerHash)
@@ -87,8 +87,8 @@ validityFromChainIndex tx =
 -- 'OnChainTx' will be the inputs of the 'ChainIndexTx'.
 fromOnChainTx :: OnChainTx -> ChainIndexTx
 fromOnChainTx = \case
-    Valid ctx   -> (fromOnChainCardanoTx True . _cardanoApiTx) ctx
-    Invalid ctx -> (fromOnChainCardanoTx False . _cardanoApiTx) ctx
+    Valid ctx   -> (fromOnChainCardanoTx True . _cardanoTx) ctx
+    Invalid ctx -> (fromOnChainCardanoTx False . _cardanoTx) ctx
 
 txRedeemersWithHash :: ChainIndexTx -> Map RedeemerHash Redeemer
 txRedeemersWithHash ChainIndexTx{_citxRedeemers} = Map.fromList

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Tx.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Tx.hs
@@ -40,21 +40,16 @@ module Plutus.ChainIndex.Tx(
     , _ValidTx
     ) where
 
-import Data.List (sort)
 import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Maybe (mapMaybe)
 import Data.Tuple (swap)
-import Ledger (OnChainTx (..), ScriptTag (Cert, Mint, Reward), SomeCardanoApiTx (SomeTx), Tx (..),
-               TxInput (txInputType), TxOut (getTxOut), TxOutRef (..), onCardanoTx, txCertifyingRedeemers, txId,
-               txMintingRedeemers, txRewardingRedeemers)
+import Ledger (OnChainTx (..), SomeCardanoApiTx (SomeTx), TxOutRef (..))
 import Ledger.Address (CardanoAddress)
 import Ledger.Scripts (Redeemer, RedeemerHash)
-import Ledger.Tx (TxInputType (TxScriptAddress), fillTxInputWitnesses)
+import Ledger.Tx (_cardanoApiTx)
 import Plutus.ChainIndex.Types
-import Plutus.Contract.CardanoAPI (fromCardanoTx, fromCardanoTxOut, setValidity)
+import Plutus.Contract.CardanoAPI (fromCardanoTx, setValidity)
 import Plutus.Script.Utils.Scripts (redeemerHash)
-import Plutus.V1.Ledger.Tx (RedeemerPtr (RedeemerPtr), Redeemers, ScriptTag (Spend))
 import Plutus.V2.Ledger.Api (Address (..), OutputDatum (..), Value (..))
 
 -- | Get tx outputs from tx.
@@ -92,38 +87,8 @@ validityFromChainIndex tx =
 -- 'OnChainTx' will be the inputs of the 'ChainIndexTx'.
 fromOnChainTx :: OnChainTx -> ChainIndexTx
 fromOnChainTx = \case
-    Valid ctx ->
-        onCardanoTx
-            (\case tx@Tx{txInputs, txOutputs, txValidRange, txData, txScripts} ->
-                    ChainIndexTx
-                        { _citxTxId = txId tx
-                        , _citxInputs = map (fillTxInputWitnesses tx) txInputs
-                        , _citxOutputs = ValidTx $ map (fromCardanoTxOut . getTxOut) txOutputs
-                        , _citxValidRange = txValidRange
-                        , _citxData = txData
-                        , _citxRedeemers = calculateRedeemerPointers tx
-                        , _citxScripts = txScripts
-                        , _citxCardanoTx = Nothing
-                        }
-            )
-            (fromOnChainCardanoTx True)
-            ctx
-    Invalid ctx ->
-        onCardanoTx
-            (\case tx@Tx{txCollateralInputs, txReturnCollateral, txValidRange, txData, txScripts} ->
-                    ChainIndexTx
-                        { _citxTxId = txId tx
-                        , _citxInputs = map (fillTxInputWitnesses tx) txCollateralInputs
-                        , _citxOutputs = InvalidTx $ fmap (fromCardanoTxOut . getTxOut) txReturnCollateral
-                        , _citxValidRange = txValidRange
-                        , _citxData = txData
-                        , _citxRedeemers = calculateRedeemerPointers tx
-                        , _citxScripts = txScripts
-                        , _citxCardanoTx = Nothing
-                        }
-            )
-            (fromOnChainCardanoTx False)
-            ctx
+    Valid ctx   -> (fromOnChainCardanoTx True . _cardanoApiTx) ctx
+    Invalid ctx -> (fromOnChainCardanoTx False . _cardanoApiTx) ctx
 
 txRedeemersWithHash :: ChainIndexTx -> Map RedeemerHash Redeemer
 txRedeemersWithHash ChainIndexTx{_citxRedeemers} = Map.fromList
@@ -134,20 +99,3 @@ txRedeemersWithHash ChainIndexTx{_citxRedeemers} = Map.fromList
 -- so we need to make sure these match up. Once we only have cardano api txs this can be removed.
 fromOnChainCardanoTx :: Bool -> SomeCardanoApiTx -> ChainIndexTx
 fromOnChainCardanoTx validity (SomeTx tx era) = fromCardanoTx era $ setValidity validity tx
-
--- TODO: the index of the txin is probably incorrect as we take it from the set.
--- To determine the proper index we have to convert the plutus's `TxIn` to cardano-api `TxIn` and
--- sort them by using the standard `Ord` instance.
-calculateRedeemerPointers :: Tx -> Redeemers
-calculateRedeemerPointers tx = spends <> rewards <> mints <> certs
-    -- we sort the inputs to make sure that the indices match with redeemer pointers
-
-    where
-        rewards = Map.fromList $ zipWith (\n (_, rd) -> (RedeemerPtr Reward n, rd)) [0..]  $ sort $ Map.assocs $ txRewardingRedeemers tx
-        mints   = Map.fromList $ zipWith (\n (_, rd) -> (RedeemerPtr Mint n, rd)) [0..]  $ sort $ Map.assocs $ txMintingRedeemers tx
-        certs   = Map.fromList $ zipWith (\n (_, rd) -> (RedeemerPtr Cert n, rd)) [0..]  $ sort $ Map.assocs $ txCertifyingRedeemers tx
-        spends = Map.fromList $ mapMaybe (uncurry getRd) $ zip [0..] $ fmap txInputType $ sort $ txInputs tx
-
-        getRd n = \case
-            TxScriptAddress rd _ _ -> Just (RedeemerPtr Spend n, rd)
-            _                      -> Nothing

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Tx.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Tx.hs
@@ -84,17 +84,15 @@ validityFromChainIndex tx =
 -- | Convert a 'OnChainTx' to a 'ChainIndexTx'. An invalid 'OnChainTx' will not
 -- produce any 'ChainIndexTx' outputs and the collateral inputs of the
 -- 'OnChainTx' will be the inputs of the 'ChainIndexTx'.
+--
+-- Cardano api transactions store validity internally. Our emulated blockchain stores validity outside of the transactions,
+-- so we need to make sure these match up.
 fromOnChainTx :: OnChainTx -> ChainIndexTx
 fromOnChainTx = \case
-    Valid ctx   -> (fromOnChainCardanoTx True) ctx
-    Invalid ctx -> (fromOnChainCardanoTx False) ctx
+    Valid (CardanoTx tx era)   -> fromCardanoTx era $ setValidity True tx
+    Invalid (CardanoTx tx era) -> fromCardanoTx era $ setValidity False tx
 
 txRedeemersWithHash :: ChainIndexTx -> Map RedeemerHash Redeemer
 txRedeemersWithHash ChainIndexTx{_citxRedeemers} = Map.fromList
     $ fmap (\r -> (redeemerHash r, r))
     $ Map.elems _citxRedeemers
-
--- Cardano api transactions store validity internally. Our emulated blockchain stores validity outside of the transactions,
--- so we need to make sure these match up. Once we only have cardano api txs this can be removed.
-fromOnChainCardanoTx :: Bool -> CardanoTx -> ChainIndexTx
-fromOnChainCardanoTx validity (CardanoTx tx era) = fromCardanoTx era $ setValidity validity tx

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Tx.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Tx.hs
@@ -43,10 +43,9 @@ module Plutus.ChainIndex.Tx(
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Tuple (swap)
-import Ledger (OnChainTx (..), SomeCardanoApiTx (SomeTx), TxOutRef (..))
+import Ledger (CardanoTx (CardanoTx), OnChainTx (..), TxOutRef (..))
 import Ledger.Address (CardanoAddress)
 import Ledger.Scripts (Redeemer, RedeemerHash)
-import Ledger.Tx (_cardanoTx)
 import Plutus.ChainIndex.Types
 import Plutus.Contract.CardanoAPI (fromCardanoTx, setValidity)
 import Plutus.Script.Utils.Scripts (redeemerHash)
@@ -87,8 +86,8 @@ validityFromChainIndex tx =
 -- 'OnChainTx' will be the inputs of the 'ChainIndexTx'.
 fromOnChainTx :: OnChainTx -> ChainIndexTx
 fromOnChainTx = \case
-    Valid ctx   -> (fromOnChainCardanoTx True . _cardanoTx) ctx
-    Invalid ctx -> (fromOnChainCardanoTx False . _cardanoTx) ctx
+    Valid ctx   -> (fromOnChainCardanoTx True) ctx
+    Invalid ctx -> (fromOnChainCardanoTx False) ctx
 
 txRedeemersWithHash :: ChainIndexTx -> Map RedeemerHash Redeemer
 txRedeemersWithHash ChainIndexTx{_citxRedeemers} = Map.fromList
@@ -97,5 +96,5 @@ txRedeemersWithHash ChainIndexTx{_citxRedeemers} = Map.fromList
 
 -- Cardano api transactions store validity internally. Our emulated blockchain stores validity outside of the transactions,
 -- so we need to make sure these match up. Once we only have cardano api txs this can be removed.
-fromOnChainCardanoTx :: Bool -> SomeCardanoApiTx -> ChainIndexTx
-fromOnChainCardanoTx validity (SomeTx tx era) = fromCardanoTx era $ setValidity validity tx
+fromOnChainCardanoTx :: Bool -> CardanoTx -> ChainIndexTx
+fromOnChainCardanoTx validity (CardanoTx tx era) = fromCardanoTx era $ setValidity validity tx

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Types.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Types.hs
@@ -90,8 +90,8 @@ import Data.Set qualified as Set
 import Data.Typeable (Proxy (Proxy), Typeable)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
-import Ledger (CardanoAddress, Language, SlotRange, SomeCardanoApiTx, TxIn (..), TxInType (..), TxOutRef (..),
-               Versioned, toPlutusAddress)
+import Ledger (CardanoAddress, CardanoTx, Language, SlotRange, TxIn (..), TxInType (..), TxOutRef (..), Versioned,
+               toPlutusAddress)
 import Ledger.Blockchain (BlockId (..))
 import Ledger.Blockchain qualified as Ledger
 import Ledger.Slot (Slot (Slot))
@@ -260,11 +260,11 @@ instance (Typeable era) => OpenApi.ToSchema (C.Tx era) where
   declareNamedSchema _ = do
     return $ NamedSchema (Just "Tx") byteSchema
 
-instance OpenApi.ToSchema SomeCardanoApiTx where
+instance OpenApi.ToSchema CardanoTx where
   declareNamedSchema _ = do
     txSchema <- declareSchemaRef (Proxy :: Proxy (C.Tx C.BabbageEra))
     eraInModeSchema <- declareSchemaRef (Proxy :: Proxy (C.EraInMode C.BabbageEra C.CardanoMode))
-    return $ NamedSchema (Just "SomeCardanoApiTx") $ mempty
+    return $ NamedSchema (Just "CardanoTx") $ mempty
       & type_ ?~ OpenApiObject
       & properties .~
           InsOrdMap.fromList [ ("tx", txSchema)
@@ -287,7 +287,7 @@ data ChainIndexTx = ChainIndexTx {
     -- ^ Redeemers of the minting scripts.
     _citxScripts    :: Map ScriptHash (Versioned Script),
     -- ^ The scripts (validator, stake validator or minting) part of cardano tx.
-    _citxCardanoTx  :: Maybe SomeCardanoApiTx
+    _citxCardanoTx  :: Maybe CardanoTx
     -- ^ The full Cardano API tx which was used to populate the rest of the
     -- 'ChainIndexTx' fields. Useful because 'ChainIndexTx' doesn't have all the
     -- details of the tx, so we keep it as a safety net. Might be Nothing if we

--- a/plutus-chain-index-core/src/Plutus/Contract/CardanoAPI.hs
+++ b/plutus-chain-index-core/src/Plutus/Contract/CardanoAPI.hs
@@ -64,7 +64,7 @@ fromCardanoTx eraInMode tx@(C.Tx txBody@(C.TxBody C.TxBodyContent{..}) _) =
             , _citxData = datums
             , _citxRedeemers = redeemers
             , _citxScripts = scriptMap
-            , _citxCardanoTx = Just $ SomeTx tx eraInMode
+            , _citxCardanoTx = Just $ CardanoTx tx eraInMode
             }
 
 fromCardanoTxOut :: C.IsCardanoEra era => C.TxOut C.CtxTx era -> ChainIndexTxOut

--- a/plutus-contract/src/Plutus/Contract/Effects.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects.hs
@@ -103,7 +103,7 @@ import Ledger.Credential (Credential)
 import Ledger.Scripts (Validator)
 import Ledger.Slot (Slot, SlotRange)
 import Ledger.Time (POSIXTime, POSIXTimeRange)
-import Ledger.Tx (CardanoTx, DecoratedTxOut, Versioned, getCardanoTxId, onCardanoTx)
+import Ledger.Tx (CardanoTx, DecoratedTxOut, Versioned, getCardanoTxId)
 import Ledger.Tx.Constraints.OffChain (UnbalancedTx)
 import Plutus.ChainIndex (Page (pageItems), PageQuery)
 import Plutus.ChainIndex.Api (IsUtxoResponse (IsUtxoResponse), QueryResponse (QueryResponse),
@@ -161,7 +161,7 @@ instance Pretty PABReq where
     OwnAddressesReq                         -> "Own addresses"
     ChainIndexQueryReq q                    -> "Chain index query:" <+> pretty q
     BalanceTxReq utx                        -> "Balance tx:" <+> pretty utx
-    WriteBalancedTxReq tx                   -> "Write balanced tx:" <+> onCardanoTx pretty (fromString . show) tx
+    WriteBalancedTxReq tx                   -> "Write balanced tx:" <+> (fromString $ show tx)
     ExposeEndpointReq ep                    -> "Expose endpoint:" <+> pretty ep
     PosixTimeRangeToContainedSlotRangeReq r -> "Posix time range to contained slot range:" <+> pretty r
     YieldUnbalancedTxReq utx                -> "Yield unbalanced tx:" <+> pretty utx

--- a/plutus-contract/src/Plutus/Contract/Test/ContractModel/Internal.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/ContractModel/Internal.hs
@@ -193,7 +193,7 @@ instance HasChainIndex (EmulatorTraceWithInstances state) where
                                                      $ Index.initialise (take 1 $ reverse (_chainNewestFirst cs))
                                               }
                   addBlock block (txs, state) =
-                    ( txs ++ [ TxInState ((\(CardanoApiEmulatorEraTx tx) -> tx) . _cardanoApiTx . unOnChain $ tx)
+                    ( txs ++ [ TxInState ((\(CardanoApiEmulatorEraTx tx) -> tx) . _cardanoTx . unOnChain $ tx)
                                          state
                                          (onChainTxIsValid tx)
                              | tx <- block ]

--- a/plutus-contract/src/Plutus/Contract/Test/ContractModel/Internal.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/ContractModel/Internal.hs
@@ -193,7 +193,7 @@ instance HasChainIndex (EmulatorTraceWithInstances state) where
                                                      $ Index.initialise (take 1 $ reverse (_chainNewestFirst cs))
                                               }
                   addBlock block (txs, state) =
-                    ( txs ++ [ TxInState ((\(CardanoApiEmulatorEraTx tx) -> tx) . _cardanoTx . unOnChain $ tx)
+                    ( txs ++ [ TxInState ((\(CardanoEmulatorEraTx tx) -> tx) . unOnChain $ tx)
                                          state
                                          (onChainTxIsValid tx)
                              | tx <- block ]

--- a/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
+++ b/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
@@ -58,8 +58,7 @@ import Ledger (CardanoAddress, POSIXTime, POSIXTimeRange, Slot (..), SlotRange)
 import Ledger.Tx (CardanoTx)
 import Ledger.Tx.CardanoAPI (ToCardanoError)
 import Ledger.Tx.Constraints (UnbalancedTx)
-import Ledger.Tx.Constraints qualified as Tx.Constraints
-import Ledger.Tx.Constraints.OffChain qualified as Constraints
+import Ledger.Tx.Constraints qualified as Constraints
 import Plutus.ChainIndex (ChainIndexQueryEffect)
 import Plutus.ChainIndex.Effects qualified as ChainIndexEff
 import Plutus.ChainIndex.Types (Tip (..))
@@ -309,11 +308,7 @@ handleAdjustUnbalancedTx =
     RequestHandler $ \utx ->
         surroundDebug @Text "handleAdjustUnbalancedTx" $ do
             params <- getClientParams
-            let
-                adjustUnbalancedTx = case Constraints.unBalancedTxTx utx of
-                    Left _  -> Tx.Constraints.adjustUnbalancedTx
-                    Right _ -> Constraints.adjustUnbalancedTx
-            forM (adjustUnbalancedTx (emulatorPParams params) utx) $ \(missingAdaCosts, adjusted) -> do
+            forM (Constraints.adjustUnbalancedTx (emulatorPParams params) utx) $ \(missingAdaCosts, adjusted) -> do
                 logDebug $ AdjustingUnbalancedTx missingAdaCosts
                 pure adjusted
 

--- a/plutus-contract/src/Plutus/Trace/Emulator/Extract.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/Extract.hs
@@ -19,17 +19,14 @@ import Control.Lens ((&), (.~))
 import Control.Monad.Freer (run)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Encode.Pretty (encodePretty)
-import Data.Bifunctor (Bifunctor (bimap))
 import Data.ByteString.Lazy qualified as BSL
 import Data.Foldable (traverse_)
 import Data.Int (Int64)
 import Data.Monoid (Sum (..))
-import Data.Set qualified as Set
 
 import Ledger qualified
 import Ledger.Tx.CardanoAPI (fromPlutusIndex)
 import Ledger.Tx.Constraints.OffChain (UnbalancedTx (..))
-import Plutus.Contract.CardanoAPI qualified as CardanoAPI
 import Plutus.Contract.Request (MkTxLog)
 import Plutus.Trace.Emulator (EmulatorConfig (_params), EmulatorTrace)
 import Plutus.Trace.Emulator qualified as Trace
@@ -119,12 +116,6 @@ writeTransaction params fp prefix idx utx = do
             BSL.writeFile filename1 $ encodePretty ctx
     where
       buildTx :: UnbalancedTx -> Either CardanoLedgerError (C.Tx C.BabbageEra)
-      buildTx (UnbalancedEmulatorTx tx sigs _) =
-        let requiredSigners = Set.toList sigs
-        in bimap
-            Right
-            (C.makeSignedTransaction [])
-            (CardanoAPI.toCardanoTxBody (pNetworkId params) (emulatorPParams params) requiredSigners tx)
       buildTx (UnbalancedCardanoTx tx utxos) =
         let fromCardanoTx ctx = do
               utxo <- fromPlutusIndex $ Ledger.UtxoIndex utxos

--- a/plutus-contract/src/Wallet/Emulator/MultiAgent.hs
+++ b/plutus-contract/src/Wallet/Emulator/MultiAgent.hs
@@ -17,6 +17,11 @@
 {-# OPTIONS_GHC -Wno-overlapping-patterns #-}
 module Wallet.Emulator.MultiAgent where
 
+import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as C
+import Cardano.Node.Emulator.Chain qualified as Chain
+import Cardano.Node.Emulator.Generators (alwaysSucceedPolicy, alwaysSucceedPolicyId, emptyTxBodyContent, signAll)
+import Cardano.Node.Emulator.Params (Params (..))
 import Control.Lens (AReview, Getter, Lens', Prism', anon, at, folded, makeLenses, prism', reversed, review, to, unto,
                      view, (&), (.~), (^.), (^..))
 import Control.Monad (join)
@@ -26,30 +31,27 @@ import Control.Monad.Freer.Extras.Log (LogMessage, LogMsg, LogObserve, handleObs
 import Control.Monad.Freer.Extras.Modify (handleZoomedState, raiseEnd, writeIntoState)
 import Control.Monad.Freer.State (State, get)
 import Data.Aeson (FromJSON, ToJSON)
-import Data.Default (def)
+import Data.Foldable (fold)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Text qualified as T
 import Data.Text.Extras (tshow)
 import GHC.Generics (Generic)
-import Prettyprinter (Pretty (pretty), colon, (<+>))
-
-import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C
-import Cardano.Node.Emulator.Chain qualified as Chain
-import Cardano.Node.Emulator.Params (Params (..))
-import Cardano.Node.Emulator.Validation qualified as Validation
-import Data.Foldable (fold)
 import Ledger hiding (to, value)
 import Ledger.AddressMap qualified as AM
-import Ledger.CardanoWallet qualified as CW
 import Ledger.Index qualified as Index
+import Ledger.Tx qualified as Tx
+import Ledger.Tx.CardanoAPI qualified as C hiding (makeTransactionBody)
 import Ledger.Tx.CardanoAPI qualified as CardanoAPI
+import Ledger.Value.CardanoAPI qualified as CardanoAPI
 import Plutus.ChainIndex.Emulator qualified as ChainIndex
 import Plutus.Contract.Error (AssertionError (GenericAssertion))
 import Plutus.Trace.Emulator.Types (ContractInstanceLog, EmulatedWalletEffects, EmulatedWalletEffects', UserThreadMsg)
 import Plutus.Trace.Scheduler qualified as Scheduler
+import Plutus.V1.Ledger.Scripts qualified as Script
+import PlutusTx (toData)
+import Prettyprinter (Pretty (pretty), colon, (<+>))
 import Wallet.API qualified as WAPI
 import Wallet.Emulator.LogMessages (RequestHandlerLogMsg, TxBalanceMsg)
 import Wallet.Emulator.NodeClient qualified as NC
@@ -292,19 +294,36 @@ to be an Ada-only output. To make sure we always have an Ada-only output availab
 we create 10 Ada-only outputs per wallet here.
 -}
 
+-- | cardano-ledger validation rules require the presence of inputs and
+-- we have to provide a stub TxIn for the genesis transaction.
+genesisTxIn :: C.TxIn
+genesisTxIn = C.TxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53" (C.TxIx 40214)
+
 -- | Initialise the emulator state with a single pending transaction that
 --   creates the initial distribution of funds to public key addresses.
 emulatorStateInitialDist :: Params -> Map PaymentPubKeyHash C.Value -> Either ToCardanoError EmulatorState
 emulatorStateInitialDist params mp = do
     minAdaEmptyTxOut <- mMinAdaTxOut
     outs <- traverse (mkOutputs minAdaEmptyTxOut) (Map.toList mp)
-    let tx = mempty
-           { txOutputs = concat outs
-           , txMint = fold mp
-           , txValidRange = WAPI.defaultSlotRange
+    validityRange <- C.toCardanoValidityRange WAPI.defaultSlotRange
+    mintWitness <- either (error . show) pure $ C.PlutusScriptWitness C.PlutusScriptV2InBabbage C.PlutusScriptV2
+                           <$> (C.PScript <$> C.toCardanoPlutusScript
+                                                  (C.AsPlutusScript C.AsPlutusScriptV2)
+                                                  (getMintingPolicy alwaysSucceedPolicy))
+                           <*> pure C.NoScriptDatumForMint
+                           <*> pure (C.fromPlutusData $ toData Script.unitRedeemer)
+                           <*> pure C.zeroExecutionUnits
+    let
+        txBodyContent = emptyTxBodyContent
+           { C.txIns = [ (genesisTxIn, C.BuildTxWith (C.KeyWitness C.KeyWitnessForSpending)) ]
+           , C.txInsCollateral = C.TxInsCollateral C.CollateralInBabbageEra [genesisTxIn]
+           , C.txMintValue = C.TxMintValue C.MultiAssetInBabbageEra (fold $ Map.map CardanoAPI.noAdaValue mp)
+                              (C.BuildTxWith (Map.singleton alwaysSucceedPolicyId mintWitness))
+           , C.txOuts = Tx.getTxOut <$> concat outs
+           , C.txValidityRange = validityRange
            }
-        cUtxoIndex = either (error . show) id $ CardanoAPI.fromPlutusIndex mempty
-        cTx = Validation.fromPlutusTxSigned def cUtxoIndex tx CW.knownPaymentKeys
+    txBody <- either (error . ("Can't create TxBody" <>) . show) pure $ C.makeTransactionBody txBodyContent
+    let cTx = signAll $ CardanoTx $ CardanoApiEmulatorEraTx $ C.Tx txBody []
     pure $ emulatorStatePool [cTx]
     where
         -- we start with an empty TxOut and we adjust it to be sure that the contained Adas fit the size

--- a/plutus-contract/src/Wallet/Emulator/MultiAgent.hs
+++ b/plutus-contract/src/Wallet/Emulator/MultiAgent.hs
@@ -323,7 +323,7 @@ emulatorStateInitialDist params mp = do
            , C.txValidityRange = validityRange
            }
     txBody <- either (error . ("Can't create TxBody" <>) . show) pure $ C.makeTransactionBody txBodyContent
-    let cTx = signAll $ CardanoTx $ CardanoApiEmulatorEraTx $ C.Tx txBody []
+    let cTx = signAll $ CardanoEmulatorEraTx $ C.Tx txBody []
     pure $ emulatorStatePool [cTx]
     where
         -- we start with an empty TxOut and we adjust it to be sure that the contained Adas fit the size

--- a/plutus-contract/src/Wallet/Emulator/Stream.hs
+++ b/plutus-contract/src/Wallet/Emulator/Stream.hs
@@ -46,10 +46,8 @@ import Data.Maybe (fromMaybe)
 import Data.Set qualified as Set
 import Ledger.AddressMap qualified as AM
 import Ledger.Blockchain (Block, OnChainTx (Valid))
-import Ledger.CardanoWallet qualified as CW
 import Ledger.Slot (Slot)
-import Ledger.Tx (CardanoTx (CardanoApiTx), onCardanoTx)
-import Ledger.Tx.CardanoAPI (fromPlutusIndex)
+import Ledger.Tx (CardanoTx)
 import Plutus.ChainIndex (ChainIndexError)
 import Streaming (Stream)
 import Streaming qualified as S
@@ -63,7 +61,6 @@ import Wallet.Emulator.MultiAgent (EmulatorState, EmulatorTimeEvent (EmulatorTim
 import Wallet.Emulator.Wallet (Wallet, mockWalletAddress)
 
 import Cardano.Api qualified as C
-import Cardano.Node.Emulator.Validation qualified as Validation
 import Plutus.Contract.Trace (InitialDistribution, defaultDist, knownWallets)
 import Plutus.Trace.Emulator.ContractInstance (EmulatorRuntimeError)
 
@@ -148,11 +145,7 @@ type InitialChainState = Either InitialDistribution [CardanoTx]
 
 -- | The wallets' initial funds
 initialDist :: EmulatorConfig -> InitialDistribution
-initialDist EmulatorConfig{..} = either id (walletFunds . map (Valid . signTx)) _initialChainState where
-    signTx = onCardanoTx
-      (\t -> Validation.fromPlutusTxSigned _params cUtxoIndex t CW.knownPaymentKeys)
-      CardanoApiTx
-    cUtxoIndex = either (error . show) id $ fromPlutusIndex mempty
+initialDist EmulatorConfig{..} = either id (walletFunds . map Valid) _initialChainState where
     walletFunds :: Block -> Map Wallet C.Value
     walletFunds theBlock =
         let values = AM.values $ AM.fromChain [theBlock]
@@ -171,11 +164,7 @@ initialState EmulatorConfig{..} = let
           (error . ("Cannot build the initial state: " <>) . show)
           id
           . EM.emulatorStateInitialDist _params . Map.mapKeys EM.mockWalletPaymentPubKeyHash
-    signTx = onCardanoTx
-          (\t -> Validation.fromPlutusTxSigned _params cUtxoIndex t CW.knownPaymentKeys)
-          CardanoApiTx
-    cUtxoIndex = either (error . show) id $ fromPlutusIndex mempty
-    in either withInitialWalletValues (EM.emulatorStatePool . map signTx) _initialChainState
+    in either withInitialWalletValues (EM.emulatorStatePool) _initialChainState
 
 
 data EmulatorErr =

--- a/plutus-contract/src/Wallet/Emulator/Types.hs
+++ b/plutus-contract/src/Wallet/Emulator/Types.hs
@@ -20,7 +20,6 @@ module Wallet.Emulator.Types(
     Wallet.Emulator.Wallet.mockWalletAddress,
     Wallet.Emulator.Wallet.mockWalletPaymentPubKey,
     Wallet.Emulator.Wallet.mockWalletPaymentPubKeyHash,
-    addSignature,
     Wallet.Emulator.Wallet.knownWallets,
     Wallet.Emulator.Wallet.knownWallet,
     Ledger.CardanoWallet.WalletNumber(..),
@@ -74,7 +73,6 @@ import Control.Monad.Freer.Extras.Log (LogMsg, mapLog)
 import Control.Monad.Freer.State (State)
 
 import Cardano.Node.Emulator.Params (Params)
-import Ledger (addSignature)
 import Plutus.ChainIndex (ChainIndexError)
 import Wallet.API (WalletAPIError)
 

--- a/plutus-contract/src/Wallet/Emulator/Wallet.hs
+++ b/plutus-contract/src/Wallet/Emulator/Wallet.hs
@@ -23,7 +23,6 @@
 
 module Wallet.Emulator.Wallet where
 
-import Cardano.Api (makeSignedTransaction)
 import Cardano.Api qualified as C
 import Cardano.Node.Emulator.Chain (ChainState (_index))
 import Cardano.Node.Emulator.Fee qualified as Fee
@@ -48,7 +47,6 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map qualified as Map
 import Data.Maybe (catMaybes, fromMaybe)
-import Data.Set qualified as Set
 import Data.String (IsString (fromString))
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
@@ -307,12 +305,10 @@ handleBalance ::
     => UnbalancedTx
     -> Eff effs CardanoTx
 handleBalance utx = do
-    params@Params { pNetworkId, emulatorPParams } <- getClientParams
+    params@Params { pNetworkId } <- getClientParams
     utxo <- get >>= ownOutputs
     mappedUtxo <- either (throwError . WAPI.ToCardanoError) pure $ traverse (Tx.toTxOut pNetworkId) utxo
-    let eitherTx = U.unBalancedTxTx utx
-        requiredSigners = Set.toList (U.unBalancedTxRequiredSignatories utx)
-    unbalancedBodyContent <- either pure (handleError eitherTx . first Right . CardanoAPI.toCardanoTxBodyContent pNetworkId emulatorPParams requiredSigners) eitherTx
+    let unbalancedBodyContent = U.unBalancedCardanoBuildTx utx
     ownAddr <- gets ownAddress
     -- filter out inputs from utxo that are already in unBalancedTx
     let inputsOutRefs = map Tx.txInRef $ Tx.getTxBodyContentInputs $ CardanoAPI.getCardanoBuildTx unbalancedBodyContent
@@ -322,18 +318,17 @@ handleBalance utx = do
         params
         (UtxoIndex $ U.unBalancedTxUtxoIndex utx)
         ownAddr
-        (handleBalancingError eitherTx . Fee.utxoProviderFromWalletOutputs filteredUtxo)
-        (handleError eitherTx . Left)
+        (handleBalancingError utx . Fee.utxoProviderFromWalletOutputs filteredUtxo)
+        (handleError utx . Left)
         unbalancedBodyContent
     pure $ Tx.CardanoApiTx (Tx.CardanoApiEmulatorEraTx cTx)
     where
-        handleError tx (Left (Left (ph, ve))) = do
+        handleError utx' (Left (Left (ph, ve))) = do
             tx' <- either (throwError . WAPI.ToCardanoError)
                            pure
-                 $ either (fmap (Tx.CardanoApiTx . Tx.CardanoApiEmulatorEraTx . makeSignedTransaction [])
-                          . CardanoAPI.makeTransactionBody Nothing mempty)
-                          (pure . Tx.EmulatorTx)
-                 $ tx
+                 $ fmap (Tx.CardanoApiTx . Tx.CardanoApiEmulatorEraTx . C.makeSignedTransaction [])
+                          . CardanoAPI.makeTransactionBody Nothing mempty
+                 $ U.unBalancedCardanoBuildTx utx'
             logWarn $ ValidationFailed ph (Ledger.getCardanoTxId tx') tx' ve mempty []
             throwError $ WAPI.ValidationError ve
         handleError _ (Left (Right ce)) = throwError $ WAPI.ToCardanoError ce
@@ -342,7 +337,7 @@ handleBalance utx = do
             $ T.unwords
                 [ "Total:", T.pack $ show total
                 , "expected:", T.pack $ show expected ]
-        handleBalancingError tx (Left (Fee.CardanoLedgerError e)) = handleError tx (Left e)
+        handleBalancingError utx' (Left (Fee.CardanoLedgerError e)) = handleError utx' (Left e)
         handleBalancingError _ (Right v) = pure v
 
 handleAddSignature ::
@@ -351,17 +346,14 @@ handleAddSignature ::
     )
     => CardanoTx
     -> Eff effs CardanoTx
-handleAddSignature tx = do
+handleAddSignature tx@(Tx.CardanoApiTx (Tx.CardanoApiEmulatorEraTx ctx)) = do
     msp <- gets _signingProcess
     case msp of
         Nothing -> do
             PaymentPrivateKey privKey <- gets ownPaymentPrivateKey
             pure $ Tx.addCardanoTxSignature privKey tx
         Just (SigningProcess sp) -> do
-            let ctx = case tx of
-                    Tx.CardanoApiTx (Tx.CardanoApiEmulatorEraTx ctx') -> ctx'
-                    _ -> error "handleAddSignature: Need a Cardano API Tx from the Alonzo era to get the required signers"
-                reqSigners = getRequiredSigners ctx
+            let reqSigners = getRequiredSigners ctx
             sp reqSigners tx
 
 ownOutputs :: forall effs.

--- a/plutus-contract/src/Wallet/Emulator/Wallet.hs
+++ b/plutus-contract/src/Wallet/Emulator/Wallet.hs
@@ -321,12 +321,12 @@ handleBalance utx = do
         (handleBalancingError utx . Fee.utxoProviderFromWalletOutputs filteredUtxo)
         (handleError utx . Left)
         unbalancedBodyContent
-    pure $ Tx.CardanoApiTx (Tx.CardanoApiEmulatorEraTx cTx)
+    pure $ Tx.CardanoTx (Tx.CardanoApiEmulatorEraTx cTx)
     where
         handleError utx' (Left (Left (ph, ve))) = do
             tx' <- either (throwError . WAPI.ToCardanoError)
                            pure
-                 $ fmap (Tx.CardanoApiTx . Tx.CardanoApiEmulatorEraTx . C.makeSignedTransaction [])
+                 $ fmap (Tx.CardanoTx . Tx.CardanoApiEmulatorEraTx . C.makeSignedTransaction [])
                           . CardanoAPI.makeTransactionBody Nothing mempty
                  $ U.unBalancedCardanoBuildTx utx'
             logWarn $ ValidationFailed ph (Ledger.getCardanoTxId tx') tx' ve mempty []
@@ -346,7 +346,7 @@ handleAddSignature ::
     )
     => CardanoTx
     -> Eff effs CardanoTx
-handleAddSignature tx@(Tx.CardanoApiTx (Tx.CardanoApiEmulatorEraTx ctx)) = do
+handleAddSignature tx@(Tx.CardanoTx (Tx.CardanoApiEmulatorEraTx ctx)) = do
     msp <- gets _signingProcess
     case msp of
         Nothing -> do

--- a/plutus-contract/src/Wallet/Emulator/Wallet.hs
+++ b/plutus-contract/src/Wallet/Emulator/Wallet.hs
@@ -321,12 +321,12 @@ handleBalance utx = do
         (handleBalancingError utx . Fee.utxoProviderFromWalletOutputs filteredUtxo)
         (handleError utx . Left)
         unbalancedBodyContent
-    pure $ Tx.CardanoTx (Tx.CardanoApiEmulatorEraTx cTx)
+    pure $ Tx.CardanoEmulatorEraTx cTx
     where
         handleError utx' (Left (Left (ph, ve))) = do
             tx' <- either (throwError . WAPI.ToCardanoError)
                            pure
-                 $ fmap (Tx.CardanoTx . Tx.CardanoApiEmulatorEraTx . C.makeSignedTransaction [])
+                 $ fmap (Tx.CardanoEmulatorEraTx . C.makeSignedTransaction [])
                           . CardanoAPI.makeTransactionBody Nothing mempty
                  $ U.unBalancedCardanoBuildTx utx'
             logWarn $ ValidationFailed ph (Ledger.getCardanoTxId tx') tx' ve mempty []
@@ -346,7 +346,7 @@ handleAddSignature ::
     )
     => CardanoTx
     -> Eff effs CardanoTx
-handleAddSignature tx@(Tx.CardanoTx (Tx.CardanoApiEmulatorEraTx ctx)) = do
+handleAddSignature tx@(Tx.CardanoEmulatorEraTx ctx) = do
     msp <- gets _signingProcess
     case msp of
         Nothing -> do

--- a/plutus-contract/test/Spec/Contract.hs
+++ b/plutus-contract/test/Spec/Contract.hs
@@ -249,7 +249,7 @@ tests =
         , let submitTxConstraintsWith sl constraints = do
                 unbalancedTx <- mkTxConstraints @Void sl constraints
                 tx <- balanceTx unbalancedTx
-                submitBalancedTx $ Ledger.CardanoApiTx $ tx ^?! Ledger.cardanoApiTx
+                submitBalancedTx $ Ledger.CardanoTx $ tx ^?! Ledger.cardanoTx
               c :: Contract [TxOutStatus] Schema ContractError () = do
                 -- Submit a payment tx of 10 lovelace to W2.
                 let w2PubKeyHash = mockWalletPaymentPubKeyHash w2

--- a/plutus-contract/test/Spec/Contract.hs
+++ b/plutus-contract/test/Spec/Contract.hs
@@ -392,7 +392,6 @@ type Schema =
         .\/ Endpoint "4" Int
         .\/ Endpoint "ep" ()
         .\/ Endpoint "5" [ActiveEndpoint]
-        .\/ Endpoint "6" Ledger.Tx
 
 initial :: _
 initial = State.initialiseContract loopCheckpointContract

--- a/plutus-contract/test/Spec/Contract.hs
+++ b/plutus-contract/test/Spec/Contract.hs
@@ -249,7 +249,7 @@ tests =
         , let submitTxConstraintsWith sl constraints = do
                 unbalancedTx <- mkTxConstraints @Void sl constraints
                 tx <- balanceTx unbalancedTx
-                submitBalancedTx $ Ledger.CardanoTx $ tx ^?! Ledger.cardanoTx
+                submitBalancedTx tx
               c :: Contract [TxOutStatus] Schema ContractError () = do
                 -- Submit a payment tx of 10 lovelace to W2.
                 let w2PubKeyHash = mockWalletPaymentPubKeyHash w2

--- a/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions.txt
@@ -11,16 +11,16 @@
 [DEBUG] Slot 0: Thread 11 {block maker}: Started (Normal)
 [INFO] Slot 0: TxnValidate 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84 [  ]
 [DEBUG] Slot 0: SlotAdd Slot 1
-[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
 [DEBUG] Slot 1: W[1]: Adjusting an unbalanced transaction: []
 [INFO] Slot 1: W[1]: Balancing an unbalanced transaction:
                        Tx:
@@ -61,16 +61,16 @@
 [INFO] Slot 1: W[1]: TxSubmit: 38fbe171e83c33581a737d0d1efa064afe389c8d49049e609a8ea311738a834e
 [INFO] Slot 1: TxnValidate 38fbe171e83c33581a737d0d1efa064afe389c8d49049e609a8ea311738a834e [  ]
 [DEBUG] Slot 1: SlotAdd Slot 2
-[DEBUG] Slot 2: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId c7e6a8921696ca0bed1e8968643ed7d73508379416804ce0d2d332f711ccf8b0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId c7e6a8921696ca0bed1e8968643ed7d73508379416804ce0d2d332f711ccf8b0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId c7e6a8921696ca0bed1e8968643ed7d73508379416804ce0d2d332f711ccf8b0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId c7e6a8921696ca0bed1e8968643ed7d73508379416804ce0d2d332f711ccf8b0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId c7e6a8921696ca0bed1e8968643ed7d73508379416804ce0d2d332f711ccf8b0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId c7e6a8921696ca0bed1e8968643ed7d73508379416804ce0d2d332f711ccf8b0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId c7e6a8921696ca0bed1e8968643ed7d73508379416804ce0d2d332f711ccf8b0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId c7e6a8921696ca0bed1e8968643ed7d73508379416804ce0d2d332f711ccf8b0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId c7e6a8921696ca0bed1e8968643ed7d73508379416804ce0d2d332f711ccf8b0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId c7e6a8921696ca0bed1e8968643ed7d73508379416804ce0d2d332f711ccf8b0, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
 [DEBUG] Slot 2: W[2]: Adjusting an unbalanced transaction: []
 [INFO] Slot 2: W[2]: Balancing an unbalanced transaction:
                        Tx:
@@ -111,16 +111,16 @@
 [INFO] Slot 2: W[2]: TxSubmit: 414d8f64e6635c954140ef931593457551fd9ede478ea420327afe8e72e0d7fd
 [INFO] Slot 2: TxnValidate 414d8f64e6635c954140ef931593457551fd9ede478ea420327afe8e72e0d7fd [  ]
 [DEBUG] Slot 2: SlotAdd Slot 3
-[DEBUG] Slot 3: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 4b956a1972508b687649a9ff2ee558a88eb64e913b0cac3fd4c496d775ed4dd9, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 4b956a1972508b687649a9ff2ee558a88eb64e913b0cac3fd4c496d775ed4dd9, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 4b956a1972508b687649a9ff2ee558a88eb64e913b0cac3fd4c496d775ed4dd9, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 4b956a1972508b687649a9ff2ee558a88eb64e913b0cac3fd4c496d775ed4dd9, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 4b956a1972508b687649a9ff2ee558a88eb64e913b0cac3fd4c496d775ed4dd9, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 4b956a1972508b687649a9ff2ee558a88eb64e913b0cac3fd4c496d775ed4dd9, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 4b956a1972508b687649a9ff2ee558a88eb64e913b0cac3fd4c496d775ed4dd9, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 4b956a1972508b687649a9ff2ee558a88eb64e913b0cac3fd4c496d775ed4dd9, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 4b956a1972508b687649a9ff2ee558a88eb64e913b0cac3fd4c496d775ed4dd9, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 4b956a1972508b687649a9ff2ee558a88eb64e913b0cac3fd4c496d775ed4dd9, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
 [DEBUG] Slot 3: W[3]: Adjusting an unbalanced transaction: []
 [INFO] Slot 3: W[3]: Balancing an unbalanced transaction:
                        Tx:
@@ -161,16 +161,16 @@
 [INFO] Slot 3: W[3]: TxSubmit: 58e57298a394aaa1efb22497deda184eb8ade83afe3ff1ce1032f07e42dc289f
 [INFO] Slot 3: TxnValidate 58e57298a394aaa1efb22497deda184eb8ade83afe3ff1ce1032f07e42dc289f [  ]
 [DEBUG] Slot 3: SlotAdd Slot 4
-[DEBUG] Slot 4: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8dc3826de52999ed3c5a70264aa01983656e10345596bfe3d96e495ec5a89aa0, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8dc3826de52999ed3c5a70264aa01983656e10345596bfe3d96e495ec5a89aa0, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8dc3826de52999ed3c5a70264aa01983656e10345596bfe3d96e495ec5a89aa0, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8dc3826de52999ed3c5a70264aa01983656e10345596bfe3d96e495ec5a89aa0, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8dc3826de52999ed3c5a70264aa01983656e10345596bfe3d96e495ec5a89aa0, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8dc3826de52999ed3c5a70264aa01983656e10345596bfe3d96e495ec5a89aa0, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8dc3826de52999ed3c5a70264aa01983656e10345596bfe3d96e495ec5a89aa0, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8dc3826de52999ed3c5a70264aa01983656e10345596bfe3d96e495ec5a89aa0, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8dc3826de52999ed3c5a70264aa01983656e10345596bfe3d96e495ec5a89aa0, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8dc3826de52999ed3c5a70264aa01983656e10345596bfe3d96e495ec5a89aa0, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
 [DEBUG] Slot 4: SlotAdd Slot 5
 [DEBUG] Slot 5: W[7]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.
 [DEBUG] Slot 5: W[8]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.

--- a/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions.txt
@@ -9,18 +9,18 @@
 [DEBUG] Slot 0: Thread 9 {W c30efb78b4e272685c1f9f0c93787fd4b6743154}: Started (Normal)
 [DEBUG] Slot 0: Thread 10 {W d3eddd0d37989746b029a0e050386bc425363901}: Started (Normal)
 [DEBUG] Slot 0: Thread 11 {block maker}: Started (Normal)
-[INFO] Slot 0: TxnValidate 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84 [  ]
+[INFO] Slot 0: TxnValidate d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d [  ]
 [DEBUG] Slot 0: SlotAdd Slot 1
-[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
 [DEBUG] Slot 1: W[1]: Adjusting an unbalanced transaction: []
 [INFO] Slot 1: W[1]: Balancing an unbalanced transaction:
                        Tx:
@@ -40,9 +40,9 @@
                          "a2c20c77887ace1cd986193e4e75babd8993cfd56995cd5cfce609c2"
                        Utxo index:
 [INFO] Slot 1: W[1]: Finished balancing:
-                       Tx 38fbe171e83c33581a737d0d1efa064afe389c8d49049e609a8ea311738a834e:
+                       Tx 2e19f40cdf462444234d0de049163d5269ee1150feda868560315346dd12807d:
                          {inputs:
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!50
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!50
 
                          reference inputs:
                          collateral inputs:
@@ -56,21 +56,21 @@
                          validity range: Interval {ivFrom = LowerBound NegInf True, ivTo = UpperBound PosInf True}
                          data:
                          redeemers:}
-[INFO] Slot 1: W[1]: Signing tx: 38fbe171e83c33581a737d0d1efa064afe389c8d49049e609a8ea311738a834e
-[INFO] Slot 1: W[1]: Submitting tx: 38fbe171e83c33581a737d0d1efa064afe389c8d49049e609a8ea311738a834e
-[INFO] Slot 1: W[1]: TxSubmit: 38fbe171e83c33581a737d0d1efa064afe389c8d49049e609a8ea311738a834e
-[INFO] Slot 1: TxnValidate 38fbe171e83c33581a737d0d1efa064afe389c8d49049e609a8ea311738a834e [  ]
+[INFO] Slot 1: W[1]: Signing tx: 2e19f40cdf462444234d0de049163d5269ee1150feda868560315346dd12807d
+[INFO] Slot 1: W[1]: Submitting tx: 2e19f40cdf462444234d0de049163d5269ee1150feda868560315346dd12807d
+[INFO] Slot 1: W[1]: TxSubmit: 2e19f40cdf462444234d0de049163d5269ee1150feda868560315346dd12807d
+[INFO] Slot 1: TxnValidate 2e19f40cdf462444234d0de049163d5269ee1150feda868560315346dd12807d [  ]
 [DEBUG] Slot 1: SlotAdd Slot 2
-[DEBUG] Slot 2: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 97741ad19a5f5a5262246a4da2c7f499a00d740d6a3e48011e453538d0076ae3, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
 [DEBUG] Slot 2: W[2]: Adjusting an unbalanced transaction: []
 [INFO] Slot 2: W[2]: Balancing an unbalanced transaction:
                        Tx:
@@ -90,9 +90,9 @@
                          "80a4f45b56b88d1139da23bc4c3c75ec6d32943c087f250b86193ca7"
                        Utxo index:
 [INFO] Slot 2: W[2]: Finished balancing:
-                       Tx 414d8f64e6635c954140ef931593457551fd9ede478ea420327afe8e72e0d7fd:
+                       Tx 741f455cedc5326a75267c0d93d87c3ff74c7f978bf3a67250b61fb84949a7c8:
                          {inputs:
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!20
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!20
 
                          reference inputs:
                          collateral inputs:
@@ -106,21 +106,21 @@
                          validity range: Interval {ivFrom = LowerBound NegInf True, ivTo = UpperBound PosInf True}
                          data:
                          redeemers:}
-[INFO] Slot 2: W[2]: Signing tx: 414d8f64e6635c954140ef931593457551fd9ede478ea420327afe8e72e0d7fd
-[INFO] Slot 2: W[2]: Submitting tx: 414d8f64e6635c954140ef931593457551fd9ede478ea420327afe8e72e0d7fd
-[INFO] Slot 2: W[2]: TxSubmit: 414d8f64e6635c954140ef931593457551fd9ede478ea420327afe8e72e0d7fd
-[INFO] Slot 2: TxnValidate 414d8f64e6635c954140ef931593457551fd9ede478ea420327afe8e72e0d7fd [  ]
+[INFO] Slot 2: W[2]: Signing tx: 741f455cedc5326a75267c0d93d87c3ff74c7f978bf3a67250b61fb84949a7c8
+[INFO] Slot 2: W[2]: Submitting tx: 741f455cedc5326a75267c0d93d87c3ff74c7f978bf3a67250b61fb84949a7c8
+[INFO] Slot 2: W[2]: TxSubmit: 741f455cedc5326a75267c0d93d87c3ff74c7f978bf3a67250b61fb84949a7c8
+[INFO] Slot 2: TxnValidate 741f455cedc5326a75267c0d93d87c3ff74c7f978bf3a67250b61fb84949a7c8 [  ]
 [DEBUG] Slot 2: SlotAdd Slot 3
-[DEBUG] Slot 3: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId b6e27960279d74d8f502b75c8b73a7e5161a3f3cd63781df388e9a0bfd098ab2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
 [DEBUG] Slot 3: W[3]: Adjusting an unbalanced transaction: []
 [INFO] Slot 3: W[3]: Balancing an unbalanced transaction:
                        Tx:
@@ -140,9 +140,9 @@
                          "2e0ad60c3207248cecd47dbde3d752e0aad141d6b8f81ac2c6eca27c"
                        Utxo index:
 [INFO] Slot 3: W[3]: Finished balancing:
-                       Tx 58e57298a394aaa1efb22497deda184eb8ade83afe3ff1ce1032f07e42dc289f:
+                       Tx ddd710ab33c2d46b0955e4844f706489cdac452163f4662747bf3c5611818634:
                          {inputs:
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!0
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!0
 
                          reference inputs:
                          collateral inputs:
@@ -156,21 +156,21 @@
                          validity range: Interval {ivFrom = LowerBound NegInf True, ivTo = UpperBound PosInf True}
                          data:
                          redeemers:}
-[INFO] Slot 3: W[3]: Signing tx: 58e57298a394aaa1efb22497deda184eb8ade83afe3ff1ce1032f07e42dc289f
-[INFO] Slot 3: W[3]: Submitting tx: 58e57298a394aaa1efb22497deda184eb8ade83afe3ff1ce1032f07e42dc289f
-[INFO] Slot 3: W[3]: TxSubmit: 58e57298a394aaa1efb22497deda184eb8ade83afe3ff1ce1032f07e42dc289f
-[INFO] Slot 3: TxnValidate 58e57298a394aaa1efb22497deda184eb8ade83afe3ff1ce1032f07e42dc289f [  ]
+[INFO] Slot 3: W[3]: Signing tx: ddd710ab33c2d46b0955e4844f706489cdac452163f4662747bf3c5611818634
+[INFO] Slot 3: W[3]: Submitting tx: ddd710ab33c2d46b0955e4844f706489cdac452163f4662747bf3c5611818634
+[INFO] Slot 3: W[3]: TxSubmit: ddd710ab33c2d46b0955e4844f706489cdac452163f4662747bf3c5611818634
+[INFO] Slot 3: TxnValidate ddd710ab33c2d46b0955e4844f706489cdac452163f4662747bf3c5611818634 [  ]
 [DEBUG] Slot 3: SlotAdd Slot 4
-[DEBUG] Slot 4: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId b4fb1a8bf111a2a0055cc9b0fbc3637d81b1055aeda0651ba8e7eeb29b3965bc, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
 [DEBUG] Slot 4: SlotAdd Slot 5
 [DEBUG] Slot 5: W[7]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.
 [DEBUG] Slot 5: W[8]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.

--- a/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions.txt
@@ -11,16 +11,16 @@
 [DEBUG] Slot 0: Thread 11 {block maker}: Started (Normal)
 [INFO] Slot 0: TxnValidate d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d [  ]
 [DEBUG] Slot 0: SlotAdd Slot 1
-[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
 [DEBUG] Slot 1: W[1]: Adjusting an unbalanced transaction: []
 [INFO] Slot 1: W[1]: Balancing an unbalanced transaction:
                        Tx:
@@ -61,16 +61,16 @@
 [INFO] Slot 1: W[1]: TxSubmit: 2e19f40cdf462444234d0de049163d5269ee1150feda868560315346dd12807d
 [INFO] Slot 1: TxnValidate 2e19f40cdf462444234d0de049163d5269ee1150feda868560315346dd12807d [  ]
 [DEBUG] Slot 1: SlotAdd Slot 2
-[DEBUG] Slot 2: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 32c9ad5aa43bb00c48d2a02368b9b5e1b59f52767209bd6b83bd42e32d7d555d, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId ff1f5db9015da8ba2e68ff2205fb77fa37beae55b4d51761e5516877817ea207, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId ff1f5db9015da8ba2e68ff2205fb77fa37beae55b4d51761e5516877817ea207, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId ff1f5db9015da8ba2e68ff2205fb77fa37beae55b4d51761e5516877817ea207, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId ff1f5db9015da8ba2e68ff2205fb77fa37beae55b4d51761e5516877817ea207, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId ff1f5db9015da8ba2e68ff2205fb77fa37beae55b4d51761e5516877817ea207, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId ff1f5db9015da8ba2e68ff2205fb77fa37beae55b4d51761e5516877817ea207, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId ff1f5db9015da8ba2e68ff2205fb77fa37beae55b4d51761e5516877817ea207, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId ff1f5db9015da8ba2e68ff2205fb77fa37beae55b4d51761e5516877817ea207, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId ff1f5db9015da8ba2e68ff2205fb77fa37beae55b4d51761e5516877817ea207, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId ff1f5db9015da8ba2e68ff2205fb77fa37beae55b4d51761e5516877817ea207, BlockNumber 1). UTxO state was added to the end.
 [DEBUG] Slot 2: W[2]: Adjusting an unbalanced transaction: []
 [INFO] Slot 2: W[2]: Balancing an unbalanced transaction:
                        Tx:
@@ -111,16 +111,16 @@
 [INFO] Slot 2: W[2]: TxSubmit: 741f455cedc5326a75267c0d93d87c3ff74c7f978bf3a67250b61fb84949a7c8
 [INFO] Slot 2: TxnValidate 741f455cedc5326a75267c0d93d87c3ff74c7f978bf3a67250b61fb84949a7c8 [  ]
 [DEBUG] Slot 2: SlotAdd Slot 3
-[DEBUG] Slot 3: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 53a520d4e4f2be20790608bc598e71e055bc3f26c57ffabe39b7c77b18c0e2ea, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId f83e25ea62cfa399e69b778e67ffc11113db8c668d460b22ef25e34231ebd0f2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId f83e25ea62cfa399e69b778e67ffc11113db8c668d460b22ef25e34231ebd0f2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId f83e25ea62cfa399e69b778e67ffc11113db8c668d460b22ef25e34231ebd0f2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId f83e25ea62cfa399e69b778e67ffc11113db8c668d460b22ef25e34231ebd0f2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId f83e25ea62cfa399e69b778e67ffc11113db8c668d460b22ef25e34231ebd0f2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId f83e25ea62cfa399e69b778e67ffc11113db8c668d460b22ef25e34231ebd0f2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId f83e25ea62cfa399e69b778e67ffc11113db8c668d460b22ef25e34231ebd0f2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId f83e25ea62cfa399e69b778e67ffc11113db8c668d460b22ef25e34231ebd0f2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId f83e25ea62cfa399e69b778e67ffc11113db8c668d460b22ef25e34231ebd0f2, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId f83e25ea62cfa399e69b778e67ffc11113db8c668d460b22ef25e34231ebd0f2, BlockNumber 2). UTxO state was added to the end.
 [DEBUG] Slot 3: W[3]: Adjusting an unbalanced transaction: []
 [INFO] Slot 3: W[3]: Balancing an unbalanced transaction:
                        Tx:
@@ -161,16 +161,16 @@
 [INFO] Slot 3: W[3]: TxSubmit: ddd710ab33c2d46b0955e4844f706489cdac452163f4662747bf3c5611818634
 [INFO] Slot 3: TxnValidate ddd710ab33c2d46b0955e4844f706489cdac452163f4662747bf3c5611818634 [  ]
 [DEBUG] Slot 3: SlotAdd Slot 4
-[DEBUG] Slot 4: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 5fcfb7689e076122310ffca02d2b6264333f23cc756f764f1d2c18a0c158a27c, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 446303a8496ba8d45c2118218d2efaf51c6b851b86c12db3fa776505727e1b62, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 446303a8496ba8d45c2118218d2efaf51c6b851b86c12db3fa776505727e1b62, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 446303a8496ba8d45c2118218d2efaf51c6b851b86c12db3fa776505727e1b62, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 446303a8496ba8d45c2118218d2efaf51c6b851b86c12db3fa776505727e1b62, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 446303a8496ba8d45c2118218d2efaf51c6b851b86c12db3fa776505727e1b62, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 446303a8496ba8d45c2118218d2efaf51c6b851b86c12db3fa776505727e1b62, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 446303a8496ba8d45c2118218d2efaf51c6b851b86c12db3fa776505727e1b62, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 446303a8496ba8d45c2118218d2efaf51c6b851b86c12db3fa776505727e1b62, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 446303a8496ba8d45c2118218d2efaf51c6b851b86c12db3fa776505727e1b62, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 446303a8496ba8d45c2118218d2efaf51c6b851b86c12db3fa776505727e1b62, BlockNumber 3). UTxO state was added to the end.
 [DEBUG] Slot 4: SlotAdd Slot 5
 [DEBUG] Slot 5: W[7]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.
 [DEBUG] Slot 5: W[8]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 4). UTxO state was added to the end.

--- a/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions2.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions2.txt
@@ -11,16 +11,16 @@
 [DEBUG] Slot 0: Thread 11 {block maker}: Started (Normal)
 [INFO] Slot 0: TxnValidate 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84 [  ]
 [DEBUG] Slot 0: SlotAdd Slot 1
-[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
 [DEBUG] Slot 1: W[1]: Adjusting an unbalanced transaction: []
 [INFO] Slot 1: W[1]: Balancing an unbalanced transaction:
                        Tx:
@@ -79,16 +79,16 @@
 [INFO] Slot 1: W[1]: TxSubmit: f27de1e5fbd1a274645a778e85974c19390b0b638918ad797de71b7a8cb7dae5
 [INFO] Slot 1: TxnValidate f27de1e5fbd1a274645a778e85974c19390b0b638918ad797de71b7a8cb7dae5 [  ]
 [DEBUG] Slot 1: SlotAdd Slot 2
-[DEBUG] Slot 2: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 25ca1d0c1ebf8ada7ea7ce4621769f4cf6292bf9df90b1d9486fb5b725be9901, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 25ca1d0c1ebf8ada7ea7ce4621769f4cf6292bf9df90b1d9486fb5b725be9901, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 25ca1d0c1ebf8ada7ea7ce4621769f4cf6292bf9df90b1d9486fb5b725be9901, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 25ca1d0c1ebf8ada7ea7ce4621769f4cf6292bf9df90b1d9486fb5b725be9901, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 25ca1d0c1ebf8ada7ea7ce4621769f4cf6292bf9df90b1d9486fb5b725be9901, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 25ca1d0c1ebf8ada7ea7ce4621769f4cf6292bf9df90b1d9486fb5b725be9901, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 25ca1d0c1ebf8ada7ea7ce4621769f4cf6292bf9df90b1d9486fb5b725be9901, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 25ca1d0c1ebf8ada7ea7ce4621769f4cf6292bf9df90b1d9486fb5b725be9901, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 25ca1d0c1ebf8ada7ea7ce4621769f4cf6292bf9df90b1d9486fb5b725be9901, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 25ca1d0c1ebf8ada7ea7ce4621769f4cf6292bf9df90b1d9486fb5b725be9901, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
 [DEBUG] Slot 2: W[2]: Adjusting an unbalanced transaction: []
 [INFO] Slot 2: W[2]: Balancing an unbalanced transaction:
                        Tx:
@@ -135,16 +135,16 @@
 [INFO] Slot 2: W[2]: TxSubmit: 58acb02a2c306546d145079a99ff90303e03718f0275dfdd625d28cbbbea4410
 [INFO] Slot 2: TxnValidate 58acb02a2c306546d145079a99ff90303e03718f0275dfdd625d28cbbbea4410 [  ]
 [DEBUG] Slot 2: SlotAdd Slot 3
-[DEBUG] Slot 3: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 534989ac88c07c75d16deca30d086532a6d0a2af41a03750c45fffb3ea00cd40, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 534989ac88c07c75d16deca30d086532a6d0a2af41a03750c45fffb3ea00cd40, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 534989ac88c07c75d16deca30d086532a6d0a2af41a03750c45fffb3ea00cd40, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 534989ac88c07c75d16deca30d086532a6d0a2af41a03750c45fffb3ea00cd40, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 534989ac88c07c75d16deca30d086532a6d0a2af41a03750c45fffb3ea00cd40, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 534989ac88c07c75d16deca30d086532a6d0a2af41a03750c45fffb3ea00cd40, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 534989ac88c07c75d16deca30d086532a6d0a2af41a03750c45fffb3ea00cd40, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 534989ac88c07c75d16deca30d086532a6d0a2af41a03750c45fffb3ea00cd40, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 534989ac88c07c75d16deca30d086532a6d0a2af41a03750c45fffb3ea00cd40, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 534989ac88c07c75d16deca30d086532a6d0a2af41a03750c45fffb3ea00cd40, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
 [DEBUG] Slot 3: W[3]: Adjusting an unbalanced transaction: []
 [INFO] Slot 3: W[3]: Balancing an unbalanced transaction:
                        Tx:
@@ -187,16 +187,16 @@
 [INFO] Slot 3: W[3]: TxSubmit: 13107325fe84a3d9b7b6acc810f2d2ddc83345f63be62cbf38fb8c29ec44a6a9
 [INFO] Slot 3: TxnValidate 13107325fe84a3d9b7b6acc810f2d2ddc83345f63be62cbf38fb8c29ec44a6a9 [  ]
 [DEBUG] Slot 3: SlotAdd Slot 4
-[DEBUG] Slot 4: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 48bea9d9f4dfe0bd56c69bb10d60df8e609141c24e8644ebaf56f49d863aa1a1, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 48bea9d9f4dfe0bd56c69bb10d60df8e609141c24e8644ebaf56f49d863aa1a1, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 48bea9d9f4dfe0bd56c69bb10d60df8e609141c24e8644ebaf56f49d863aa1a1, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 48bea9d9f4dfe0bd56c69bb10d60df8e609141c24e8644ebaf56f49d863aa1a1, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 48bea9d9f4dfe0bd56c69bb10d60df8e609141c24e8644ebaf56f49d863aa1a1, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 48bea9d9f4dfe0bd56c69bb10d60df8e609141c24e8644ebaf56f49d863aa1a1, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 48bea9d9f4dfe0bd56c69bb10d60df8e609141c24e8644ebaf56f49d863aa1a1, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 48bea9d9f4dfe0bd56c69bb10d60df8e609141c24e8644ebaf56f49d863aa1a1, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 48bea9d9f4dfe0bd56c69bb10d60df8e609141c24e8644ebaf56f49d863aa1a1, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 48bea9d9f4dfe0bd56c69bb10d60df8e609141c24e8644ebaf56f49d863aa1a1, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
 [DEBUG] Slot 4: W[1]: Adjusting an unbalanced transaction: []
 [INFO] Slot 4: W[1]: Balancing an unbalanced transaction:
                        Tx:
@@ -237,16 +237,16 @@
 [INFO] Slot 4: W[1]: TxSubmit: 0c2f86bb3b8de2e696833433420e7d1ac77816bcf08114169916ba53115c2574
 [INFO] Slot 4: TxnValidate 0c2f86bb3b8de2e696833433420e7d1ac77816bcf08114169916ba53115c2574 [  ]
 [DEBUG] Slot 4: SlotAdd Slot 5
-[DEBUG] Slot 5: W[7]: InsertionSuccess: New tip is Tip(Slot 5, BlockId c471d7167404089f59fe6a28a9d0a51f0d03d12da59e68ff204f0e2dcbb6987d, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[8]: InsertionSuccess: New tip is Tip(Slot 5, BlockId c471d7167404089f59fe6a28a9d0a51f0d03d12da59e68ff204f0e2dcbb6987d, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[6]: InsertionSuccess: New tip is Tip(Slot 5, BlockId c471d7167404089f59fe6a28a9d0a51f0d03d12da59e68ff204f0e2dcbb6987d, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[4]: InsertionSuccess: New tip is Tip(Slot 5, BlockId c471d7167404089f59fe6a28a9d0a51f0d03d12da59e68ff204f0e2dcbb6987d, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[2]: InsertionSuccess: New tip is Tip(Slot 5, BlockId c471d7167404089f59fe6a28a9d0a51f0d03d12da59e68ff204f0e2dcbb6987d, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[1]: InsertionSuccess: New tip is Tip(Slot 5, BlockId c471d7167404089f59fe6a28a9d0a51f0d03d12da59e68ff204f0e2dcbb6987d, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[10]: InsertionSuccess: New tip is Tip(Slot 5, BlockId c471d7167404089f59fe6a28a9d0a51f0d03d12da59e68ff204f0e2dcbb6987d, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[9]: InsertionSuccess: New tip is Tip(Slot 5, BlockId c471d7167404089f59fe6a28a9d0a51f0d03d12da59e68ff204f0e2dcbb6987d, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[3]: InsertionSuccess: New tip is Tip(Slot 5, BlockId c471d7167404089f59fe6a28a9d0a51f0d03d12da59e68ff204f0e2dcbb6987d, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[5]: InsertionSuccess: New tip is Tip(Slot 5, BlockId c471d7167404089f59fe6a28a9d0a51f0d03d12da59e68ff204f0e2dcbb6987d, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[7]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[8]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[6]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[4]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[2]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[1]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[10]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[9]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[3]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[5]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
 [DEBUG] Slot 5: SlotAdd Slot 6
 [DEBUG] Slot 6: W[7]: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.
 [DEBUG] Slot 6: W[8]: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.

--- a/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions2.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions2.txt
@@ -9,18 +9,18 @@
 [DEBUG] Slot 0: Thread 9 {W c30efb78b4e272685c1f9f0c93787fd4b6743154}: Started (Normal)
 [DEBUG] Slot 0: Thread 10 {W d3eddd0d37989746b029a0e050386bc425363901}: Started (Normal)
 [DEBUG] Slot 0: Thread 11 {block maker}: Started (Normal)
-[INFO] Slot 0: TxnValidate 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84 [  ]
+[INFO] Slot 0: TxnValidate d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d [  ]
 [DEBUG] Slot 0: SlotAdd Slot 1
-[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
 [DEBUG] Slot 1: W[1]: Adjusting an unbalanced transaction: []
 [INFO] Slot 1: W[1]: Balancing an unbalanced transaction:
                        Tx:
@@ -40,27 +40,27 @@
                          "a2c20c77887ace1cd986193e4e75babd8993cfd56995cd5cfce609c2"
                        Utxo index:
 [INFO] Slot 1: W[1]: Finished balancing:
-                       Tx f27de1e5fbd1a274645a778e85974c19390b0b638918ad797de71b7a8cb7dae5:
+                       Tx a86d1ed2c668b7fb623b2a7ccddb4a0b43c5b4b1dd9bc1524558d44708402d95:
                          {inputs:
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!50
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!50
 
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!51
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!51
 
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!52
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!52
 
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!53
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!53
 
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!54
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!54
 
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!55
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!55
 
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!56
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!56
 
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!57
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!57
 
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!58
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!58
 
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!59
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!59
 
                          reference inputs:
                          collateral inputs:
@@ -74,21 +74,21 @@
                          validity range: Interval {ivFrom = LowerBound NegInf True, ivTo = UpperBound PosInf True}
                          data:
                          redeemers:}
-[INFO] Slot 1: W[1]: Signing tx: f27de1e5fbd1a274645a778e85974c19390b0b638918ad797de71b7a8cb7dae5
-[INFO] Slot 1: W[1]: Submitting tx: f27de1e5fbd1a274645a778e85974c19390b0b638918ad797de71b7a8cb7dae5
-[INFO] Slot 1: W[1]: TxSubmit: f27de1e5fbd1a274645a778e85974c19390b0b638918ad797de71b7a8cb7dae5
-[INFO] Slot 1: TxnValidate f27de1e5fbd1a274645a778e85974c19390b0b638918ad797de71b7a8cb7dae5 [  ]
+[INFO] Slot 1: W[1]: Signing tx: a86d1ed2c668b7fb623b2a7ccddb4a0b43c5b4b1dd9bc1524558d44708402d95
+[INFO] Slot 1: W[1]: Submitting tx: a86d1ed2c668b7fb623b2a7ccddb4a0b43c5b4b1dd9bc1524558d44708402d95
+[INFO] Slot 1: W[1]: TxSubmit: a86d1ed2c668b7fb623b2a7ccddb4a0b43c5b4b1dd9bc1524558d44708402d95
+[INFO] Slot 1: TxnValidate a86d1ed2c668b7fb623b2a7ccddb4a0b43c5b4b1dd9bc1524558d44708402d95 [  ]
 [DEBUG] Slot 1: SlotAdd Slot 2
-[DEBUG] Slot 2: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 51c0cc78451a11df48af91bd8e15dfa30ff117fdc850ed235a9c621e6abb46e0, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
 [DEBUG] Slot 2: W[2]: Adjusting an unbalanced transaction: []
 [INFO] Slot 2: W[2]: Balancing an unbalanced transaction:
                        Tx:
@@ -108,15 +108,15 @@
                          "80a4f45b56b88d1139da23bc4c3c75ec6d32943c087f250b86193ca7"
                        Utxo index:
 [INFO] Slot 2: W[2]: Finished balancing:
-                       Tx 58acb02a2c306546d145079a99ff90303e03718f0275dfdd625d28cbbbea4410:
+                       Tx 431fc62490514f82a44ee2d5d5388d11280679c4e992f6efdd87fea6039fb34a:
                          {inputs:
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!20
+                            - a86d1ed2c668b7fb623b2a7ccddb4a0b43c5b4b1dd9bc1524558d44708402d95!0
 
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!21
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!20
 
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!22
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!21
 
-                            - f27de1e5fbd1a274645a778e85974c19390b0b638918ad797de71b7a8cb7dae5!0
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!22
 
                          reference inputs:
                          collateral inputs:
@@ -130,21 +130,21 @@
                          validity range: Interval {ivFrom = LowerBound NegInf True, ivTo = UpperBound PosInf True}
                          data:
                          redeemers:}
-[INFO] Slot 2: W[2]: Signing tx: 58acb02a2c306546d145079a99ff90303e03718f0275dfdd625d28cbbbea4410
-[INFO] Slot 2: W[2]: Submitting tx: 58acb02a2c306546d145079a99ff90303e03718f0275dfdd625d28cbbbea4410
-[INFO] Slot 2: W[2]: TxSubmit: 58acb02a2c306546d145079a99ff90303e03718f0275dfdd625d28cbbbea4410
-[INFO] Slot 2: TxnValidate 58acb02a2c306546d145079a99ff90303e03718f0275dfdd625d28cbbbea4410 [  ]
+[INFO] Slot 2: W[2]: Signing tx: 431fc62490514f82a44ee2d5d5388d11280679c4e992f6efdd87fea6039fb34a
+[INFO] Slot 2: W[2]: Submitting tx: 431fc62490514f82a44ee2d5d5388d11280679c4e992f6efdd87fea6039fb34a
+[INFO] Slot 2: W[2]: TxSubmit: 431fc62490514f82a44ee2d5d5388d11280679c4e992f6efdd87fea6039fb34a
+[INFO] Slot 2: TxnValidate 431fc62490514f82a44ee2d5d5388d11280679c4e992f6efdd87fea6039fb34a [  ]
 [DEBUG] Slot 2: SlotAdd Slot 3
-[DEBUG] Slot 3: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 5279094c8135a39e36962b55ec4fb5f362a45433c8fd7a7cee7d7672743dff39, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
 [DEBUG] Slot 3: W[3]: Adjusting an unbalanced transaction: []
 [INFO] Slot 3: W[3]: Balancing an unbalanced transaction:
                        Tx:
@@ -164,11 +164,11 @@
                          "2e0ad60c3207248cecd47dbde3d752e0aad141d6b8f81ac2c6eca27c"
                        Utxo index:
 [INFO] Slot 3: W[3]: Finished balancing:
-                       Tx 13107325fe84a3d9b7b6acc810f2d2ddc83345f63be62cbf38fb8c29ec44a6a9:
+                       Tx a67c4a462aca7a7701284dccc4ca4c6ea3b576925d0849c7c18185d151a7f183:
                          {inputs:
-                            - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!0
+                            - 431fc62490514f82a44ee2d5d5388d11280679c4e992f6efdd87fea6039fb34a!0
 
-                            - 58acb02a2c306546d145079a99ff90303e03718f0275dfdd625d28cbbbea4410!0
+                            - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!0
 
                          reference inputs:
                          collateral inputs:
@@ -182,21 +182,21 @@
                          validity range: Interval {ivFrom = LowerBound NegInf True, ivTo = UpperBound PosInf True}
                          data:
                          redeemers:}
-[INFO] Slot 3: W[3]: Signing tx: 13107325fe84a3d9b7b6acc810f2d2ddc83345f63be62cbf38fb8c29ec44a6a9
-[INFO] Slot 3: W[3]: Submitting tx: 13107325fe84a3d9b7b6acc810f2d2ddc83345f63be62cbf38fb8c29ec44a6a9
-[INFO] Slot 3: W[3]: TxSubmit: 13107325fe84a3d9b7b6acc810f2d2ddc83345f63be62cbf38fb8c29ec44a6a9
-[INFO] Slot 3: TxnValidate 13107325fe84a3d9b7b6acc810f2d2ddc83345f63be62cbf38fb8c29ec44a6a9 [  ]
+[INFO] Slot 3: W[3]: Signing tx: a67c4a462aca7a7701284dccc4ca4c6ea3b576925d0849c7c18185d151a7f183
+[INFO] Slot 3: W[3]: Submitting tx: a67c4a462aca7a7701284dccc4ca4c6ea3b576925d0849c7c18185d151a7f183
+[INFO] Slot 3: W[3]: TxSubmit: a67c4a462aca7a7701284dccc4ca4c6ea3b576925d0849c7c18185d151a7f183
+[INFO] Slot 3: TxnValidate a67c4a462aca7a7701284dccc4ca4c6ea3b576925d0849c7c18185d151a7f183 [  ]
 [DEBUG] Slot 3: SlotAdd Slot 4
-[DEBUG] Slot 4: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 24a787dcdcff541da8c2502b6b2cd204f872280aa16d12994558d00288584b38, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
 [DEBUG] Slot 4: W[1]: Adjusting an unbalanced transaction: []
 [INFO] Slot 4: W[1]: Balancing an unbalanced transaction:
                        Tx:
@@ -216,9 +216,9 @@
                          "a2c20c77887ace1cd986193e4e75babd8993cfd56995cd5cfce609c2"
                        Utxo index:
 [INFO] Slot 4: W[1]: Finished balancing:
-                       Tx 0c2f86bb3b8de2e696833433420e7d1ac77816bcf08114169916ba53115c2574:
+                       Tx 0d0eb440266851eda465f3304382bc18053b57369d260d95f48217cd9ed7770e:
                          {inputs:
-                            - 13107325fe84a3d9b7b6acc810f2d2ddc83345f63be62cbf38fb8c29ec44a6a9!0
+                            - a67c4a462aca7a7701284dccc4ca4c6ea3b576925d0849c7c18185d151a7f183!0
 
                          reference inputs:
                          collateral inputs:
@@ -232,21 +232,21 @@
                          validity range: Interval {ivFrom = LowerBound NegInf True, ivTo = UpperBound PosInf True}
                          data:
                          redeemers:}
-[INFO] Slot 4: W[1]: Signing tx: 0c2f86bb3b8de2e696833433420e7d1ac77816bcf08114169916ba53115c2574
-[INFO] Slot 4: W[1]: Submitting tx: 0c2f86bb3b8de2e696833433420e7d1ac77816bcf08114169916ba53115c2574
-[INFO] Slot 4: W[1]: TxSubmit: 0c2f86bb3b8de2e696833433420e7d1ac77816bcf08114169916ba53115c2574
-[INFO] Slot 4: TxnValidate 0c2f86bb3b8de2e696833433420e7d1ac77816bcf08114169916ba53115c2574 [  ]
+[INFO] Slot 4: W[1]: Signing tx: 0d0eb440266851eda465f3304382bc18053b57369d260d95f48217cd9ed7770e
+[INFO] Slot 4: W[1]: Submitting tx: 0d0eb440266851eda465f3304382bc18053b57369d260d95f48217cd9ed7770e
+[INFO] Slot 4: W[1]: TxSubmit: 0d0eb440266851eda465f3304382bc18053b57369d260d95f48217cd9ed7770e
+[INFO] Slot 4: TxnValidate 0d0eb440266851eda465f3304382bc18053b57369d260d95f48217cd9ed7770e [  ]
 [DEBUG] Slot 4: SlotAdd Slot 5
-[DEBUG] Slot 5: W[7]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[8]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[6]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[4]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[2]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[1]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[10]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[9]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[3]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[5]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 97d5e82ddfbfbf9a5651cb9e0752458b78dbb1134956c973606288bca4733d43, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[7]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[8]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[6]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[4]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[2]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[1]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[10]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[9]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[3]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[5]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
 [DEBUG] Slot 5: SlotAdd Slot 6
 [DEBUG] Slot 6: W[7]: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.
 [DEBUG] Slot 6: W[8]: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.

--- a/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions2.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions2.txt
@@ -11,16 +11,16 @@
 [DEBUG] Slot 0: Thread 11 {block maker}: Started (Normal)
 [INFO] Slot 0: TxnValidate d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d [  ]
 [DEBUG] Slot 0: SlotAdd Slot 1
-[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
 [DEBUG] Slot 1: W[1]: Adjusting an unbalanced transaction: []
 [INFO] Slot 1: W[1]: Balancing an unbalanced transaction:
                        Tx:
@@ -79,16 +79,16 @@
 [INFO] Slot 1: W[1]: TxSubmit: a86d1ed2c668b7fb623b2a7ccddb4a0b43c5b4b1dd9bc1524558d44708402d95
 [INFO] Slot 1: TxnValidate a86d1ed2c668b7fb623b2a7ccddb4a0b43c5b4b1dd9bc1524558d44708402d95 [  ]
 [DEBUG] Slot 1: SlotAdd Slot 2
-[DEBUG] Slot 2: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
-[DEBUG] Slot 2: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 77a5b4dc2c883a7aaadf41b350d00662161fce975ca7c738c798f144f760f757, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 4b559f87e65d419b90ac8a4ae375aa6133d133ef72372decbe040a208f78ef2a, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 4b559f87e65d419b90ac8a4ae375aa6133d133ef72372decbe040a208f78ef2a, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[6]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 4b559f87e65d419b90ac8a4ae375aa6133d133ef72372decbe040a208f78ef2a, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[4]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 4b559f87e65d419b90ac8a4ae375aa6133d133ef72372decbe040a208f78ef2a, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[2]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 4b559f87e65d419b90ac8a4ae375aa6133d133ef72372decbe040a208f78ef2a, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[1]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 4b559f87e65d419b90ac8a4ae375aa6133d133ef72372decbe040a208f78ef2a, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[10]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 4b559f87e65d419b90ac8a4ae375aa6133d133ef72372decbe040a208f78ef2a, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[9]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 4b559f87e65d419b90ac8a4ae375aa6133d133ef72372decbe040a208f78ef2a, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[3]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 4b559f87e65d419b90ac8a4ae375aa6133d133ef72372decbe040a208f78ef2a, BlockNumber 1). UTxO state was added to the end.
+[DEBUG] Slot 2: W[5]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 4b559f87e65d419b90ac8a4ae375aa6133d133ef72372decbe040a208f78ef2a, BlockNumber 1). UTxO state was added to the end.
 [DEBUG] Slot 2: W[2]: Adjusting an unbalanced transaction: []
 [INFO] Slot 2: W[2]: Balancing an unbalanced transaction:
                        Tx:
@@ -135,16 +135,16 @@
 [INFO] Slot 2: W[2]: TxSubmit: 431fc62490514f82a44ee2d5d5388d11280679c4e992f6efdd87fea6039fb34a
 [INFO] Slot 2: TxnValidate 431fc62490514f82a44ee2d5d5388d11280679c4e992f6efdd87fea6039fb34a [  ]
 [DEBUG] Slot 2: SlotAdd Slot 3
-[DEBUG] Slot 3: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
-[DEBUG] Slot 3: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 82081b8c2d7785334fc9588646edb378a956d6616df517895fa7e4e4ce204ee5, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[7]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 081a929a9482d365cb13f905c0535e2ef79fab64c440235d012f1987b725224f, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[8]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 081a929a9482d365cb13f905c0535e2ef79fab64c440235d012f1987b725224f, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[6]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 081a929a9482d365cb13f905c0535e2ef79fab64c440235d012f1987b725224f, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[4]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 081a929a9482d365cb13f905c0535e2ef79fab64c440235d012f1987b725224f, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[2]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 081a929a9482d365cb13f905c0535e2ef79fab64c440235d012f1987b725224f, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[1]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 081a929a9482d365cb13f905c0535e2ef79fab64c440235d012f1987b725224f, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[10]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 081a929a9482d365cb13f905c0535e2ef79fab64c440235d012f1987b725224f, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[9]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 081a929a9482d365cb13f905c0535e2ef79fab64c440235d012f1987b725224f, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[3]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 081a929a9482d365cb13f905c0535e2ef79fab64c440235d012f1987b725224f, BlockNumber 2). UTxO state was added to the end.
+[DEBUG] Slot 3: W[5]: InsertionSuccess: New tip is Tip(Slot 3, BlockId 081a929a9482d365cb13f905c0535e2ef79fab64c440235d012f1987b725224f, BlockNumber 2). UTxO state was added to the end.
 [DEBUG] Slot 3: W[3]: Adjusting an unbalanced transaction: []
 [INFO] Slot 3: W[3]: Balancing an unbalanced transaction:
                        Tx:
@@ -187,16 +187,16 @@
 [INFO] Slot 3: W[3]: TxSubmit: a67c4a462aca7a7701284dccc4ca4c6ea3b576925d0849c7c18185d151a7f183
 [INFO] Slot 3: TxnValidate a67c4a462aca7a7701284dccc4ca4c6ea3b576925d0849c7c18185d151a7f183 [  ]
 [DEBUG] Slot 3: SlotAdd Slot 4
-[DEBUG] Slot 4: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
-[DEBUG] Slot 4: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 8364cb178e81e13b88756f7d5509c5b3dd98627d0a40abc38c8349e6381d51fd, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[7]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 99201f0f00cbfa839509d8f8918f781dd413c2f97b74b2ca47159f2f8e0481a3, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[8]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 99201f0f00cbfa839509d8f8918f781dd413c2f97b74b2ca47159f2f8e0481a3, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[6]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 99201f0f00cbfa839509d8f8918f781dd413c2f97b74b2ca47159f2f8e0481a3, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[4]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 99201f0f00cbfa839509d8f8918f781dd413c2f97b74b2ca47159f2f8e0481a3, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[2]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 99201f0f00cbfa839509d8f8918f781dd413c2f97b74b2ca47159f2f8e0481a3, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[1]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 99201f0f00cbfa839509d8f8918f781dd413c2f97b74b2ca47159f2f8e0481a3, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[10]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 99201f0f00cbfa839509d8f8918f781dd413c2f97b74b2ca47159f2f8e0481a3, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[9]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 99201f0f00cbfa839509d8f8918f781dd413c2f97b74b2ca47159f2f8e0481a3, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[3]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 99201f0f00cbfa839509d8f8918f781dd413c2f97b74b2ca47159f2f8e0481a3, BlockNumber 3). UTxO state was added to the end.
+[DEBUG] Slot 4: W[5]: InsertionSuccess: New tip is Tip(Slot 4, BlockId 99201f0f00cbfa839509d8f8918f781dd413c2f97b74b2ca47159f2f8e0481a3, BlockNumber 3). UTxO state was added to the end.
 [DEBUG] Slot 4: W[1]: Adjusting an unbalanced transaction: []
 [INFO] Slot 4: W[1]: Balancing an unbalanced transaction:
                        Tx:
@@ -237,16 +237,16 @@
 [INFO] Slot 4: W[1]: TxSubmit: 0d0eb440266851eda465f3304382bc18053b57369d260d95f48217cd9ed7770e
 [INFO] Slot 4: TxnValidate 0d0eb440266851eda465f3304382bc18053b57369d260d95f48217cd9ed7770e [  ]
 [DEBUG] Slot 4: SlotAdd Slot 5
-[DEBUG] Slot 5: W[7]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[8]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[6]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[4]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[2]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[1]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[10]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[9]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[3]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
-[DEBUG] Slot 5: W[5]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 1f508edbf382eea34fcff3db7842d4687d28ea6670d81e1c5b6844c3d3374a30, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[7]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 45fb32a35f431d1f562fced6b7a9477d36060757a32f1c5a9f0aa90ad3e39002, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[8]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 45fb32a35f431d1f562fced6b7a9477d36060757a32f1c5a9f0aa90ad3e39002, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[6]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 45fb32a35f431d1f562fced6b7a9477d36060757a32f1c5a9f0aa90ad3e39002, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[4]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 45fb32a35f431d1f562fced6b7a9477d36060757a32f1c5a9f0aa90ad3e39002, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[2]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 45fb32a35f431d1f562fced6b7a9477d36060757a32f1c5a9f0aa90ad3e39002, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[1]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 45fb32a35f431d1f562fced6b7a9477d36060757a32f1c5a9f0aa90ad3e39002, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[10]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 45fb32a35f431d1f562fced6b7a9477d36060757a32f1c5a9f0aa90ad3e39002, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[9]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 45fb32a35f431d1f562fced6b7a9477d36060757a32f1c5a9f0aa90ad3e39002, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[3]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 45fb32a35f431d1f562fced6b7a9477d36060757a32f1c5a9f0aa90ad3e39002, BlockNumber 4). UTxO state was added to the end.
+[DEBUG] Slot 5: W[5]: InsertionSuccess: New tip is Tip(Slot 5, BlockId 45fb32a35f431d1f562fced6b7a9477d36060757a32f1c5a9f0aa90ad3e39002, BlockNumber 4). UTxO state was added to the end.
 [DEBUG] Slot 5: SlotAdd Slot 6
 [DEBUG] Slot 6: W[7]: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.
 [DEBUG] Slot 6: W[8]: InsertionSuccess: New tip is Tip(Slot 6, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 5). UTxO state was added to the end.

--- a/plutus-contract/test/Spec/golden/traceOutput - wait1.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - wait1.txt
@@ -11,16 +11,16 @@
 [DEBUG] Slot 0: Thread 11 {block maker}: Started (Normal)
 [INFO] Slot 0: TxnValidate 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84 [  ]
 [DEBUG] Slot 0: SlotAdd Slot 1
-[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 9e944371f5292bcd66e4e498bbc313b92ae884154f0eca1ddf75cd0ec69ddc47, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
 [DEBUG] Slot 1: SlotAdd Slot 2
 [DEBUG] Slot 2: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.
 [DEBUG] Slot 2: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.

--- a/plutus-contract/test/Spec/golden/traceOutput - wait1.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - wait1.txt
@@ -9,18 +9,18 @@
 [DEBUG] Slot 0: Thread 9 {W c30efb78b4e272685c1f9f0c93787fd4b6743154}: Started (Normal)
 [DEBUG] Slot 0: Thread 10 {W d3eddd0d37989746b029a0e050386bc425363901}: Started (Normal)
 [DEBUG] Slot 0: Thread 11 {block maker}: Started (Normal)
-[INFO] Slot 0: TxnValidate 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84 [  ]
+[INFO] Slot 0: TxnValidate d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d [  ]
 [DEBUG] Slot 0: SlotAdd Slot 1
-[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId f21c6e2db5201d6956c39d269269777c0be9424ec4cc6243a35d74c730e98e8c, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
 [DEBUG] Slot 1: SlotAdd Slot 2
 [DEBUG] Slot 2: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.
 [DEBUG] Slot 2: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.

--- a/plutus-contract/test/Spec/golden/traceOutput - wait1.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - wait1.txt
@@ -11,16 +11,16 @@
 [DEBUG] Slot 0: Thread 11 {block maker}: Started (Normal)
 [INFO] Slot 0: TxnValidate d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d [  ]
 [DEBUG] Slot 0: SlotAdd Slot 1
-[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
-[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId 2e3c894143727f3c776925b3413788cc8f9d2efc1fa84c05df007c4ea0672537, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[7]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[8]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[6]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[4]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[2]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[1]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[10]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[9]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[3]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
+[DEBUG] Slot 1: W[5]: InsertionSuccess: New tip is Tip(Slot 1, BlockId ad9b405b2fa0a28c33a5e41d23bc1d80ddbd809b42f1f6c4f252ee133ac9f843, BlockNumber 0). UTxO state was added to the end.
 [DEBUG] Slot 1: SlotAdd Slot 2
 [DEBUG] Slot 2: W[7]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.
 [DEBUG] Slot 2: W[8]: InsertionSuccess: New tip is Tip(Slot 2, BlockId 76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71, BlockNumber 1). UTxO state was added to the end.

--- a/plutus-ledger/changelog.d/20230302_122918_ak3n_drop_emulator_tx.md
+++ b/plutus-ledger/changelog.d/20230302_122918_ak3n_drop_emulator_tx.md
@@ -1,0 +1,12 @@
+### Removed
+
+- Remove `unspentOutputsTx` and `spentOutputs`.
+- Remove `cardanoApiTx`, `emulatorTx`, `onCardanoTx`, `cardanoTxMap`, `addSignature`, `addSignature'`, `txOutRefs`, `unspentOutputsTx`, `txId`.
+- Remove `CardanoTx(EmulatorTx, CardanoApiTx)`.
+- Remove `toCardanoTxBody`, `toCardanoTxBodyContent`, `toCardanoTxInWitness`, `toCardanoMintValue`.
+- Remove `Tx` and `TxStripped` types and all related functions.
+
+### Changed
+
+- Renamed `SomeCardanoApiTx(SomeTx)` to `CardanoTx(CardanoTx`.
+- Renamed `CardanoApiEmulatorEraTx` to `CardanoEmulatorEraTx`.

--- a/plutus-ledger/changelog.d/20230302_122918_ak3n_drop_emulator_tx.md
+++ b/plutus-ledger/changelog.d/20230302_122918_ak3n_drop_emulator_tx.md
@@ -8,5 +8,5 @@
 
 ### Changed
 
-- Renamed `SomeCardanoApiTx(SomeTx)` to `CardanoTx(CardanoTx`.
+- Renamed `SomeCardanoApiTx(SomeTx)` to `CardanoTx(CardanoTx)`.
 - Renamed `CardanoApiEmulatorEraTx` to `CardanoEmulatorEraTx`.

--- a/plutus-ledger/plutus-ledger.cabal
+++ b/plutus-ledger/plutus-ledger.cabal
@@ -187,8 +187,8 @@ test-suite plutus-ledger-test
   -- Local components
   --------------------
   build-depends:
-    , plutus-ledger        >=1.0.0
-    , plutus-script-utils  >=1.0.0
+    , plutus-ledger        >=1.1.0
+    , plutus-script-utils  >=1.1.0
 
   --------------------------
   -- Other IOG dependencies
@@ -206,7 +206,6 @@ test-suite plutus-ledger-test
     , aeson
     , base            >=4.9 && <5
     , bytestring
-    , data-default
     , hedgehog
     , tasty
     , tasty-hedgehog

--- a/plutus-ledger/src/Ledger/Blockchain.hs
+++ b/plutus-ledger/src/Ledger/Blockchain.hs
@@ -23,8 +23,6 @@ module Ledger.Blockchain (
     transaction,
     out,
     value,
-    unspentOutputsTx,
-    spentOutputs,
     unspentOutputs,
     datumTxo,
     updateUtxo,
@@ -50,8 +48,8 @@ import Prettyprinter (Pretty (..), (<+>))
 
 import Cardano.Api qualified as C
 import Ledger.Tx (CardanoTx, TxId, TxIn, TxOut, TxOutRef (..), getCardanoTxCollateralInputs, getCardanoTxId,
-                  getCardanoTxInputs, getCardanoTxProducedOutputs, getCardanoTxProducedReturnCollateral, spentOutputs,
-                  txOutDatumHash, txOutPubKey, txOutValue, unspentOutputsTx, updateUtxo, updateUtxoCollateral)
+                  getCardanoTxInputs, getCardanoTxProducedOutputs, getCardanoTxProducedReturnCollateral, txOutDatumHash,
+                  txOutPubKey, txOutValue, updateUtxo, updateUtxoCollateral)
 import Plutus.V1.Ledger.Crypto
 import Plutus.V1.Ledger.Scripts
 

--- a/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
+++ b/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
@@ -21,16 +21,12 @@ module Ledger.Tx.CardanoAPI(
   , fromCardanoTxInsCollateral
   , fromCardanoTotalCollateral
   , fromCardanoReturnCollateral
-  , toCardanoTxBody
-  , toCardanoTxBodyContent
   , toCardanoTxInsCollateral
   , toCardanoTotalCollateral
   , toCardanoReturnCollateral
-  , toCardanoTxInWitness
   , toCardanoDatumWitness
   , toCardanoTxInReferenceWitnessHeader
   , toCardanoTxInScriptWitnessHeader
-  , toCardanoMintValue
   , toCardanoMintWitness
   , ToCardanoError(..)
   , FromCardanoError(..)
@@ -45,13 +41,12 @@ import Cardano.Api qualified as C
 import Cardano.Api.Shelley qualified as C
 import Cardano.Ledger.Alonzo.Tx (ValidatedTx (..))
 import Cardano.Ledger.Babbage qualified as Babbage
-import Cardano.Ledger.Babbage.PParams qualified as Babbage
 import Cardano.Ledger.Babbage.TxBody (TxBody (TxBody, reqSignerHashes))
 import Cardano.Ledger.BaseTypes (mkTxIxPartial)
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Shelley.API qualified as C.Ledger
 import Data.Bifunctor (Bifunctor (..))
-import Data.Bitraversable (bisequence, bitraverse)
+import Data.Bitraversable (bitraverse)
 import Data.Map qualified as Map
 import Ledger.Address qualified as P
 import Ledger.Index.Internal qualified as P
@@ -60,66 +55,6 @@ import Ledger.Tx.CardanoAPI.Internal
 import Ledger.Tx.Internal qualified as P
 import Plutus.V1.Ledger.Api qualified as PV1
 
-
-toCardanoTxBodyContent
-    :: C.NetworkId
-    -> Babbage.PParams (Babbage.BabbageEra StandardCrypto)
-    -> [P.PaymentPubKeyHash] -- ^ Required signers of the transaction
-    -> P.Tx
-    -> Either ToCardanoError CardanoBuildTx
-toCardanoTxBodyContent networkId protocolParams sigs tx@P.Tx{..} = do
-    -- TODO: translate all fields
-    txIns <- traverse (toCardanoTxInBuild tx) txInputs
-    txInsReference <- traverse (toCardanoTxIn . P.txInputRef) txReferenceInputs
-    txInsCollateral <- toCardanoTxInsCollateral txCollateralInputs
-    let txOuts = P.getTxOut <$> txOutputs
-    let returnCollateral = toCardanoReturnCollateral txReturnCollateral
-    let totalCollateral = toCardanoTotalCollateral txTotalCollateral
-    let txFee' = toCardanoFee txFee
-    txValidityRange <- toCardanoValidityRange txValidRange
-    txMintValue <- toCardanoMintValue tx
-    txExtraKeyWits <- C.TxExtraKeyWitnesses C.ExtraKeyWitnessesInBabbageEra <$> traverse toCardanoPaymentKeyHash sigs
-    withdrawals <- toWithdrawals txScripts networkId txWithdrawals
-    pure $ CardanoBuildTx $ C.TxBodyContent
-        { txIns = txIns
-        , txInsReference = C.TxInsReference C.ReferenceTxInsScriptsInlineDatumsInBabbageEra txInsReference
-        , txInsCollateral = txInsCollateral
-        , txOuts = txOuts
-        , txTotalCollateral = totalCollateral
-        , txReturnCollateral = returnCollateral
-        , txFee = txFee'
-        , txValidityRange = txValidityRange
-        , txMintValue = txMintValue
-        , txProtocolParams = C.BuildTxWith $ Just $ C.fromLedgerPParams C.ShelleyBasedEraBabbage protocolParams
-        , txScriptValidity = C.TxScriptValidityNone
-        , txExtraKeyWits
-        -- unused:
-        , txMetadata = C.TxMetadataNone
-        , txAuxScripts = C.TxAuxScriptsNone
-        , txWithdrawals = withdrawals
-        , txCertificates = C.TxCertificatesNone
-        , txUpdateProposal = C.TxUpdateProposalNone
-        }
-
-toWithdrawals :: P.ScriptsMap
-  -> C.NetworkId
-  -> [P.Withdrawal]
-  -> Either ToCardanoError (C.TxWithdrawals C.BuildTx C.BabbageEra)
-toWithdrawals txScripts networkId = \case
-  [] -> pure C.TxWithdrawalsNone
-  xs -> C.TxWithdrawals C.WithdrawalsInBabbageEra <$> mapM toWithdraw xs
-
-  where
-    toWithdraw P.Withdrawal{withdrawalCredential, withdrawalAmount, withdrawalRedeemer} = do
-      saddr <- toCardanoStakeAddress networkId withdrawalCredential
-      witness <- toStakeWitness withdrawalRedeemer withdrawalCredential
-      pure (saddr, C.Lovelace withdrawalAmount, witness)
-
-    toStakeWitness withdrawalRedeemer cred = case cred of
-      PV1.PubKeyCredential _pkh -> pure $ C.BuildTxWith $ C.KeyWitness C.KeyWitnessForStakeAddr
-      PV1.ScriptCredential _vh -> case (,) <$> withdrawalRedeemer <*> P.lookupValidator txScripts _vh of
-        Just (redeemer, script) -> C.BuildTxWith . C.ScriptWitness C.ScriptWitnessForStakeAddr <$> toCardanoScriptWitness C.NoScriptDatumForStake redeemer (Left $ fmap P.getValidator script)
-        Nothing                    -> Left MissingStakeValidator
 
 toCardanoMintWitness :: PV1.Redeemer -> Maybe (P.Versioned PV1.TxOutRef) -> Maybe (P.Versioned PV1.MintingPolicy) -> Either ToCardanoError (C.ScriptWitness C.WitCtxMint C.BabbageEra)
 toCardanoMintWitness _ Nothing Nothing = Left MissingMintingPolicy
@@ -152,28 +87,6 @@ toCardanoScriptWitness datum redeemer scriptOrRef = (case lang of
   where
     lang = either P.version P.version scriptOrRef
 
-toCardanoStakeAddress :: C.NetworkId -> PV1.Credential -> Either ToCardanoError C.StakeAddress
-toCardanoStakeAddress networkId credential =
-  C.StakeAddress (C.toShelleyNetwork networkId) . C.toShelleyStakeCredential <$> toCardanoStakingCredential credential
-
-toCardanoStakingCredential :: PV1.Credential -> Either ToCardanoError C.StakeCredential
-toCardanoStakingCredential (PV1.PubKeyCredential pubKeyHash) = C.StakeCredentialByKey <$> toCardanoStakeKeyHash pubKeyHash
-toCardanoStakingCredential (PV1.ScriptCredential validatorHash) = C.StakeCredentialByScript <$> toCardanoScriptHash validatorHash
-
-
-toCardanoTxBody ::
-    C.NetworkId
-    -> Babbage.PParams (Babbage.BabbageEra StandardCrypto)
-    -> [P.PaymentPubKeyHash] -- ^ Required signers of the transaction
-    -> P.Tx
-    -> Either ToCardanoError (C.TxBody C.BabbageEra)
-toCardanoTxBody networkId params sigs tx = do
-    txBodyContent <- toCardanoTxBodyContent networkId params sigs tx
-    makeTransactionBody (Just params) mempty txBodyContent
-
-toCardanoTxInBuild :: P.Tx -> P.TxInput -> Either ToCardanoError (C.TxIn, C.BuildTxWith C.BuildTx (C.Witness C.WitCtxTxIn C.BabbageEra))
-toCardanoTxInBuild tx (P.TxInput txInRef txInType) = (,) <$> toCardanoTxIn txInRef <*> (C.BuildTxWith <$> toCardanoTxInWitness tx txInType)
-
 fromCardanoTxInsCollateral :: C.TxInsCollateral era -> [P.TxIn]
 fromCardanoTxInsCollateral C.TxInsCollateralNone       = []
 fromCardanoTxInsCollateral (C.TxInsCollateral _ txIns) = map (P.pubKeyTxIn . fromCardanoTxIn) txIns
@@ -181,24 +94,6 @@ fromCardanoTxInsCollateral (C.TxInsCollateral _ txIns) = map (P.pubKeyTxIn . fro
 toCardanoTxInsCollateral :: [P.TxInput] -> Either ToCardanoError (C.TxInsCollateral C.BabbageEra)
 toCardanoTxInsCollateral [] = pure C.TxInsCollateralNone
 toCardanoTxInsCollateral inputs = fmap (C.TxInsCollateral C.CollateralInBabbageEra) (traverse (toCardanoTxIn . P.txInputRef) inputs)
-
-toCardanoTxInWitness :: P.Tx -> P.TxInputType -> Either ToCardanoError (C.Witness C.WitCtxTxIn C.BabbageEra)
-toCardanoTxInWitness _ P.TxConsumePublicKeyAddress = pure (C.KeyWitness C.KeyWitnessForSpending)
-toCardanoTxInWitness _ P.TxConsumeSimpleScriptAddress = Left SimpleScriptsNotSupportedToCardano -- TODO: Better support for simple scripts
-toCardanoTxInWitness tx
-    (P.TxScriptAddress
-        (P.Redeemer redeemer)
-        valhOrRef
-        dh)
-    = do
-      mDatum <- traverse (maybe (Left MissingDatum) pure . (`Map.lookup` P.txData tx)) dh
-      mkWitness <- case valhOrRef of
-        Left valh -> maybe (Left MissingInputValidator) (toCardanoTxInScriptWitnessHeader . fmap PV1.getValidator) $ P.lookupValidator (P.txScripts tx) valh
-        Right vref -> toCardanoTxInReferenceWitnessHeader vref
-      pure $ C.ScriptWitness C.ScriptWitnessForSpending $ mkWitness
-            (toCardanoDatumWitness mDatum)
-            (toCardanoScriptData redeemer)
-            zeroExecutionUnits
 
 toCardanoDatumWitness :: Maybe PV1.Datum -> C.ScriptDatum C.WitCtxTxIn
 toCardanoDatumWitness = maybe C.InlineScriptDatum (C.ScriptDatumForTxIn . toCardanoScriptData . PV1.getDatum)
@@ -225,14 +120,6 @@ toCardanoTxInScriptWitnessHeader (P.Versioned script lang) =
         P.PlutusV2 ->
             C.PlutusScriptWitness C.PlutusScriptV2InBabbage C.PlutusScriptV2 . C.PScript <$>
                 toCardanoPlutusScript (C.AsPlutusScript C.AsPlutusScriptV2) script
-
-toCardanoMintValue :: P.Tx -> Either ToCardanoError (C.TxMintValue C.BuildTx C.BabbageEra)
-toCardanoMintValue tx@P.Tx{..} =
-    let indexedMps = Map.assocs txMintingWitnesses
-    in C.TxMintValue C.MultiAssetInBabbageEra txMint . C.BuildTxWith . Map.fromList <$>
-        traverse (\(mph, (rd, mTxOutRef)) ->
-            bisequence (toCardanoPolicyId mph, toCardanoMintWitness rd mTxOutRef (P.lookupMintingPolicy (P.txScripts tx) mph)))
-            indexedMps
 
 fromCardanoTotalCollateral :: C.TxTotalCollateral C.BabbageEra -> Maybe C.Lovelace
 fromCardanoTotalCollateral C.TxTotalCollateralNone    = Nothing

--- a/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
+++ b/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
@@ -17,7 +17,7 @@ Interface to the transaction types from 'cardano-api'
 module Ledger.Tx.CardanoAPI(
   module Ledger.Tx.CardanoAPI.Internal
   , CardanoBuildTx(..)
-  , SomeCardanoApiTx(..)
+  , CardanoTx(..)
   , fromCardanoTxInsCollateral
   , fromCardanoTotalCollateral
   , fromCardanoReturnCollateral

--- a/plutus-ledger/src/Ledger/Tx/CardanoAPI/Internal.hs
+++ b/plutus-ledger/src/Ledger/Tx/CardanoAPI/Internal.hs
@@ -19,7 +19,7 @@ Interface to the transaction types from 'cardano-api'
 -}
 module Ledger.Tx.CardanoAPI.Internal(
   CardanoBuildTx(..)
-  , SomeCardanoApiTx(..)
+  , CardanoTx(..)
   , txOutRefs
   , unspentOutputsTx
   , fromCardanoTxId
@@ -371,22 +371,22 @@ deriving instance FromJSON (C.TxBodyContent C.BuildTx C.BabbageEra)
 deriving instance ToJSON (C.TxBodyContent C.BuildTx C.BabbageEra)
 
 -- | Cardano tx from any era.
-data SomeCardanoApiTx where
-  SomeTx :: C.IsCardanoEra era => C.Tx era -> C.EraInMode era C.CardanoMode -> SomeCardanoApiTx
+data CardanoTx where
+  CardanoTx :: C.IsCardanoEra era => C.Tx era -> C.EraInMode era C.CardanoMode -> CardanoTx
 
-instance Eq SomeCardanoApiTx where
-  (SomeTx tx1 C.ByronEraInCardanoMode) == (SomeTx tx2 C.ByronEraInCardanoMode)     = tx1 == tx2
-  (SomeTx tx1 C.ShelleyEraInCardanoMode) == (SomeTx tx2 C.ShelleyEraInCardanoMode) = tx1 == tx2
-  (SomeTx tx1 C.AllegraEraInCardanoMode) == (SomeTx tx2 C.AllegraEraInCardanoMode) = tx1 == tx2
-  (SomeTx tx1 C.MaryEraInCardanoMode) == (SomeTx tx2 C.MaryEraInCardanoMode)       = tx1 == tx2
-  (SomeTx tx1 C.AlonzoEraInCardanoMode) == (SomeTx tx2 C.AlonzoEraInCardanoMode)   = tx1 == tx2
-  (SomeTx tx1 C.BabbageEraInCardanoMode) == (SomeTx tx2 C.BabbageEraInCardanoMode) = tx1 == tx2
-  _ == _                                                                           = False
+instance Eq CardanoTx where
+  (CardanoTx tx1 C.ByronEraInCardanoMode) == (CardanoTx tx2 C.ByronEraInCardanoMode)     = tx1 == tx2
+  (CardanoTx tx1 C.ShelleyEraInCardanoMode) == (CardanoTx tx2 C.ShelleyEraInCardanoMode) = tx1 == tx2
+  (CardanoTx tx1 C.AllegraEraInCardanoMode) == (CardanoTx tx2 C.AllegraEraInCardanoMode) = tx1 == tx2
+  (CardanoTx tx1 C.MaryEraInCardanoMode) == (CardanoTx tx2 C.MaryEraInCardanoMode)       = tx1 == tx2
+  (CardanoTx tx1 C.AlonzoEraInCardanoMode) == (CardanoTx tx2 C.AlonzoEraInCardanoMode)   = tx1 == tx2
+  (CardanoTx tx1 C.BabbageEraInCardanoMode) == (CardanoTx tx2 C.BabbageEraInCardanoMode) = tx1 == tx2
+  _ == _                                                                                 = False
 
-deriving instance Show SomeCardanoApiTx
+deriving instance Show CardanoTx
 
-instance Serialise SomeCardanoApiTx where
-  encode (SomeTx tx eraInMode) = encodedMode eraInMode <> Encoding (TkBytes (C.serialiseToCBOR tx))
+instance Serialise CardanoTx where
+  encode (CardanoTx tx eraInMode) = encodedMode eraInMode <> Encoding (TkBytes (C.serialiseToCBOR tx))
     where
       encodedMode :: C.EraInMode era C.CardanoMode -> Encoding
       -- 0 and 1 are for ByronEraInByronMode and ShelleyEraInShelleyMode
@@ -407,23 +407,23 @@ instance Serialise SomeCardanoApiTx where
       7 -> decodeTx C.AsBabbageEra C.BabbageEraInCardanoMode
       _ -> fail "Unexpected value while decoding Cardano.Api.EraInMode"
     where
-      decodeTx :: C.IsCardanoEra era => C.AsType era -> C.EraInMode era C.CardanoMode -> Decoder s SomeCardanoApiTx
+      decodeTx :: C.IsCardanoEra era => C.AsType era -> C.EraInMode era C.CardanoMode -> Decoder s CardanoTx
       decodeTx asType eraInMode = do
         bytes <- decodeBytes
         tx <- either (const $ fail "Failed to decode Cardano.Api.Tx") pure $ C.deserialiseFromCBOR (C.AsTx asType) bytes
-        pure $ SomeTx tx eraInMode
+        pure $ CardanoTx tx eraInMode
 
-instance ToJSON SomeCardanoApiTx where
-  toJSON (SomeTx tx eraInMode) =
+instance ToJSON CardanoTx where
+  toJSON (CardanoTx tx eraInMode) =
     object [ "tx" .= C.serialiseToTextEnvelope Nothing tx
            , "eraInMode" .= eraInMode
            ]
 
--- | Converting 'SomeCardanoApiTx' to JSON.
+-- | Converting 'CardanoTx' to JSON.
 --
 -- If the "tx" field is from an unknown era, the JSON parser will print an
 -- error at runtime while parsing.
-instance FromJSON SomeCardanoApiTx where
+instance FromJSON CardanoTx where
   parseJSON v = parseByronInCardanoModeTx v
             <|> parseShelleyEraInCardanoModeTx v
             <|> parseAllegraEraInCardanoModeTx v
@@ -441,48 +441,48 @@ withIsCardanoEra C.MaryEraInCardanoMode r    = r
 withIsCardanoEra C.AlonzoEraInCardanoMode r  = r
 withIsCardanoEra C.BabbageEraInCardanoMode r = r
 
-parseByronInCardanoModeTx :: Aeson.Value -> Parser SomeCardanoApiTx
+parseByronInCardanoModeTx :: Aeson.Value -> Parser CardanoTx
 parseByronInCardanoModeTx =
-  parseSomeCardanoTx "Failed to parse ByronEra 'tx' field from SomeCardanoApiTx"
+  parseSomeCardanoTx "Failed to parse ByronEra 'tx' field from CardanoTx"
                      (C.AsTx C.AsByronEra)
 
-parseShelleyEraInCardanoModeTx :: Aeson.Value -> Parser SomeCardanoApiTx
+parseShelleyEraInCardanoModeTx :: Aeson.Value -> Parser CardanoTx
 parseShelleyEraInCardanoModeTx =
-  parseSomeCardanoTx "Failed to parse ShelleyEra 'tx' field from SomeCardanoApiTx"
+  parseSomeCardanoTx "Failed to parse ShelleyEra 'tx' field from CardanoTx"
                      (C.AsTx C.AsShelleyEra)
 
-parseMaryEraInCardanoModeTx :: Aeson.Value -> Parser SomeCardanoApiTx
+parseMaryEraInCardanoModeTx :: Aeson.Value -> Parser CardanoTx
 parseMaryEraInCardanoModeTx =
-  parseSomeCardanoTx "Failed to parse MaryEra 'tx' field from SomeCardanoApiTx"
+  parseSomeCardanoTx "Failed to parse MaryEra 'tx' field from CardanoTx"
                      (C.AsTx C.AsMaryEra)
 
-parseAllegraEraInCardanoModeTx :: Aeson.Value -> Parser SomeCardanoApiTx
+parseAllegraEraInCardanoModeTx :: Aeson.Value -> Parser CardanoTx
 parseAllegraEraInCardanoModeTx =
-  parseSomeCardanoTx "Failed to parse AllegraEra 'tx' field from SomeCardanoApiTx"
+  parseSomeCardanoTx "Failed to parse AllegraEra 'tx' field from CardanoTx"
                      (C.AsTx C.AsAllegraEra)
 
-parseAlonzoEraInCardanoModeTx :: Aeson.Value -> Parser SomeCardanoApiTx
+parseAlonzoEraInCardanoModeTx :: Aeson.Value -> Parser CardanoTx
 parseAlonzoEraInCardanoModeTx =
-  parseSomeCardanoTx "Failed to parse AlonzoEra 'tx' field from SomeCardanoApiTx"
+  parseSomeCardanoTx "Failed to parse AlonzoEra 'tx' field from CardanoTx"
                      (C.AsTx C.AsAlonzoEra)
 
 -- TODO Uncomment the implementation once Cardano.Api adds a FromJSON instance
 -- for 'EraInMode BabbageEra CardanoMode':
 -- https://github.com/input-output-hk/cardano-node/pull/3837
-parseBabbageEraInCardanoModeTx :: Aeson.Value -> Parser SomeCardanoApiTx
+parseBabbageEraInCardanoModeTx :: Aeson.Value -> Parser CardanoTx
 parseBabbageEraInCardanoModeTx (Aeson.Object v) =
-    SomeTx
-    <$> (v .: "tx" >>= \envelope -> either (const $ parseFail "Failed to parse BabbageEra 'tx' field from SomeCardanoApiTx")
+    CardanoTx
+    <$> (v .: "tx" >>= \envelope -> either (const $ parseFail "Failed to parse BabbageEra 'tx' field from CardanoTx")
                                            pure
                                            $ C.deserialiseFromTextEnvelope (C.AsTx C.AsBabbageEra) envelope)
     <*> pure C.BabbageEraInCardanoMode -- This is a workaround that only works because we tried all other eras first
 parseBabbageEraInCardanoModeTx invalid =
-  prependFailure "parsing SomeCardanoApiTx failed, "
+  prependFailure "parsing CardanoTx failed, "
       (typeMismatch "Object" invalid)
-  -- parseSomeCardanoTx "Failed to parse BabbageEra 'tx' field from SomeCardanoApiTx"
+  -- parseSomeCardanoTx "Failed to parse BabbageEra 'tx' field from CardanoTx"
   --                    (C.AsTx C.AsBabbageEra)
 
-parseEraInCardanoModeFail :: Aeson.Value -> Parser SomeCardanoApiTx
+parseEraInCardanoModeFail :: Aeson.Value -> Parser CardanoTx
 parseEraInCardanoModeFail _ = fail "Unable to parse 'eraInMode'"
 
 parseSomeCardanoTx
@@ -492,25 +492,25 @@ parseSomeCardanoTx
   => String
   -> C.AsType (C.Tx era)
   -> Aeson.Value
-  -> Parser SomeCardanoApiTx
+  -> Parser CardanoTx
 parseSomeCardanoTx errorMsg txAsType (Aeson.Object v) =
-  SomeTx
+  CardanoTx
     <$> (v .: "tx" >>= \envelope -> either (const $ parseFail errorMsg)
                                            pure
                                            $ C.deserialiseFromTextEnvelope txAsType envelope)
     <*> v .: "eraInMode"
 parseSomeCardanoTx _ _ invalid =
-    prependFailure "parsing SomeCardanoApiTx failed, "
+    prependFailure "parsing CardanoTx failed, "
       (typeMismatch "Object" invalid)
 
-txOutRefs :: SomeCardanoApiTx -> [(PV1.TxOut, PV1.TxOutRef)]
-txOutRefs (SomeTx (C.Tx txBody@(C.TxBody C.TxBodyContent{..}) _) _) =
+txOutRefs :: CardanoTx -> [(PV1.TxOut, PV1.TxOutRef)]
+txOutRefs (CardanoTx (C.Tx txBody@(C.TxBody C.TxBodyContent{..}) _) _) =
   mkOut <$> zip [0..] plutusTxOuts
   where
     mkOut (i, o) = (o, PV1.TxOutRef (fromCardanoTxId $ C.getTxId txBody) i)
     plutusTxOuts = fromCardanoTxOutToPV1TxInfoTxOut <$> txOuts
 
-unspentOutputsTx :: SomeCardanoApiTx -> Map PV1.TxOutRef PV1.TxOut
+unspentOutputsTx :: CardanoTx -> Map PV1.TxOutRef PV1.TxOut
 unspentOutputsTx tx = Map.fromList $ swap <$> txOutRefs tx
 
 -- | Given a 'C.TxScriptValidity era', if the @era@ supports scripts, return a

--- a/plutus-ledger/src/Ledger/Tx/Orphans.hs
+++ b/plutus-ledger/src/Ledger/Tx/Orphans.hs
@@ -33,8 +33,8 @@ instance ToJSON (C.Tx C.BabbageEra) where
 instance FromJSON (C.Tx C.BabbageEra) where
   parseJSON (Object v) = do
    envelope <- v .: "tx"
-   either (const $ parseFail "Failed to parse BabbageEra 'tx' field from SomeCardanoApiTx")
+   either (const $ parseFail "Failed to parse BabbageEra 'tx' field from CardanoTx")
           pure
           $ C.deserialiseFromTextEnvelope (C.AsTx C.AsBabbageEra) envelope
   parseJSON invalid =
-    prependFailure "parsing SomeCardanoApiTx failed, " (typeMismatch "Object" invalid)
+    prependFailure "parsing CardanoTx failed, " (typeMismatch "Object" invalid)

--- a/plutus-ledger/test/Ledger/Tx/CardanoAPISpec.hs
+++ b/plutus-ledger/test/Ledger/Tx/CardanoAPISpec.hs
@@ -8,28 +8,18 @@ import Cardano.Api (AsType (AsPaymentKey, AsStakeKey), Key (verificationKeyHash)
                     NetworkMagic (NetworkMagic), PaymentCredential (PaymentCredentialByKey),
                     StakeAddressReference (NoStakeAddress, StakeAddressByValue), StakeCredential, makeShelleyAddress,
                     shelleyAddressInEra)
-import Cardano.Api.Shelley (StakeCredential (StakeCredentialByKey), TxBody (ShelleyTxBody))
+import Cardano.Api.Shelley (StakeCredential (StakeCredentialByKey))
 import Gen.Cardano.Api.Typed (genAssetName, genTxId, genValueDefault)
 import Gen.Cardano.Api.Typed qualified as Gen
-import Ledger (toPlutusAddress)
-import Ledger.Test (someValidator)
-import Ledger.Tx (Language (PlutusV1), Tx (txMint), Versioned (Versioned), addMintingPolicy)
-import Ledger.Tx.CardanoAPI (fromCardanoAssetName, fromCardanoTxId, fromCardanoValue, makeTransactionBody,
-                             toCardanoAddressInEra, toCardanoAssetName, toCardanoPolicyId, toCardanoTxBodyContent,
-                             toCardanoTxId, toCardanoValue)
-import Ledger.Value.CardanoAPI (combine, valueFromList, valueGeq)
-import Plutus.Script.Utils.V1.Scripts qualified as PV1
-import Plutus.Script.Utils.V1.Typed.Scripts.MonetaryPolicies qualified as MPS
-import Plutus.V1.Ledger.Scripts (unitRedeemer)
-import PlutusTx.Lattice ((\/))
-
-import Cardano.Api qualified as C
-import Data.Default (def)
-import Data.Function ((&))
 import Hedgehog (Gen, Property, forAll, property, tripping, (===))
 import Hedgehog qualified
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
+import Ledger (toPlutusAddress)
+import Ledger.Tx.CardanoAPI (fromCardanoAssetName, fromCardanoTxId, fromCardanoValue, toCardanoAddressInEra,
+                             toCardanoAssetName, toCardanoTxId, toCardanoValue)
+import Ledger.Value.CardanoAPI (combine, valueFromList, valueGeq)
+import PlutusTx.Lattice ((\/))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 
@@ -38,7 +28,6 @@ tests =
   testGroup "CardanoAPI"
   [ testGroup "Ledger.Tx.CardanoAPI"
     [ testPropertyNamed "Cardano Address -> Plutus Address roundtrip" "addressRoundTripSpec" addressRoundTripSpec
-    , testPropertyNamed "Tx conversion retains minting policy scripts" "txConversionRetainsMPS" convertMintingTx
     , testPropertyNamed "TokenName <- Cardano AssetName roundtrip" "cardanoAssetNameRoundTrip" cardanoAssetNameRoundTrip
     , testPropertyNamed "Plutus Value <- Cardano Value roundtrip" "cardanoValueRoundTrip" cardanoValueRoundTrip
     , testPropertyNamed "TxId round trip" "cardanoValueRoundTrip" cardanoTxIdRoundTrip
@@ -108,25 +97,6 @@ genNetworkId =
 -- Copied from Gen.Cardano.Api.Typed, because it's not exported.
 genNetworkMagic :: Gen NetworkMagic
 genNetworkMagic = NetworkMagic <$> Gen.word32 Range.constantBounded
-
-
-convertMintingTx :: Property
-convertMintingTx = property $ do
-  let vHash = PV1.validatorHash someValidator
-      mps  = MPS.mkForwardingMintingPolicy vHash
-  policyId <- either (\err -> do Hedgehog.annotateShow err; Hedgehog.failure) pure $
-    toCardanoPolicyId (PV1.mintingPolicyHash mps)
-  let vL n = C.valueFromList [(C.AssetId policyId "L", n)]
-      tx   = mempty { txMint = vL 1 }
-          & addMintingPolicy (Versioned mps PlutusV1) (unitRedeemer, Nothing)
-      ectx = toCardanoTxBodyContent (Testnet $ NetworkMagic 1) def [] tx >>= makeTransactionBody Nothing mempty
-  case ectx of
-    -- Check that the converted tx contains exactly one script
-    Right (ShelleyTxBody _ _ [_script] _ _ _) -> do
-      Hedgehog.success
-    msg -> do
-      Hedgehog.annotateShow msg
-      Hedgehog.failure
 
 combineLeftId :: Property
 combineLeftId = property $ do

--- a/plutus-ledger/test/Spec.hs
+++ b/plutus-ledger/test/Spec.hs
@@ -19,7 +19,7 @@ import Hedgehog.Range qualified as Range
 import Ledger (Slot (Slot))
 import Ledger.Interval qualified as Interval
 import Ledger.Tx qualified as Tx
-import Ledger.Tx.CardanoAPI (CardanoBuildTx (CardanoBuildTx), SomeCardanoApiTx (SomeTx))
+import Ledger.Tx.CardanoAPI (CardanoBuildTx (CardanoBuildTx), CardanoTx (CardanoTx))
 import Ledger.Tx.CardanoAPI qualified as CardanoAPI
 import Ledger.Tx.CardanoAPISpec qualified
 import Plutus.Script.Utils.Ada qualified as Ada
@@ -55,8 +55,8 @@ tests = testGroup "all tests" [
     testGroup "TxIn" [
         testPropertyNamed "Check that Ord instances of TxIn match" "txInOrdInstanceEquivalenceTest" txInOrdInstanceEquivalenceTest
     ],
-    testGroup "SomeCardanoApiTx" [
-        testPropertyNamed "Value ToJSON/FromJSON" "genSomeCardanoApiTx" (jsonRoundTrip genSomeCardanoApiTx)
+    testGroup "CardanoTx" [
+        testPropertyNamed "Value ToJSON/FromJSON" "genCardanoTx" (jsonRoundTrip genCardanoTx)
     ],
     testGroup "CardanoBuildTx" [
         testPropertyNamed "Value ToJSON/FromJSON" "genCardanoBuildTx" (jsonRoundTrip genCardanoBuildTx)
@@ -148,8 +148,8 @@ genCardanoBuildTx = do
 
 -- TODO Unfortunately, there's no way to get a warning if another era has been
 -- added to EraInMode. Alternative way?
-genSomeCardanoApiTx :: Hedgehog.Gen SomeCardanoApiTx
-genSomeCardanoApiTx = Gen.choice [ genByronEraInCardanoModeTx
+genCardanoTx :: Hedgehog.Gen CardanoTx
+genCardanoTx = Gen.choice [ genByronEraInCardanoModeTx
                                  , genShelleyEraInCardanoModeTx
                                  , genAllegraEraInCardanoModeTx
                                  , genMaryEraInCardanoModeTx
@@ -157,32 +157,32 @@ genSomeCardanoApiTx = Gen.choice [ genByronEraInCardanoModeTx
                                  , genBabbageEraInCardanoModeTx
                                  ]
 
-genByronEraInCardanoModeTx :: Hedgehog.Gen SomeCardanoApiTx
+genByronEraInCardanoModeTx :: Hedgehog.Gen CardanoTx
 genByronEraInCardanoModeTx = do
   tx <- fromGenT $ Gen.genTx C.ByronEra
-  pure $ SomeTx tx C.ByronEraInCardanoMode
+  pure $ CardanoTx tx C.ByronEraInCardanoMode
 
-genShelleyEraInCardanoModeTx :: Hedgehog.Gen SomeCardanoApiTx
+genShelleyEraInCardanoModeTx :: Hedgehog.Gen CardanoTx
 genShelleyEraInCardanoModeTx = do
   tx <- fromGenT $ Gen.genTx C.ShelleyEra
-  pure $ SomeTx tx C.ShelleyEraInCardanoMode
+  pure $ CardanoTx tx C.ShelleyEraInCardanoMode
 
-genAllegraEraInCardanoModeTx :: Hedgehog.Gen SomeCardanoApiTx
+genAllegraEraInCardanoModeTx :: Hedgehog.Gen CardanoTx
 genAllegraEraInCardanoModeTx = do
   tx <- fromGenT $ Gen.genTx C.AllegraEra
-  pure $ SomeTx tx C.AllegraEraInCardanoMode
+  pure $ CardanoTx tx C.AllegraEraInCardanoMode
 
-genMaryEraInCardanoModeTx :: Hedgehog.Gen SomeCardanoApiTx
+genMaryEraInCardanoModeTx :: Hedgehog.Gen CardanoTx
 genMaryEraInCardanoModeTx = do
   tx <- fromGenT $ Gen.genTx C.MaryEra
-  pure $ SomeTx tx C.MaryEraInCardanoMode
+  pure $ CardanoTx tx C.MaryEraInCardanoMode
 
-genAlonzoEraInCardanoModeTx :: Hedgehog.Gen SomeCardanoApiTx
+genAlonzoEraInCardanoModeTx :: Hedgehog.Gen CardanoTx
 genAlonzoEraInCardanoModeTx = do
   tx <- fromGenT $ Gen.genTx C.AlonzoEra
-  pure $ SomeTx tx C.AlonzoEraInCardanoMode
+  pure $ CardanoTx tx C.AlonzoEraInCardanoMode
 
-genBabbageEraInCardanoModeTx :: Hedgehog.Gen SomeCardanoApiTx
+genBabbageEraInCardanoModeTx :: Hedgehog.Gen CardanoTx
 genBabbageEraInCardanoModeTx = do
   tx <- fromGenT $ Gen.genTx C.BabbageEra
-  pure $ SomeTx tx C.BabbageEraInCardanoMode
+  pure $ CardanoTx tx C.BabbageEraInCardanoMode

--- a/plutus-pab-executables/test/full/Plutus/PAB/CoreSpec.hs
+++ b/plutus-pab-executables/test/full/Plutus/PAB/CoreSpec.hs
@@ -49,8 +49,7 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Extras (tshow)
 import Ledger (Address, PaymentPubKeyHash (unPaymentPubKeyHash), cardanoPubKeyHash, getCardanoTxFee, getCardanoTxId,
-               getCardanoTxOutRefs, pubKeyAddress, pubKeyHash, pubKeyHashAddress, txId, txOutAddress, txOutRefId,
-               txOutRefs, txOutputs)
+               getCardanoTxOutRefs, pubKeyAddress, pubKeyHash, pubKeyHashAddress, txOutAddress, txOutRefId)
 import Ledger qualified
 import Ledger.AddressMap qualified as AM
 import Ledger.CardanoWallet qualified as CW

--- a/plutus-pab-executables/tx-inject/Main.hs
+++ b/plutus-pab-executables/tx-inject/Main.hs
@@ -94,7 +94,7 @@ runProducer AppEnv{txQueue, stats, utxoIndex} = do
       -- boundaries. We don't currently use boundaries for our generated
       -- transactions, so we chose the random number.
       tx <- generateTx rng (Slot 4) utxo
-      let utxo' = insertBlock [Valid $ CardanoApiTx $ CardanoApiEmulatorEraTx tx] utxo
+      let utxo' = insertBlock [Valid $ CardanoTx $ CardanoApiEmulatorEraTx tx] utxo
       atomically $ do
         writeTBQueue txQueue tx
         modifyTVar' stats $ \s -> s { stUtxoSize = Map.size $ getIndex utxo' }

--- a/plutus-pab-executables/tx-inject/Main.hs
+++ b/plutus-pab-executables/tx-inject/Main.hs
@@ -41,7 +41,7 @@ import Data.Either (fromRight)
 import Ledger.Blockchain (OnChainTx (..))
 import Ledger.Index (UtxoIndex (..), insertBlock)
 import Ledger.Slot (Slot (..))
-import Ledger.Tx (CardanoTx (..), SomeCardanoApiTx (CardanoApiEmulatorEraTx))
+import Ledger.Tx (CardanoTx (..))
 import Ledger.Value.CardanoAPI qualified as CardanoAPI
 import Plutus.PAB.Types (Config (..))
 import TxInject.RandomTx (generateTx)
@@ -94,7 +94,7 @@ runProducer AppEnv{txQueue, stats, utxoIndex} = do
       -- boundaries. We don't currently use boundaries for our generated
       -- transactions, so we chose the random number.
       tx <- generateTx rng (Slot 4) utxo
-      let utxo' = insertBlock [Valid $ CardanoTx $ CardanoApiEmulatorEraTx tx] utxo
+      let utxo' = insertBlock [Valid $ CardanoEmulatorEraTx tx] utxo
       atomically $ do
         writeTBQueue txQueue tx
         modifyTVar' stats $ \s -> s { stUtxoSize = Map.size $ getIndex utxo' }

--- a/plutus-pab-executables/tx-inject/TxInject/RandomTx.hs
+++ b/plutus-pab-executables/tx-inject/TxInject/RandomTx.hs
@@ -26,8 +26,8 @@ import Ledger.Address (CardanoAddress)
 import Ledger.CardanoWallet qualified as CW
 import Ledger.Index (UtxoIndex (..))
 import Ledger.Slot (Slot (..))
-import Ledger.Tx (CardanoTx (CardanoApiTx), SomeCardanoApiTx (CardanoApiEmulatorEraTx),
-                  TxInType (ConsumePublicKeyAddress), txOutAddress, txOutValue)
+import Ledger.Tx (CardanoTx (CardanoTx), SomeCardanoApiTx (CardanoApiEmulatorEraTx), TxInType (ConsumePublicKeyAddress),
+                  txOutAddress, txOutValue)
 import Ledger.Tx.CardanoAPI (fromPlutusIndex)
 import Ledger.Value.CardanoAPI (isAdaOnlyValue)
 
@@ -93,8 +93,7 @@ generateTx gen slot (UtxoIndex utxo) = do
       utxoIndex = either (error . show) id $ fromPlutusIndex $ UtxoIndex utxo
       validationResult = Validation.validateCardanoTx params slot utxoIndex txn
     case validationResult of
-      Left _  -> case txn of
-                      CardanoApiTx (CardanoApiEmulatorEraTx cTx) -> pure cTx
+      Left _  -> case txn of CardanoTx (CardanoApiEmulatorEraTx cTx) -> pure cTx
       Right _ -> generateTx gen slot (UtxoIndex utxo)
 
 keyPairs :: NonEmpty CardanoAddress

--- a/plutus-pab-executables/tx-inject/TxInject/RandomTx.hs
+++ b/plutus-pab-executables/tx-inject/TxInject/RandomTx.hs
@@ -26,7 +26,7 @@ import Ledger.Address (CardanoAddress)
 import Ledger.CardanoWallet qualified as CW
 import Ledger.Index (UtxoIndex (..))
 import Ledger.Slot (Slot (..))
-import Ledger.Tx (CardanoTx (CardanoApiTx, EmulatorTx), SomeCardanoApiTx (CardanoApiEmulatorEraTx),
+import Ledger.Tx (CardanoTx (CardanoApiTx), SomeCardanoApiTx (CardanoApiEmulatorEraTx),
                   TxInType (ConsumePublicKeyAddress), txOutAddress, txOutValue)
 import Ledger.Tx.CardanoAPI (fromPlutusIndex)
 import Ledger.Value.CardanoAPI (isAdaOnlyValue)
@@ -85,18 +85,16 @@ generateTx gen slot (UtxoIndex utxo) = do
             inputs
         -- inputs of the transaction
         sourceTxIns = fmap ((`TxInputWitnessed` ConsumePublicKeyAddress) . fst) inputs
-    EmulatorTx tx <- Gen.sample $
+    txn <- Gen.sample $
       Generators.genValidTransactionSpending sourceTxIns sourceAda
     slotCfg <- Gen.sample Generators.genSlotConfig
     let
       params = def { pSlotConfig = slotCfg }
       utxoIndex = either (error . show) id $ fromPlutusIndex $ UtxoIndex utxo
-      txn = Validation.fromPlutusTxSigned params utxoIndex tx CW.knownPaymentKeys
       validationResult = Validation.validateCardanoTx params slot utxoIndex txn
     case validationResult of
       Left _  -> case txn of
                       CardanoApiTx (CardanoApiEmulatorEraTx cTx) -> pure cTx
-                      EmulatorTx _ -> error "fromPlutusTxSigned can't generate an Emulator tx"
       Right _ -> generateTx gen slot (UtxoIndex utxo)
 
 keyPairs :: NonEmpty CardanoAddress

--- a/plutus-pab-executables/tx-inject/TxInject/RandomTx.hs
+++ b/plutus-pab-executables/tx-inject/TxInject/RandomTx.hs
@@ -26,8 +26,7 @@ import Ledger.Address (CardanoAddress)
 import Ledger.CardanoWallet qualified as CW
 import Ledger.Index (UtxoIndex (..))
 import Ledger.Slot (Slot (..))
-import Ledger.Tx (CardanoTx (CardanoTx), SomeCardanoApiTx (CardanoApiEmulatorEraTx), TxInType (ConsumePublicKeyAddress),
-                  txOutAddress, txOutValue)
+import Ledger.Tx (CardanoTx (CardanoEmulatorEraTx), TxInType (ConsumePublicKeyAddress), txOutAddress, txOutValue)
 import Ledger.Tx.CardanoAPI (fromPlutusIndex)
 import Ledger.Value.CardanoAPI (isAdaOnlyValue)
 
@@ -85,7 +84,7 @@ generateTx gen slot (UtxoIndex utxo) = do
             inputs
         -- inputs of the transaction
         sourceTxIns = fmap ((`TxInputWitnessed` ConsumePublicKeyAddress) . fst) inputs
-    txn <- Gen.sample $
+    txn@(CardanoEmulatorEraTx cTx) <- Gen.sample $
       Generators.genValidTransactionSpending sourceTxIns sourceAda
     slotCfg <- Gen.sample Generators.genSlotConfig
     let
@@ -93,7 +92,7 @@ generateTx gen slot (UtxoIndex utxo) = do
       utxoIndex = either (error . show) id $ fromPlutusIndex $ UtxoIndex utxo
       validationResult = Validation.validateCardanoTx params slot utxoIndex txn
     case validationResult of
-      Left _  -> case txn of CardanoTx (CardanoApiEmulatorEraTx cTx) -> pure cTx
+      Left _  -> pure cTx
       Right _ -> generateTx gen slot (UtxoIndex utxo)
 
 keyPairs :: NonEmpty CardanoAddress

--- a/plutus-pab/src/Cardano/BM/Data/Tracer/Extras.hs
+++ b/plutus-pab/src/Cardano/BM/Data/Tracer/Extras.hs
@@ -24,7 +24,7 @@ import Data.Tagged (Tagged (Tagged))
 import Data.Text (Text)
 import Data.UUID (UUID)
 import GHC.TypeLits (KnownSymbol, symbolVal)
-import Ledger.Tx (Tx)
+import Ledger.Tx (CardanoTx)
 import Plutus.Contract.Checkpoint (CheckpointLogMsg)
 import Plutus.Contract.Resumable (Response (..))
 import Plutus.Contract.State (ContractRequest)
@@ -79,7 +79,7 @@ deriving via (Tagged "contract_instance_iteration" IterationID) instance Structu
 deriving via (Tagged "message" CheckpointLogMsg) instance StructuredLog CheckpointLogMsg
 deriving via (Tagged "message" RequestHandlerLogMsg) instance StructuredLog RequestHandlerLogMsg
 deriving via (Tagged "message" TxBalanceMsg) instance StructuredLog TxBalanceMsg
-deriving via (Tagged "tx" Tx) instance StructuredLog Tx
+deriving via (Tagged "tx" CardanoTx) instance StructuredLog CardanoTx
 deriving via (Tagged "uuid" UUID) instance StructuredLog UUID
 deriving via (Tagged "request" (ContractRequest w v)) instance (ToJSON w, ToJSON v) => StructuredLog (ContractRequest w v)
 deriving via (Tagged "value" V.Value) instance StructuredLog V.Value

--- a/plutus-pab/src/Cardano/Node/Client.hs
+++ b/plutus-pab/src/Cardano/Node/Client.hs
@@ -14,7 +14,7 @@ import Control.Monad.Freer.Error (Error, throwError)
 import Control.Monad.Freer.Reader (Reader, ask)
 import Control.Monad.IO.Class
 import Data.Proxy (Proxy (Proxy))
-import Ledger (SomeCardanoApiTx (CardanoApiEmulatorEraTx), onCardanoTx)
+import Ledger (SomeCardanoApiTx (CardanoApiEmulatorEraTx), _cardanoApiTx)
 import Servant (NoContent, (:<|>) (..))
 import Servant.Client (ClientM, client)
 
@@ -59,11 +59,7 @@ handleNodeClientClient params e = do
                   -- need to be sent via the wallet, not the mocked server node
                   -- (which is not actually running).
                   throwError TxSenderNotAvailable
-              Just handle ->
-                  liftIO $
-                      onCardanoTx (const $ error "Cardano.Node.Client: Expecting a cardano-api tx, not a mock when publishing it.")
-                                  (MockClient.queueTx handle . (\(CardanoApiEmulatorEraTx c) -> c))
-                                  tx
+              Just handle -> liftIO $ (MockClient.queueTx handle . (\(CardanoApiEmulatorEraTx c) -> c) . _cardanoApiTx) tx
         GetClientSlot ->
             either (liftIO . MockClient.getCurrentSlot)
                    (liftIO . Client.getCurrentSlot)

--- a/plutus-pab/src/Cardano/Node/Client.hs
+++ b/plutus-pab/src/Cardano/Node/Client.hs
@@ -14,7 +14,7 @@ import Control.Monad.Freer.Error (Error, throwError)
 import Control.Monad.Freer.Reader (Reader, ask)
 import Control.Monad.IO.Class
 import Data.Proxy (Proxy (Proxy))
-import Ledger (SomeCardanoApiTx (CardanoApiEmulatorEraTx), _cardanoApiTx)
+import Ledger (SomeCardanoApiTx (CardanoApiEmulatorEraTx), _cardanoTx)
 import Servant (NoContent, (:<|>) (..))
 import Servant.Client (ClientM, client)
 
@@ -59,7 +59,7 @@ handleNodeClientClient params e = do
                   -- need to be sent via the wallet, not the mocked server node
                   -- (which is not actually running).
                   throwError TxSenderNotAvailable
-              Just handle -> liftIO $ (MockClient.queueTx handle . (\(CardanoApiEmulatorEraTx c) -> c) . _cardanoApiTx) tx
+              Just handle -> liftIO $ (MockClient.queueTx handle . (\(CardanoApiEmulatorEraTx c) -> c) . _cardanoTx) tx
         GetClientSlot ->
             either (liftIO . MockClient.getCurrentSlot)
                    (liftIO . Client.getCurrentSlot)

--- a/plutus-pab/src/Cardano/Node/Client.hs
+++ b/plutus-pab/src/Cardano/Node/Client.hs
@@ -14,7 +14,7 @@ import Control.Monad.Freer.Error (Error, throwError)
 import Control.Monad.Freer.Reader (Reader, ask)
 import Control.Monad.IO.Class
 import Data.Proxy (Proxy (Proxy))
-import Ledger (SomeCardanoApiTx (CardanoApiEmulatorEraTx), _cardanoTx)
+import Ledger (CardanoTx (CardanoEmulatorEraTx))
 import Servant (NoContent, (:<|>) (..))
 import Servant.Client (ClientM, client)
 
@@ -59,7 +59,7 @@ handleNodeClientClient params e = do
                   -- need to be sent via the wallet, not the mocked server node
                   -- (which is not actually running).
                   throwError TxSenderNotAvailable
-              Just handle -> liftIO $ (MockClient.queueTx handle . (\(CardanoApiEmulatorEraTx c) -> c) . _cardanoTx) tx
+              Just handle -> liftIO $ (MockClient.queueTx handle . (\(CardanoEmulatorEraTx c) -> c)) tx
         GetClientSlot ->
             either (liftIO . MockClient.getCurrentSlot)
                    (liftIO . Client.getCurrentSlot)

--- a/plutus-pab/src/Cardano/Protocol/Socket/Mock/Server.hs
+++ b/plutus-pab/src/Cardano/Protocol/Socket/Mock/Server.hs
@@ -153,7 +153,7 @@ handleCommand ::
 handleCommand trace CommandChannel {ccCommand, ccResponse} mvChainState params =
     liftIO (atomically $ readTQueue ccCommand) >>= \case
         AddTx tx     -> do
-            liftIO $ modifyMVar_ mvChainState (pure . over txPool (CardanoApiTx (CardanoApiEmulatorEraTx tx) :))
+            liftIO $ modifyMVar_ mvChainState (pure . over txPool (CardanoTx (CardanoApiEmulatorEraTx tx) :))
         ModifySlot f -> liftIO $ do
             state <- liftIO $ takeMVar mvChainState
             (s, nextState') <- liftIO $ Chain.modifySlot f
@@ -480,7 +480,7 @@ txSubmissionServer state = txSubmissionState
         TxSubmission.LocalTxSubmissionServer {
           TxSubmission.recvMsgSubmitTx =
             \tx -> do
-                modifyMVar_ state (pure . over txPool (addTxToPool (CardanoApiTx $ CardanoApiEmulatorEraTx tx)))
+                modifyMVar_ state (pure . over txPool (addTxToPool (CardanoTx $ CardanoApiEmulatorEraTx tx)))
                 return (TxSubmission.SubmitSuccess, txSubmissionState)
         , TxSubmission.recvMsgDone     = ()
         }

--- a/plutus-pab/src/Cardano/Protocol/Socket/Mock/Server.hs
+++ b/plutus-pab/src/Cardano/Protocol/Socket/Mock/Server.hs
@@ -53,7 +53,7 @@ import Cardano.Chain (MockNodeServerChainState (..), addTxToPool, chainNewestFir
                       getTip, handleControlChain, tip, txPool)
 import Cardano.Node.Emulator.Chain qualified as Chain
 import Cardano.Node.Emulator.Params (Params)
-import Ledger (Block, CardanoTx (..), Slot (..), SomeCardanoApiTx (CardanoApiEmulatorEraTx))
+import Ledger (Block, CardanoTx (..), Slot (..))
 
 data CommandChannel = CommandChannel
   { ccCommand  :: TQueue ServerCommand
@@ -153,7 +153,7 @@ handleCommand ::
 handleCommand trace CommandChannel {ccCommand, ccResponse} mvChainState params =
     liftIO (atomically $ readTQueue ccCommand) >>= \case
         AddTx tx     -> do
-            liftIO $ modifyMVar_ mvChainState (pure . over txPool (CardanoTx (CardanoApiEmulatorEraTx tx) :))
+            liftIO $ modifyMVar_ mvChainState (pure . over txPool ((CardanoEmulatorEraTx tx) :))
         ModifySlot f -> liftIO $ do
             state <- liftIO $ takeMVar mvChainState
             (s, nextState') <- liftIO $ Chain.modifySlot f
@@ -480,7 +480,7 @@ txSubmissionServer state = txSubmissionState
         TxSubmission.LocalTxSubmissionServer {
           TxSubmission.recvMsgSubmitTx =
             \tx -> do
-                modifyMVar_ state (pure . over txPool (addTxToPool (CardanoTx $ CardanoApiEmulatorEraTx tx)))
+                modifyMVar_ state (pure . over txPool (addTxToPool (CardanoEmulatorEraTx tx)))
                 return (TxSubmission.SubmitSuccess, txSubmissionState)
         , TxSubmission.recvMsgDone     = ()
         }

--- a/plutus-pab/src/Cardano/Wallet/LocalClient.hs
+++ b/plutus-pab/src/Cardano/Wallet/LocalClient.hs
@@ -168,7 +168,7 @@ tokenMapToValue :: C.TokenMap -> Value
 tokenMapToValue = Value . Map.fromList . fmap (bimap (currencySymbol . C.getHash . C.unTokenPolicyId) (Map.fromList . fmap (bimap (tokenName . C.unTokenName) (fromIntegral . C.unTokenQuantity)) . toList)) . C.toNestedList
 
 fromApiSerialisedTransaction :: C.ApiSerialisedTransaction -> CardanoTx
-fromApiSerialisedTransaction (C.ApiSerialisedTransaction (C.ApiT sealedTx)) = CardanoApiTx $ case C.cardanoTxIdeallyNoLaterThan (Cardano.Api.anyCardanoEra Cardano.Api.BabbageEra) sealedTx of
+fromApiSerialisedTransaction (C.ApiSerialisedTransaction (C.ApiT sealedTx)) = CardanoTx $ case C.cardanoTxIdeallyNoLaterThan (Cardano.Api.anyCardanoEra Cardano.Api.BabbageEra) sealedTx of
     Cardano.Api.InAnyCardanoEra Cardano.Api.ByronEra tx   -> SomeTx tx Cardano.Api.ByronEraInCardanoMode
     Cardano.Api.InAnyCardanoEra Cardano.Api.ShelleyEra tx -> SomeTx tx Cardano.Api.ShelleyEraInCardanoMode
     Cardano.Api.InAnyCardanoEra Cardano.Api.AllegraEra tx -> SomeTx tx Cardano.Api.AllegraEraInCardanoMode
@@ -177,12 +177,12 @@ fromApiSerialisedTransaction (C.ApiSerialisedTransaction (C.ApiT sealedTx)) = Ca
     Cardano.Api.InAnyCardanoEra Cardano.Api.BabbageEra tx -> SomeTx tx Cardano.Api.BabbageEraInCardanoMode
 
 toSealedTx :: CardanoTx -> Either ToCardanoError C.SealedTx
-toSealedTx (CardanoApiTx (SomeTx tx Cardano.Api.ByronEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.ByronEra tx
-toSealedTx (CardanoApiTx (SomeTx tx Cardano.Api.ShelleyEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.ShelleyEra tx
-toSealedTx (CardanoApiTx (SomeTx tx Cardano.Api.AllegraEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.AllegraEra tx
-toSealedTx (CardanoApiTx (SomeTx tx Cardano.Api.MaryEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.MaryEra tx
-toSealedTx (CardanoApiTx (SomeTx tx Cardano.Api.AlonzoEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.AlonzoEra tx
-toSealedTx (CardanoApiTx (SomeTx tx Cardano.Api.BabbageEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.BabbageEra tx
+toSealedTx (CardanoTx (SomeTx tx Cardano.Api.ByronEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.ByronEra tx
+toSealedTx (CardanoTx (SomeTx tx Cardano.Api.ShelleyEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.ShelleyEra tx
+toSealedTx (CardanoTx (SomeTx tx Cardano.Api.AllegraEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.AllegraEra tx
+toSealedTx (CardanoTx (SomeTx tx Cardano.Api.MaryEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.MaryEra tx
+toSealedTx (CardanoTx (SomeTx tx Cardano.Api.AlonzoEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.AlonzoEra tx
+toSealedTx (CardanoTx (SomeTx tx Cardano.Api.BabbageEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.BabbageEra tx
 
 throwOtherError :: (Member (Error WalletAPIError) effs, Show err) => err -> Eff effs a
 throwOtherError = throwError . OtherError . pack . show

--- a/plutus-pab/src/Cardano/Wallet/LocalClient.hs
+++ b/plutus-pab/src/Cardano/Wallet/LocalClient.hs
@@ -13,7 +13,6 @@ module Cardano.Wallet.LocalClient where
 
 import Cardano.Api (shelleyAddressInEra)
 import Cardano.Api qualified
-import Cardano.Node.Emulator.Params (Params (..))
 import Cardano.Node.Types (PABServerConfig (pscPassphrase))
 import Cardano.Wallet.Api qualified as C
 import Cardano.Wallet.Api.Client qualified as C
@@ -48,7 +47,7 @@ import Data.Quantity (Quantity (Quantity))
 import Data.Text (Text, pack)
 import Data.Text.Class (fromText)
 import Ledger (CardanoAddress, CardanoTx (..))
-import Ledger.Tx.CardanoAPI (SomeCardanoApiTx (SomeTx), ToCardanoError, toCardanoTxBody)
+import Ledger.Tx.CardanoAPI (SomeCardanoApiTx (SomeTx), ToCardanoError)
 import Ledger.Tx.Constraints.OffChain (UnbalancedTx)
 import Plutus.PAB.Monitoring.PABLogMsg (WalletClientMsg (BalanceTxError, WalletClientError))
 import Plutus.Script.Utils.Ada qualified as Ada
@@ -104,7 +103,7 @@ handleWalletClient config (Wallet _ (WalletId wId)) event = do
 
         submitTxnH :: CardanoTx -> Eff effs ()
         submitTxnH tx = do
-            sealedTx <- either (throwError . ToCardanoError) pure $ toSealedTx params tx
+            sealedTx <- either (throwError . ToCardanoError) pure $ toSealedTx tx
             void . runClient $ C.postExternalTransaction C.transactionClient (C.ApiBytesT (C.SerialisedTx $ C.serialisedTx sealedTx))
 
         ownAddressesH :: Eff effs (NonEmpty CardanoAddress)
@@ -137,7 +136,7 @@ handleWalletClient config (Wallet _ (WalletId wId)) event = do
 
         walletAddSignatureH :: CardanoTx -> Eff effs CardanoTx
         walletAddSignatureH tx = do
-            sealedTx <- either (throwError . ToCardanoError) pure $ toSealedTx params tx
+            sealedTx <- either (throwError . ToCardanoError) pure $ toSealedTx tx
             passphrase <- maybe (throwError $ OtherError "Wallet passphrase required") pure mpassphrase
             lenientPP <- either throwOtherError pure $ fromText passphrase
             let postData = C.ApiSignTransactionPostData (C.ApiT sealedTx) (C.ApiT lenientPP)
@@ -177,14 +176,13 @@ fromApiSerialisedTransaction (C.ApiSerialisedTransaction (C.ApiT sealedTx)) = Ca
     Cardano.Api.InAnyCardanoEra Cardano.Api.AlonzoEra tx  -> SomeTx tx Cardano.Api.AlonzoEraInCardanoMode
     Cardano.Api.InAnyCardanoEra Cardano.Api.BabbageEra tx -> SomeTx tx Cardano.Api.BabbageEraInCardanoMode
 
-toSealedTx :: Params -> CardanoTx -> Either ToCardanoError C.SealedTx
-toSealedTx _ (CardanoApiTx (SomeTx tx Cardano.Api.ByronEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.ByronEra tx
-toSealedTx _ (CardanoApiTx (SomeTx tx Cardano.Api.ShelleyEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.ShelleyEra tx
-toSealedTx _ (CardanoApiTx (SomeTx tx Cardano.Api.AllegraEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.AllegraEra tx
-toSealedTx _ (CardanoApiTx (SomeTx tx Cardano.Api.MaryEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.MaryEra tx
-toSealedTx _ (CardanoApiTx (SomeTx tx Cardano.Api.AlonzoEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.AlonzoEra tx
-toSealedTx _ (CardanoApiTx (SomeTx tx Cardano.Api.BabbageEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.BabbageEra tx
-toSealedTx params (EmulatorTx tx) = C.sealedTxFromCardanoBody <$> toCardanoTxBody (pNetworkId params) (emulatorPParams params) [] tx
+toSealedTx :: CardanoTx -> Either ToCardanoError C.SealedTx
+toSealedTx (CardanoApiTx (SomeTx tx Cardano.Api.ByronEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.ByronEra tx
+toSealedTx (CardanoApiTx (SomeTx tx Cardano.Api.ShelleyEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.ShelleyEra tx
+toSealedTx (CardanoApiTx (SomeTx tx Cardano.Api.AllegraEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.AllegraEra tx
+toSealedTx (CardanoApiTx (SomeTx tx Cardano.Api.MaryEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.MaryEra tx
+toSealedTx (CardanoApiTx (SomeTx tx Cardano.Api.AlonzoEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.AlonzoEra tx
+toSealedTx (CardanoApiTx (SomeTx tx Cardano.Api.BabbageEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.BabbageEra tx
 
 throwOtherError :: (Member (Error WalletAPIError) effs, Show err) => err -> Eff effs a
 throwOtherError = throwError . OtherError . pack . show

--- a/plutus-pab/src/Cardano/Wallet/LocalClient.hs
+++ b/plutus-pab/src/Cardano/Wallet/LocalClient.hs
@@ -46,8 +46,8 @@ import Data.Proxy (Proxy (Proxy))
 import Data.Quantity (Quantity (Quantity))
 import Data.Text (Text, pack)
 import Data.Text.Class (fromText)
-import Ledger (CardanoAddress, CardanoTx (..))
-import Ledger.Tx.CardanoAPI (SomeCardanoApiTx (SomeTx), ToCardanoError)
+import Ledger (CardanoAddress)
+import Ledger.Tx.CardanoAPI (CardanoTx (CardanoTx), ToCardanoError)
 import Ledger.Tx.Constraints.OffChain (UnbalancedTx)
 import Plutus.PAB.Monitoring.PABLogMsg (WalletClientMsg (BalanceTxError, WalletClientError))
 import Plutus.Script.Utils.Ada qualified as Ada
@@ -168,21 +168,21 @@ tokenMapToValue :: C.TokenMap -> Value
 tokenMapToValue = Value . Map.fromList . fmap (bimap (currencySymbol . C.getHash . C.unTokenPolicyId) (Map.fromList . fmap (bimap (tokenName . C.unTokenName) (fromIntegral . C.unTokenQuantity)) . toList)) . C.toNestedList
 
 fromApiSerialisedTransaction :: C.ApiSerialisedTransaction -> CardanoTx
-fromApiSerialisedTransaction (C.ApiSerialisedTransaction (C.ApiT sealedTx)) = CardanoTx $ case C.cardanoTxIdeallyNoLaterThan (Cardano.Api.anyCardanoEra Cardano.Api.BabbageEra) sealedTx of
-    Cardano.Api.InAnyCardanoEra Cardano.Api.ByronEra tx   -> SomeTx tx Cardano.Api.ByronEraInCardanoMode
-    Cardano.Api.InAnyCardanoEra Cardano.Api.ShelleyEra tx -> SomeTx tx Cardano.Api.ShelleyEraInCardanoMode
-    Cardano.Api.InAnyCardanoEra Cardano.Api.AllegraEra tx -> SomeTx tx Cardano.Api.AllegraEraInCardanoMode
-    Cardano.Api.InAnyCardanoEra Cardano.Api.MaryEra tx    -> SomeTx tx Cardano.Api.MaryEraInCardanoMode
-    Cardano.Api.InAnyCardanoEra Cardano.Api.AlonzoEra tx  -> SomeTx tx Cardano.Api.AlonzoEraInCardanoMode
-    Cardano.Api.InAnyCardanoEra Cardano.Api.BabbageEra tx -> SomeTx tx Cardano.Api.BabbageEraInCardanoMode
+fromApiSerialisedTransaction (C.ApiSerialisedTransaction (C.ApiT sealedTx)) = case C.cardanoTxIdeallyNoLaterThan (Cardano.Api.anyCardanoEra Cardano.Api.BabbageEra) sealedTx of
+    Cardano.Api.InAnyCardanoEra Cardano.Api.ByronEra tx   -> CardanoTx tx Cardano.Api.ByronEraInCardanoMode
+    Cardano.Api.InAnyCardanoEra Cardano.Api.ShelleyEra tx -> CardanoTx tx Cardano.Api.ShelleyEraInCardanoMode
+    Cardano.Api.InAnyCardanoEra Cardano.Api.AllegraEra tx -> CardanoTx tx Cardano.Api.AllegraEraInCardanoMode
+    Cardano.Api.InAnyCardanoEra Cardano.Api.MaryEra tx    -> CardanoTx tx Cardano.Api.MaryEraInCardanoMode
+    Cardano.Api.InAnyCardanoEra Cardano.Api.AlonzoEra tx  -> CardanoTx tx Cardano.Api.AlonzoEraInCardanoMode
+    Cardano.Api.InAnyCardanoEra Cardano.Api.BabbageEra tx -> CardanoTx tx Cardano.Api.BabbageEraInCardanoMode
 
 toSealedTx :: CardanoTx -> Either ToCardanoError C.SealedTx
-toSealedTx (CardanoTx (SomeTx tx Cardano.Api.ByronEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.ByronEra tx
-toSealedTx (CardanoTx (SomeTx tx Cardano.Api.ShelleyEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.ShelleyEra tx
-toSealedTx (CardanoTx (SomeTx tx Cardano.Api.AllegraEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.AllegraEra tx
-toSealedTx (CardanoTx (SomeTx tx Cardano.Api.MaryEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.MaryEra tx
-toSealedTx (CardanoTx (SomeTx tx Cardano.Api.AlonzoEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.AlonzoEra tx
-toSealedTx (CardanoTx (SomeTx tx Cardano.Api.BabbageEraInCardanoMode)) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.BabbageEra tx
+toSealedTx (CardanoTx tx Cardano.Api.ByronEraInCardanoMode) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.ByronEra tx
+toSealedTx (CardanoTx tx Cardano.Api.ShelleyEraInCardanoMode) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.ShelleyEra tx
+toSealedTx (CardanoTx tx Cardano.Api.AllegraEraInCardanoMode) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.AllegraEra tx
+toSealedTx (CardanoTx tx Cardano.Api.MaryEraInCardanoMode) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.MaryEra tx
+toSealedTx (CardanoTx tx Cardano.Api.AlonzoEraInCardanoMode) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.AlonzoEra tx
+toSealedTx (CardanoTx tx Cardano.Api.BabbageEraInCardanoMode) = Right $ C.sealedTxFromCardano $ Cardano.Api.InAnyCardanoEra Cardano.Api.BabbageEra tx
 
 throwOtherError :: (Member (Error WalletAPIError) effs, Show err) => err -> Eff effs a
 throwOtherError = throwError . OtherError . pack . show

--- a/plutus-pab/src/Plutus/PAB/Arbitrary.hs
+++ b/plutus-pab/src/Plutus/PAB/Arbitrary.hs
@@ -26,8 +26,7 @@ import Ledger.Crypto (PubKey, Signature)
 import Ledger.Interval (Extended, Interval, LowerBound, UpperBound)
 import Ledger.Scripts (Language (..), Versioned (..))
 import Ledger.Slot (Slot)
-import Ledger.Tx (Certificate, RedeemerPtr, ScriptTag, Tx, TxId, TxIn, TxInType, TxInput, TxInputType, TxOutRef,
-                  Withdrawal)
+import Ledger.Tx (Certificate, RedeemerPtr, ScriptTag, TxId, TxIn, TxInType, TxInput, TxInputType, TxOutRef, Withdrawal)
 import Ledger.Tx.CardanoAPI (ToCardanoError, toCardanoAddressInEra, toCardanoTxOut)
 import Ledger.Tx.Constraints (MkTxError)
 import Ledger.Value.CardanoAPI (policyId)
@@ -105,10 +104,6 @@ instance Arbitrary WalletAPIError where
     shrink = genericShrink
 
 instance Arbitrary ToCardanoError where
-    arbitrary = genericArbitrary
-    shrink = genericShrink
-
-instance Arbitrary Tx where
     arbitrary = genericArbitrary
     shrink = genericShrink
 

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/RequestHandlers.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/RequestHandlers.hs
@@ -20,7 +20,7 @@ import Data.Aeson qualified as JSON
 import Data.Aeson.Encode.Pretty qualified as JSON
 import Data.ByteString.Lazy.Char8 qualified as BSL8
 import GHC.Generics (Generic)
-import Ledger.Tx (Tx, txId)
+import Ledger.Tx (CardanoTx, getCardanoTxId)
 import Plutus.Contract.Effects (PABReq (..), PABResp (..))
 import Plutus.Contract.Resumable (IterationID, Request (..), Response (..))
 import Plutus.Contract.Trace.RequestHandler (RequestHandlerLogMsg)
@@ -50,7 +50,7 @@ data ContractInstanceMsg t =
     | ActivatedContractInstance (Contract.ContractDef t) Wallet ContractInstanceId
     | RunRequestHandler ContractInstanceId Int -- number of requests
     | RunRequestHandlerDidNotHandleAnyEvents
-    | StoringSignedTx Tx
+    | StoringSignedTx CardanoTx
     | CallingEndpoint String ContractInstanceId JSON.Value
     | ProcessContractInbox ContractInstanceId
     | HandlingRequest RequestHandlerLogMsg
@@ -152,7 +152,7 @@ instance Pretty (Contract.ContractDef t) => Pretty (ContractInstanceMsg t) where
         ActivatedContractInstance _ wallet instanceID -> "Activated instance" <+> pretty instanceID <+> "on" <+> pretty wallet
         RunRequestHandler instanceID numRequests -> "Running request handler for" <+> pretty instanceID <+> "with" <+> pretty numRequests <+> "requests."
         RunRequestHandlerDidNotHandleAnyEvents -> "runRequestHandler: did not handle any requests"
-        StoringSignedTx tx -> "Storing signed tx" <+> pretty (txId tx)
+        StoringSignedTx tx -> "Storing signed tx" <+> pretty (getCardanoTxId tx)
         CallingEndpoint endpoint instanceID value ->
             "Calling endpoint" <+> pretty endpoint <+> "on instance" <+> pretty instanceID <+> "with" <+> viaShow value
         ProcessContractInbox i -> "Processing contract inbox for" <+> pretty i

--- a/plutus-pab/src/Plutus/PAB/Events.hs
+++ b/plutus-pab/src/Plutus/PAB/Events.hs
@@ -21,7 +21,7 @@ module Plutus.PAB.Events
 import Control.Lens.TH (makePrisms)
 import Data.Aeson (FromJSON, ToJSON, Value)
 import GHC.Generics (Generic)
-import Ledger.Tx (Tx, txId)
+import Ledger.Tx (CardanoTx, getCardanoTxId)
 import Plutus.Contract.Effects (PABReq, PABResp)
 import Plutus.Contract.State (ContractResponse)
 import Plutus.PAB.Webserver.Types (ContractActivationArgs)
@@ -31,7 +31,7 @@ import Wallet.Types (ContractInstanceId)
 -- | A structure which ties together all possible event types into one parent.
 data PABEvent t =
     UpdateContractInstanceState !(ContractActivationArgs t) !ContractInstanceId !(ContractResponse Value Value PABResp PABReq) -- ^ Update the state of a contract instance
-    | SubmitTx !Tx -- ^ Send a transaction to the node
+    | SubmitTx !CardanoTx -- ^ Send a transaction to the node
     | ActivateContract !(ContractActivationArgs t) !ContractInstanceId
     | StopContract !ContractInstanceId
     deriving stock (Eq, Show, Generic)
@@ -42,6 +42,6 @@ makePrisms ''PABEvent
 instance Pretty t => Pretty (PABEvent t) where
     pretty = \case
         UpdateContractInstanceState t i _ -> "Update state:" <+> pretty t <+> pretty i
-        SubmitTx t                        -> "SubmitTx:" <+> pretty (txId t)
+        SubmitTx t                        -> "SubmitTx:" <+> pretty (getCardanoTxId t)
         ActivateContract _ i              -> "Start contract instance" <+> pretty i
         StopContract i                    -> "Stop contract instance" <+> pretty i

--- a/plutus-pab/src/Plutus/PAB/Webserver/Types.hs
+++ b/plutus-pab/src/Plutus/PAB/Webserver/Types.hs
@@ -29,7 +29,7 @@ import Data.OpenApi (NamedSchema (NamedSchema), OpenApiType (OpenApiObject), byt
                      required, type_)
 import Data.OpenApi.Schema qualified as OpenApi
 import GHC.Generics (Generic)
-import Ledger (Certificate, Datum, POSIXTime (POSIXTime), PaymentPubKeyHash (PaymentPubKeyHash), PubKeyHash, Tx, TxId,
+import Ledger (Certificate, Datum, POSIXTime (POSIXTime), PaymentPubKeyHash (PaymentPubKeyHash), PubKeyHash, TxId,
                TxOut, Value, Withdrawal)
 import Ledger.Crypto (PubKey (PubKey), Signature (Signature))
 import Ledger.Index (UtxoIndex)
@@ -114,7 +114,6 @@ deriving instance OpenApi.ToSchema TxInputType
 deriving instance OpenApi.ToSchema TxInput
 deriving instance OpenApi.ToSchema Withdrawal
 deriving instance OpenApi.ToSchema Certificate
-deriving anyclass instance OpenApi.ToSchema Tx
 deriving anyclass instance OpenApi.ToSchema UtxoIndex
 deriving anyclass instance OpenApi.ToSchema CardanoTx
 deriving anyclass instance OpenApi.ToSchema DereferencedInput
@@ -124,7 +123,7 @@ deriving anyclass instance OpenApi.ToSchema AnnotatedTx
 
 data ChainReport =
     ChainReport
-        { transactionMap      :: Map TxId Tx
+        { transactionMap      :: Map TxId CardanoTx
         , utxoIndex           :: UtxoIndex
         , annotatedBlockchain :: [[AnnotatedTx]]
         }

--- a/plutus-pab/src/Plutus/PAB/Webserver/Types.hs
+++ b/plutus-pab/src/Plutus/PAB/Webserver/Types.hs
@@ -115,7 +115,6 @@ deriving instance OpenApi.ToSchema TxInput
 deriving instance OpenApi.ToSchema Withdrawal
 deriving instance OpenApi.ToSchema Certificate
 deriving anyclass instance OpenApi.ToSchema UtxoIndex
-deriving anyclass instance OpenApi.ToSchema CardanoTx
 deriving anyclass instance OpenApi.ToSchema DereferencedInput
 deriving anyclass instance OpenApi.ToSchema BeneficialOwner
 deriving anyclass instance OpenApi.ToSchema TxKey

--- a/plutus-tx-constraints/changelog.d/20230302_122624_ak3n_drop_emulator_tx.md
+++ b/plutus-tx-constraints/changelog.d/20230302_122624_ak3n_drop_emulator_tx.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Remove `UnbalancedEmulatorTx` and `unBalancedTxTx` as the `Tx` was removed from `plutus-ledger`.

--- a/plutus-tx-constraints/test/Spec.hs
+++ b/plutus-tx-constraints/test/Spec.hs
@@ -34,7 +34,7 @@ import Ledger.Crypto (PubKeyHash (PubKeyHash))
 import Ledger.Scripts (WitCtx (WitCtxStake), examplePlutusScriptAlwaysSucceedsHash)
 import Ledger.Slot qualified as Slot
 import Ledger.Test (asRedeemer)
-import Ledger.Tx (Tx (txOutputs), TxOut (TxOut), txOutAddress)
+import Ledger.Tx (TxOut (TxOut), txOutAddress)
 import Ledger.Tx.CardanoAPI qualified as C
 import Ledger.Tx.Constraints as Constraints
 import Ledger.Tx.Constraints.OffChain qualified as OC

--- a/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
@@ -1,4 +1,4 @@
-Slot 0: TxnValidate 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84 [  ]
+Slot 0: TxnValidate d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d [  ]
 Slot 1: 00000000-0000-4000-8000-000000000000 {Wallet W[1]}:
           Contract instance started
 Slot 1: 00000000-0000-4000-8000-000000000000 {Wallet W[1]}:
@@ -43,11 +43,11 @@ Slot 1: W[2]: Balancing an unbalanced transaction:
                 Requires signatures:
                 Utxo index:
 Slot 1: W[2]: Finished balancing:
-                Tx 347e93f9aef35ed28126dce19cf9f4d8f88d49b6afb4b9983a03d79e8ac81be4:
+                Tx 454b0dec735648cb9923b835b48f4ff8e9e80bf99ad081c2d905d801c6ce3328:
                   {inputs:
-                     - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!20
+                     - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!20
 
-                     - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!21
+                     - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!21
 
                   reference inputs:
                   collateral inputs:
@@ -64,9 +64,9 @@ Slot 1: W[2]: Finished balancing:
                     ( 77ab184b7537cd4b1dc3730f6a8a76a3d3aad1642fae9d769aa5dae40be38b51
                     , "\128\164\244[V\184\141\DC19\218#\188L<u\236m2\148<\b\DEL%\v\134\EM<\167" )
                   redeemers:}
-Slot 1: W[2]: Signing tx: 347e93f9aef35ed28126dce19cf9f4d8f88d49b6afb4b9983a03d79e8ac81be4
-Slot 1: W[2]: Submitting tx: 347e93f9aef35ed28126dce19cf9f4d8f88d49b6afb4b9983a03d79e8ac81be4
-Slot 1: W[2]: TxSubmit: 347e93f9aef35ed28126dce19cf9f4d8f88d49b6afb4b9983a03d79e8ac81be4
+Slot 1: W[2]: Signing tx: 454b0dec735648cb9923b835b48f4ff8e9e80bf99ad081c2d905d801c6ce3328
+Slot 1: W[2]: Submitting tx: 454b0dec735648cb9923b835b48f4ff8e9e80bf99ad081c2d905d801c6ce3328
+Slot 1: W[2]: TxSubmit: 454b0dec735648cb9923b835b48f4ff8e9e80bf99ad081c2d905d801c6ce3328
 Slot 1: W[3]: Balancing an unbalanced transaction:
                 Tx:
                   Tx 194cca53f8695e0a74eea757808428376b4bfd8a06fccaf19e75f9129459915e:
@@ -87,11 +87,11 @@ Slot 1: W[3]: Balancing an unbalanced transaction:
                 Requires signatures:
                 Utxo index:
 Slot 1: W[3]: Finished balancing:
-                Tx a522f112d96e2dd90ac280b540e7c7823f8431a9b3978e6fdc6fb6d6c4df2e31:
+                Tx 2cf42b87d8872ad340b26fb4926eb29b40fffddfeb8745cdd970ea6f51762287:
                   {inputs:
-                     - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!0
+                     - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!0
 
-                     - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!1
+                     - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!1
 
                   reference inputs:
                   collateral inputs:
@@ -108,9 +108,9 @@ Slot 1: W[3]: Finished balancing:
                     ( 2cc2afd267462229babbc139837611310e4307bd6c7e870049c22fb02c2ad122
                     , ".\n\214\f2\a$\140\236\212}\189\227\215R\224\170\209A\214\184\248\SUB\194\198\236\162|" )
                   redeemers:}
-Slot 1: W[3]: Signing tx: a522f112d96e2dd90ac280b540e7c7823f8431a9b3978e6fdc6fb6d6c4df2e31
-Slot 1: W[3]: Submitting tx: a522f112d96e2dd90ac280b540e7c7823f8431a9b3978e6fdc6fb6d6c4df2e31
-Slot 1: W[3]: TxSubmit: a522f112d96e2dd90ac280b540e7c7823f8431a9b3978e6fdc6fb6d6c4df2e31
+Slot 1: W[3]: Signing tx: 2cf42b87d8872ad340b26fb4926eb29b40fffddfeb8745cdd970ea6f51762287
+Slot 1: W[3]: Submitting tx: 2cf42b87d8872ad340b26fb4926eb29b40fffddfeb8745cdd970ea6f51762287
+Slot 1: W[3]: TxSubmit: 2cf42b87d8872ad340b26fb4926eb29b40fffddfeb8745cdd970ea6f51762287
 Slot 1: W[4]: Balancing an unbalanced transaction:
                 Tx:
                   Tx 3d717362ec1a56be4e25bfb41385cf70fea675caa88a2c6f1005b4de6dee4860:
@@ -131,9 +131,9 @@ Slot 1: W[4]: Balancing an unbalanced transaction:
                 Requires signatures:
                 Utxo index:
 Slot 1: W[4]: Finished balancing:
-                Tx 7a0884c15e9e68dee44e312b74b890119b98e341764d8d797d6e36d851b14df6:
+                Tx 4219625e5c8cbb7aac9cd02a8fe6abba627e11289cc9cae55c273aa0b713eee8:
                   {inputs:
-                     - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!10
+                     - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!10
 
                   reference inputs:
                   collateral inputs:
@@ -150,23 +150,23 @@ Slot 1: W[4]: Finished balancing:
                     ( 63f4305deedb48449f218150b39eceb8d5951aa680e28a414024bc4c04758969
                     , "U}#\192\165\&3\180\210\149\172-\193Kx:~\252);\194>\222\136\166\254\253 =" )
                   redeemers:}
-Slot 1: W[4]: Signing tx: 7a0884c15e9e68dee44e312b74b890119b98e341764d8d797d6e36d851b14df6
-Slot 1: W[4]: Submitting tx: 7a0884c15e9e68dee44e312b74b890119b98e341764d8d797d6e36d851b14df6
-Slot 1: W[4]: TxSubmit: 7a0884c15e9e68dee44e312b74b890119b98e341764d8d797d6e36d851b14df6
-Slot 1: TxnValidate 7a0884c15e9e68dee44e312b74b890119b98e341764d8d797d6e36d851b14df6 [  ]
-Slot 1: TxnValidate a522f112d96e2dd90ac280b540e7c7823f8431a9b3978e6fdc6fb6d6c4df2e31 [  ]
-Slot 1: TxnValidate 347e93f9aef35ed28126dce19cf9f4d8f88d49b6afb4b9983a03d79e8ac81be4 [  ]
+Slot 1: W[4]: Signing tx: 4219625e5c8cbb7aac9cd02a8fe6abba627e11289cc9cae55c273aa0b713eee8
+Slot 1: W[4]: Submitting tx: 4219625e5c8cbb7aac9cd02a8fe6abba627e11289cc9cae55c273aa0b713eee8
+Slot 1: W[4]: TxSubmit: 4219625e5c8cbb7aac9cd02a8fe6abba627e11289cc9cae55c273aa0b713eee8
+Slot 1: TxnValidate 4219625e5c8cbb7aac9cd02a8fe6abba627e11289cc9cae55c273aa0b713eee8 [  ]
+Slot 1: TxnValidate 2cf42b87d8872ad340b26fb4926eb29b40fffddfeb8745cdd970ea6f51762287 [  ]
+Slot 1: TxnValidate 454b0dec735648cb9923b835b48f4ff8e9e80bf99ad081c2d905d801c6ce3328 [  ]
 Slot 20: 00000000-0000-4000-8000-000000000000 {Wallet W[1]}:
            Contract log: String "Collecting funds"
 Slot 20: W[1]: Balancing an unbalanced transaction:
                  Tx:
-                   Tx 1a10475d70fa7871c67872e654e30a722c904be8659271930819de11666290a6:
+                   Tx 9088249ae32dbe7e723828c6806f84857068badb79061715ba69234e6fd0b4de:
                      {inputs:
-                        - 347e93f9aef35ed28126dce19cf9f4d8f88d49b6afb4b9983a03d79e8ac81be4!0
+                        - 2cf42b87d8872ad340b26fb4926eb29b40fffddfeb8745cdd970ea6f51762287!0
 
-                        - 7a0884c15e9e68dee44e312b74b890119b98e341764d8d797d6e36d851b14df6!0
+                        - 4219625e5c8cbb7aac9cd02a8fe6abba627e11289cc9cae55c273aa0b713eee8!0
 
-                        - a522f112d96e2dd90ac280b540e7c7823f8431a9b3978e6fdc6fb6d6c4df2e31!0
+                        - 454b0dec735648cb9923b835b48f4ff8e9e80bf99ad081c2d905d801c6ce3328!0
 
                      reference inputs:
                      collateral inputs:
@@ -182,44 +182,38 @@ Slot 20: W[1]: Balancing an unbalanced transaction:
                        ( 77ab184b7537cd4b1dc3730f6a8a76a3d3aad1642fae9d769aa5dae40be38b51
                        , "\128\164\244[V\184\141\DC19\218#\188L<u\236m2\148<\b\DEL%\v\134\EM<\167" )
                      redeemers:
-<<<<<<< HEAD
-                       RedeemerPtr Spend 0 : Redeemer {getRedeemer = Constr 0 []}
-                       RedeemerPtr Spend 1 : Redeemer {getRedeemer = Constr 0 []}
-                       RedeemerPtr Spend 2 : Redeemer {getRedeemer = Constr 0 []}
+                       RedeemerPtr Spend 0 : Constr 0 []
+                       RedeemerPtr Spend 1 : Constr 0 []
+                       RedeemerPtr Spend 2 : Constr 0 []
                      attached scripts:
                        PlutusScript PlutusV2 ScriptHash "c3387c08305c03856c391b6c1b1bc872331a3a238fbaf72051142264"}
                  Requires signatures:
                    "a2c20c77887ace1cd986193e4e75babd8993cfd56995cd5cfce609c2"
-=======
-                       RedeemerPtr Spend 0 : Constr 0 []
-                       RedeemerPtr Spend 1 : Constr 0 []
-                       RedeemerPtr Spend 2 : Constr 0 []}
->>>>>>> 063752850 (Drop EmulatorTx)
                  Utxo index:
-                   ( 347e93f9aef35ed28126dce19cf9f4d8f88d49b6afb4b9983a03d79e8ac81be4!0
-                   , - 10000000 lovelace addressed to
-                       ScriptCredential: c3387c08305c03856c391b6c1b1bc872331a3a238fbaf72051142264 (no staking credential)
-                       with datum hash 77ab184b7537cd4b1dc3730f6a8a76a3d3aad1642fae9d769aa5dae40be38b51 )
-                   ( 7a0884c15e9e68dee44e312b74b890119b98e341764d8d797d6e36d851b14df6!0
-                   , - 2500000 lovelace addressed to
-                       ScriptCredential: c3387c08305c03856c391b6c1b1bc872331a3a238fbaf72051142264 (no staking credential)
-                       with datum hash 63f4305deedb48449f218150b39eceb8d5951aa680e28a414024bc4c04758969 )
-                   ( a522f112d96e2dd90ac280b540e7c7823f8431a9b3978e6fdc6fb6d6c4df2e31!0
+                   ( 2cf42b87d8872ad340b26fb4926eb29b40fffddfeb8745cdd970ea6f51762287!0
                    , - 10000000 lovelace addressed to
                        ScriptCredential: c3387c08305c03856c391b6c1b1bc872331a3a238fbaf72051142264 (no staking credential)
                        with datum hash 2cc2afd267462229babbc139837611310e4307bd6c7e870049c22fb02c2ad122 )
+                   ( 4219625e5c8cbb7aac9cd02a8fe6abba627e11289cc9cae55c273aa0b713eee8!0
+                   , - 2500000 lovelace addressed to
+                       ScriptCredential: c3387c08305c03856c391b6c1b1bc872331a3a238fbaf72051142264 (no staking credential)
+                       with datum hash 63f4305deedb48449f218150b39eceb8d5951aa680e28a414024bc4c04758969 )
+                   ( 454b0dec735648cb9923b835b48f4ff8e9e80bf99ad081c2d905d801c6ce3328!0
+                   , - 10000000 lovelace addressed to
+                       ScriptCredential: c3387c08305c03856c391b6c1b1bc872331a3a238fbaf72051142264 (no staking credential)
+                       with datum hash 77ab184b7537cd4b1dc3730f6a8a76a3d3aad1642fae9d769aa5dae40be38b51 )
 Slot 20: W[1]: Finished balancing:
-                 Tx 19f9d8e8183af81bd3a4163a31dd31098c7e705fa33eaa224922847f9726409f:
+                 Tx 0f1c069771f164f1a8a13e20bf8f6ee125b349c0780b54c7ca899c1a87237263:
                    {inputs:
-                      - 347e93f9aef35ed28126dce19cf9f4d8f88d49b6afb4b9983a03d79e8ac81be4!0
+                      - 2cf42b87d8872ad340b26fb4926eb29b40fffddfeb8745cdd970ea6f51762287!0
 
-                      - 7a0884c15e9e68dee44e312b74b890119b98e341764d8d797d6e36d851b14df6!0
+                      - 4219625e5c8cbb7aac9cd02a8fe6abba627e11289cc9cae55c273aa0b713eee8!0
 
-                      - a522f112d96e2dd90ac280b540e7c7823f8431a9b3978e6fdc6fb6d6c4df2e31!0
+                      - 454b0dec735648cb9923b835b48f4ff8e9e80bf99ad081c2d905d801c6ce3328!0
 
                    reference inputs:
                    collateral inputs:
-                     - 43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84!50
+                     - d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d!50
 
                    outputs:
                      - 21983335 lovelace addressed to
@@ -239,23 +233,17 @@ Slot 20: W[1]: Finished balancing:
                      ( 77ab184b7537cd4b1dc3730f6a8a76a3d3aad1642fae9d769aa5dae40be38b51
                      , "\128\164\244[V\184\141\DC19\218#\188L<u\236m2\148<\b\DEL%\v\134\EM<\167" )
                    redeemers:
-<<<<<<< HEAD
-                     RedeemerPtr Spend 0 : Redeemer {getRedeemer = Constr 0 []}
-                     RedeemerPtr Spend 1 : Redeemer {getRedeemer = Constr 0 []}
-                     RedeemerPtr Spend 2 : Redeemer {getRedeemer = Constr 0 []}
-                   attached scripts:
-                     PlutusScript PlutusV2 ScriptHash "c3387c08305c03856c391b6c1b1bc872331a3a238fbaf72051142264"}
-=======
                      RedeemerPtr Spend 0 : Constr 0 []
                      RedeemerPtr Spend 1 : Constr 0 []
-                     RedeemerPtr Spend 2 : Constr 0 []}
->>>>>>> 063752850 (Drop EmulatorTx)
-Slot 20: W[1]: Signing tx: 19f9d8e8183af81bd3a4163a31dd31098c7e705fa33eaa224922847f9726409f
-Slot 20: W[1]: Submitting tx: 19f9d8e8183af81bd3a4163a31dd31098c7e705fa33eaa224922847f9726409f
-Slot 20: W[1]: TxSubmit: 19f9d8e8183af81bd3a4163a31dd31098c7e705fa33eaa224922847f9726409f
+                     RedeemerPtr Spend 2 : Constr 0 []
+                   attached scripts:
+                     PlutusScript PlutusV2 ScriptHash "c3387c08305c03856c391b6c1b1bc872331a3a238fbaf72051142264"}
+Slot 20: W[1]: Signing tx: 0f1c069771f164f1a8a13e20bf8f6ee125b349c0780b54c7ca899c1a87237263
+Slot 20: W[1]: Submitting tx: 0f1c069771f164f1a8a13e20bf8f6ee125b349c0780b54c7ca899c1a87237263
+Slot 20: W[1]: TxSubmit: 0f1c069771f164f1a8a13e20bf8f6ee125b349c0780b54c7ca899c1a87237263
 Slot 20: 00000000-0000-4000-8000-000000000000 {Wallet W[1]}:
            Contract instance stopped (no errors)
-Slot 20: TxnValidate 19f9d8e8183af81bd3a4163a31dd31098c7e705fa33eaa224922847f9726409f [ Data decoded successfully
+Slot 20: TxnValidate 0f1c069771f164f1a8a13e20bf8f6ee125b349c0780b54c7ca899c1a87237263 [ Data decoded successfully
                                                                                       , Redeemer decoded successfully
                                                                                       , Script context decoded successfully
                                                                                       , Data decoded successfully

--- a/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
@@ -182,6 +182,7 @@ Slot 20: W[1]: Balancing an unbalanced transaction:
                        ( 77ab184b7537cd4b1dc3730f6a8a76a3d3aad1642fae9d769aa5dae40be38b51
                        , "\128\164\244[V\184\141\DC19\218#\188L<u\236m2\148<\b\DEL%\v\134\EM<\167" )
                      redeemers:
+<<<<<<< HEAD
                        RedeemerPtr Spend 0 : Redeemer {getRedeemer = Constr 0 []}
                        RedeemerPtr Spend 1 : Redeemer {getRedeemer = Constr 0 []}
                        RedeemerPtr Spend 2 : Redeemer {getRedeemer = Constr 0 []}
@@ -189,6 +190,11 @@ Slot 20: W[1]: Balancing an unbalanced transaction:
                        PlutusScript PlutusV2 ScriptHash "c3387c08305c03856c391b6c1b1bc872331a3a238fbaf72051142264"}
                  Requires signatures:
                    "a2c20c77887ace1cd986193e4e75babd8993cfd56995cd5cfce609c2"
+=======
+                       RedeemerPtr Spend 0 : Constr 0 []
+                       RedeemerPtr Spend 1 : Constr 0 []
+                       RedeemerPtr Spend 2 : Constr 0 []}
+>>>>>>> 063752850 (Drop EmulatorTx)
                  Utxo index:
                    ( 347e93f9aef35ed28126dce19cf9f4d8f88d49b6afb4b9983a03d79e8ac81be4!0
                    , - 10000000 lovelace addressed to
@@ -233,11 +239,17 @@ Slot 20: W[1]: Finished balancing:
                      ( 77ab184b7537cd4b1dc3730f6a8a76a3d3aad1642fae9d769aa5dae40be38b51
                      , "\128\164\244[V\184\141\DC19\218#\188L<u\236m2\148<\b\DEL%\v\134\EM<\167" )
                    redeemers:
+<<<<<<< HEAD
                      RedeemerPtr Spend 0 : Redeemer {getRedeemer = Constr 0 []}
                      RedeemerPtr Spend 1 : Redeemer {getRedeemer = Constr 0 []}
                      RedeemerPtr Spend 2 : Redeemer {getRedeemer = Constr 0 []}
                    attached scripts:
                      PlutusScript PlutusV2 ScriptHash "c3387c08305c03856c391b6c1b1bc872331a3a238fbaf72051142264"}
+=======
+                     RedeemerPtr Spend 0 : Constr 0 []
+                     RedeemerPtr Spend 1 : Constr 0 []
+                     RedeemerPtr Spend 2 : Constr 0 []}
+>>>>>>> 063752850 (Drop EmulatorTx)
 Slot 20: W[1]: Signing tx: 19f9d8e8183af81bd3a4163a31dd31098c7e705fa33eaa224922847f9726409f
 Slot 20: W[1]: Submitting tx: 19f9d8e8183af81bd3a4163a31dd31098c7e705fa33eaa224922847f9726409f
 Slot 20: W[1]: TxSubmit: 19f9d8e8183af81bd3a4163a31dd31098c7e705fa33eaa224922847f9726409f

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -1,7 +1,7 @@
 ==== Slot #0, Tx #0 ====
-TxId:       43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+TxId:       d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
 Fee:        0 lovelace
-Mint:       1000000000 lovelace
+Mint:       
 Inputs:
   
 
@@ -550,7 +550,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       7a0884c15e9e68dee44e312b74b890119b98e341764d8d797d6e36d851b14df6
+TxId:       4219625e5c8cbb7aac9cd02a8fe6abba627e11289cc9cae55c273aa0b713eee8
 Fee:        170209 lovelace
 Mint:       
 Inputs:
@@ -559,7 +559,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+    Tx:     d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
     Output #10
 
 
@@ -621,7 +621,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  2500000
 
 ==== Slot #1, Tx #1 ====
-TxId:       a522f112d96e2dd90ac280b540e7c7823f8431a9b3978e6fdc6fb6d6c4df2e31
+TxId:       2cf42b87d8872ad340b26fb4926eb29b40fffddfeb8745cdd970ea6f51762287
 Fee:        176237 lovelace
 Mint:       
 Inputs:
@@ -630,7 +630,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+    Tx:     d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
     Output #0
 
   ---- Input 1 ----
@@ -638,7 +638,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+    Tx:     d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
     Output #1
 
 
@@ -700,7 +700,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  12500000
 
 ==== Slot #1, Tx #2 ====
-TxId:       347e93f9aef35ed28126dce19cf9f4d8f88d49b6afb4b9983a03d79e8ac81be4
+TxId:       454b0dec735648cb9923b835b48f4ff8e9e80bf99ad081c2d905d801c6ce3328
 Fee:        176237 lovelace
 Mint:       
 Inputs:
@@ -709,7 +709,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+    Tx:     d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
     Output #20
 
   ---- Input 1 ----
@@ -717,7 +717,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+    Tx:     d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
     Output #21
 
 
@@ -779,7 +779,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  22500000
 
 ==== Slot #2, Tx #0 ====
-TxId:       19f9d8e8183af81bd3a4163a31dd31098c7e705fa33eaa224922847f9726409f
+TxId:       0f1c069771f164f1a8a13e20bf8f6ee125b349c0780b54c7ca899c1a87237263
 Fee:        516665 lovelace
 Mint:       
 Inputs:
@@ -788,7 +788,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     347e93f9aef35ed28126dce19cf9f4d8f88d49b6afb4b9983a03d79e8ac81be4
+    Tx:     2cf42b87d8872ad340b26fb4926eb29b40fffddfeb8745cdd970ea6f51762287
     Output #0
 
   ---- Input 1 ----
@@ -796,7 +796,7 @@ Inputs:
   Value:
     2500000 lovelace
   Source:
-    Tx:     7a0884c15e9e68dee44e312b74b890119b98e341764d8d797d6e36d851b14df6
+    Tx:     4219625e5c8cbb7aac9cd02a8fe6abba627e11289cc9cae55c273aa0b713eee8
     Output #0
 
   ---- Input 2 ----
@@ -804,7 +804,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     a522f112d96e2dd90ac280b540e7c7823f8431a9b3978e6fdc6fb6d6c4df2e31
+    Tx:     454b0dec735648cb9923b835b48f4ff8e9e80bf99ad081c2d905d801c6ce3328
     Output #0
 
 

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -1,7 +1,7 @@
 ==== Slot #0, Tx #0 ====
-TxId:       43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+TxId:       d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
 Fee:        0 lovelace
-Mint:       1000000000 lovelace
+Mint:       
 Inputs:
   
 
@@ -550,7 +550,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       18ff0a43c9a18aa720d0374db11148469bc7c1463775e27926d9e3e7da8a9c4d
+TxId:       4c26b0e20a3bd083e200e2ea03b380d2e591d9f428f466b7185495fcab5d2468
 Fee:        178173 lovelace
 Mint:       
 Inputs:
@@ -559,7 +559,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+    Tx:     d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
     Output #50
 
   ---- Input 1 ----
@@ -567,7 +567,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+    Tx:     d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
     Output #51
 
 

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -1,7 +1,7 @@
 ==== Slot #0, Tx #0 ====
-TxId:       43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+TxId:       d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
 Fee:        0 lovelace
-Mint:       1000000000 lovelace
+Mint:       
 Inputs:
   
 
@@ -550,7 +550,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       a4eee47264b19526630a8f0965d3b6e8a10413199f646050603a8255619490a9
+TxId:       076d59eabac93e6688d3cbcca5fe4e1dfc9e83af7812e51ae18bae2edff94bf5
 Fee:        205233 lovelace
 Mint:       
 Inputs:
@@ -559,7 +559,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+    Tx:     d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
     Output #20
 
   ---- Input 1 ----
@@ -567,7 +567,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+    Tx:     d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
     Output #21
 
   ---- Input 2 ----
@@ -575,7 +575,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+    Tx:     d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
     Output #22
 
   ---- Input 3 ----
@@ -583,7 +583,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+    Tx:     d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
     Output #23
 
   ---- Input 4 ----
@@ -591,7 +591,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+    Tx:     d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
     Output #24
 
   ---- Input 5 ----
@@ -599,7 +599,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+    Tx:     d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
     Output #25
 
   ---- Input 6 ----
@@ -607,7 +607,7 @@ Inputs:
   Value:
     10000000 lovelace
   Source:
-    Tx:     43ba666cc8a22a04b63a3b605ce14146dfa5ed999986625ad90c1bc16dabdd84
+    Tx:     d0f5b08cc20688becb8eceba9770a18ea49a49d5df159715b899736bd1d1121d
     Output #26
 
 
@@ -669,7 +669,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  60000000
 
 ==== Slot #2, Tx #0 ====
-TxId:       9d2e1930ee14fe3db091060ab775099f0267e544002ca97b03bf16ed2ac8b451
+TxId:       7512c7a4dc97fc67081756ba375b416b55a2d733ddc8dd453597fb7be56060a7
 Fee:        460575 lovelace
 Mint:       
 Inputs:
@@ -678,7 +678,7 @@ Inputs:
   Value:
     60000000 lovelace
   Source:
-    Tx:     a4eee47264b19526630a8f0965d3b6e8a10413199f646050603a8255619490a9
+    Tx:     076d59eabac93e6688d3cbcca5fe4e1dfc9e83af7812e51ae18bae2edff94bf5
     Output #0
 
 


### PR DESCRIPTION
This PR:
- drops `Tx` and `EmulatorTx` types
- removes `CardanoTx` newtype layer, renames `SomeCardanoTx` to `CardanoTx`

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [x] Important changes are reflected in changelog.d of the affected packages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
