### PR TITLE
Use random ports for CardanoTestnet to prevent conflict

### DIFF
--- a/plutus-e2e-tests/plutus-e2e-tests.cabal
+++ b/plutus-e2e-tests/plutus-e2e-tests.cabal
@@ -67,6 +67,7 @@ common lang
     , filepath
     , lens
     , mwc-random
+    , network
     , optparse-applicative
     , prettyprinter
     , process
@@ -77,6 +78,8 @@ common lang
     , text
     , time
     , transformers-except
+    , unlift
+    , unliftio
     , unordered-containers
 
 test-suite plutus-e2e-tests-test


### PR DESCRIPTION
Looks like [canConnect](https://github.com/input-output-hk/hedgehog-extras/blob/9ea1845ca2036e7a1ae9fcebe393526540c5c233/src/Hedgehog/Extras/Stock/IO/Network/Socket.hs#L40) in Hedgehog.Extras had a bug so [isPortOpen](https://github.com/input-output-hk/hedgehog-extras/blob/9ea1845ca2036e7a1ae9fcebe393526540c5c233/src/Hedgehog/Extras/Stock/IO/Network/Socket.hs#L30) always reported False. Using local copy of implementation with fix for now.