### PR TITLE
PLT-1558: Added golden test for ToJSON instance in the UTXO indexer query

### DIFF
--- a/marconi-mamba/marconi-mamba.cabal
+++ b/marconi-mamba/marconi-mamba.cabal
@@ -207,6 +207,7 @@ test-suite marconi-mamba-test
   ------------------------
   build-depends:
     , aeson
+    , aeson-pretty
     , base                  >=4.9 && <5
     , bytestring
     , containers

--- a/marconi-mamba/src/Marconi/Mamba/Api/Query/Indexers/Utxo.hs
+++ b/marconi-mamba/src/Marconi/Mamba/Api/Query/Indexers/Utxo.hs
@@ -10,6 +10,7 @@ module Marconi.Mamba.Api.Query.Indexers.Utxo
     , writeTMVar
     , writeTMVar'
     ) where
+
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TMVar (TMVar, newEmptyTMVar, putTMVar, tryReadTMVar, tryTakeTMVar)
 import Control.Lens ((^.))

--- a/marconi-mamba/test/Spec/Marconi/Mamba/Api/Query/Indexers/Utxo.hs
+++ b/marconi-mamba/test/Spec/Marconi/Mamba/Api/Query/Indexers/Utxo.hs
@@ -1,36 +1,49 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE TypeApplications   #-}
 
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Spec.Marconi.Mamba.Api.Query.Indexers.Utxo (tests) where
 
+import Cardano.Api qualified as C
 import Control.Concurrent.STM (atomically)
 import Control.Lens.Operators ((^.))
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson qualified as Aeson
+import Data.Aeson.Encode.Pretty qualified as Aeson
+import Data.ByteString.Lazy (ByteString)
 import Data.Foldable (fold)
 import Data.List (nub)
+import Data.Proxy (Proxy (Proxy))
 import Data.Set qualified as Set
 import Gen.Marconi.ChainIndex.Indexers.Utxo (genUtxoEvents)
 import Hedgehog (Property, forAll, property, (===))
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
+import Marconi.ChainIndex.Indexers.Utxo (Utxo (Utxo), UtxoRow (UtxoRow))
 import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 import Marconi.Core.Storable qualified as Storable
 import Marconi.Mamba.Api.Query.Indexers.Utxo qualified as UIQ
 import Marconi.Mamba.Api.Types (HasIndexerEnv (uiIndexer))
 import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Golden (goldenVsStringDiff)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 
 tests :: TestTree
 tests = testGroup "marconi-mamba-utxo query Api Specs"
-    [
-      testPropertyNamed
+    [ testPropertyNamed
         "marconi-mamba-utxo query-target-addresses"
         "Spec. Insert events and query for utxo's with address in the generated ShelleyEra targetAddresses"
         queryTargetAddressTest
+
+    , goldenVsStringDiff
+        "Golden test for conversion of UtxoRow to JSON as Address->UTXO response"
+        (\expected actual -> ["diff", "--color=always", expected, actual])
+        "test/Spec/Marconi/Mamba/Api/Query/Indexers/address-utxo-response.json"
+        generateUtxoRowJson
     ]
 
 -- | Insert events, and perform the callback
@@ -72,3 +85,54 @@ queryTargetAddressTest = property $ do
   -- To remove once the assert above is fixed
   fmap Aeson.encode fetchedRows === fmap Aeson.encode fetchedRows
   fmap Aeson.encode rows === fmap Aeson.encode rows
+
+generateUtxoRowJson :: IO ByteString
+generateUtxoRowJson = do
+    let addressBech32 = "addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc"
+    addr <-
+        either
+            (error . show)
+            pure
+            $ C.deserialiseFromBech32 (C.AsAddress C.AsShelleyAddr) addressBech32
+
+    let datumCbor = "4"
+    datum <-
+        either
+            (error . show)
+            pure
+            $ C.deserialiseFromCBOR C.AsScriptData datumCbor
+
+    let scriptCbor = "484701000022220011"
+    plutusScript <-
+        either
+            (error . show)
+            pure
+            $ C.deserialiseFromRawBytesHex (C.AsPlutusScript C.AsPlutusScriptV1) scriptCbor
+    let script = C.PlutusScript C.PlutusScriptV1 plutusScript
+
+    let txIdRawBytes = "ec7d3bd7c6a3a31368093b077af0db46ceac77956999eb842373e08c6420f000"
+    txId <-
+        either
+            (error . show)
+            pure
+            $ C.deserialiseFromRawBytesHex C.AsTxId $ txIdRawBytes
+
+    let blockHeaderHashRawBytes = "6161616161616161616161616161616161616161616161616161616161616161"
+    blockHeaderHash <-
+        either
+            (error . show)
+            pure
+            $ C.deserialiseFromRawBytesHex (C.AsHash (C.proxyToAsType $ Proxy @C.BlockHeader)) blockHeaderHashRawBytes
+
+    let utxo =
+            Utxo
+                (C.AddressShelley addr)
+                txId
+                (C.TxIx 0)
+                (Just datum)
+                (Just $ C.hashScriptData datum)
+                (C.lovelaceToValue $ C.Lovelace 10_000_000)
+                (Just $ C.ScriptInAnyLang (C.PlutusScriptLanguage C.PlutusScriptV1) script)
+                (Just $ C.hashScript script)
+        utxoRow = UtxoRow utxo (C.SlotNo 1) blockHeaderHash
+    pure $ Aeson.encodePretty utxoRow

--- a/marconi-mamba/test/Spec/Marconi/Mamba/Api/Query/Indexers/address-utxo-response.json
+++ b/marconi-mamba/test/Spec/Marconi/Mamba/Api/Query/Indexers/address-utxo-response.json
@@ -1,0 +1,16 @@
+{
+    "blockHeaderHash": "6161616161616161616161616161616161616161616161616161616161616161",
+    "slotNo": 1,
+    "utxo": {
+        "address": "addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc",
+        "datum": "4",
+        "datumHash": "eb8649214997574e20c464388a172420d25403682bbbb80c496831c8cc1f8f0d",
+        "inlineScript": "0x49484701000022220011",
+        "inlineScriptHash": "284d60f7e56f5fd54faed4c50fd5cab0307da1c4034d6a92c5dbb940",
+        "txId": "ec7d3bd7c6a3a31368093b077af0db46ceac77956999eb842373e08c6420f000",
+        "txIx": 0,
+        "value": {
+            "lovelace": 10000000
+        }
+    }
+}


### PR DESCRIPTION
Users of Marconi will typically communicate with it using the JSON representation of the datatype. Thus, we need to have a golden test case which makes sure that any changes to that representation is expected and validated by PR reviewers.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
    - [x] Important changes are reflected in changelog.d of the affected packages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
