### PR TITLE
PLT-776 Modified the Utxo indexer property test for testing provided target addresses

### DIFF
--- a/marconi-chain-index/changelog.d/20230224_061323_konstantinos.lambrou_PLT_776_fix_test_running_time_of_tx_address_to_utxo_address_test.md
+++ b/marconi-chain-index/changelog.d/20230224_061323_konstantinos.lambrou_PLT_776_fix_test_running_time_of_tx_address_to_utxo_address_test.md
@@ -1,0 +1,3 @@
+### Fixed
+
+* Fixed a bug in the datum extraction in the Utxo indexer

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -163,6 +163,7 @@ library marconi-chain-index-test-lib
   hs-source-dirs:  test-lib
   exposed-modules:
     Gen.Marconi.ChainIndex.Indexers.Utxo
+    Gen.Marconi.ChainIndex.Mockchain
     Gen.Marconi.ChainIndex.Types
     Helpers
 

--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -1,26 +1,28 @@
-{-# LANGUAGE NamedFieldPuns  #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections   #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE RecordWildCards    #-}
 
 module Gen.Marconi.ChainIndex.Indexers.Utxo
     ( genUtxoEvents
     , genShelleyEraUtxoEvents
+    , genUtxoEventsWithTxs
     , genEventWithShelleyAddressAtChainPoint
     )
 where
 
-import Control.Monad (foldM, forM)
+import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as C
+import Control.Monad (forM)
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Maybe (mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
+import GHC.Generics (Generic)
+import Gen.Cardano.Api.Typed qualified as CGen
+import Gen.Marconi.ChainIndex.Mockchain (MockBlock (MockBlock), MockBlockHeader (MockBlockHeader), genMockchain)
 import Hedgehog (Gen)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
-
-import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C
-import Gen.Cardano.Api.Typed qualified as CGen
-import Gen.Marconi.ChainIndex.Types (genChainPoints, genTxOutTxContext, nonEmptySubset)
-import Helpers (emptyTxBodyContent)
 import Marconi.ChainIndex.Indexers.Utxo (StorableEvent (UtxoEvent), Utxo (Utxo), UtxoHandle, _address)
 import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 
@@ -36,25 +38,73 @@ genUtxoEvents = genUtxoEvents' convertTxOutToUtxo
 genUtxoEvents'
   :: (C.TxId -> C.TxIx -> C.TxOut C.CtxTx C.BabbageEra -> Utxo)
   -> Gen [StorableEvent UtxoHandle]
-genUtxoEvents' txOutToUtxo = do
-    chainPoints <- genChainPoints 1 3
-    txIns <- Set.singleton <$> CGen.genTxIn
-    snd <$> foldM f (txIns, []) chainPoints
+genUtxoEvents' txOutToUtxo = fmap fst <$> genUtxoEventsWithTxs' txOutToUtxo
+
+-- | Generates a list of UTXO events, along with the list of transactions that generated each of
+-- them.
+--
+-- This generators has the following properties:
+--
+--   * that any generated UTXO is unique
+--   * for any spent tx output, there must be a UTXO created in a previous event
+genUtxoEventsWithTxs :: Gen [(StorableEvent UtxoHandle, MockBlock C.BabbageEra)]
+genUtxoEventsWithTxs = genUtxoEventsWithTxs' convertTxOutToUtxo
+
+genUtxoEventsWithTxs'
+    :: (C.TxId -> C.TxIx -> C.TxOut C.CtxTx C.BabbageEra -> Utxo)
+    -> Gen [(StorableEvent UtxoHandle, MockBlock C.BabbageEra)]
+genUtxoEventsWithTxs' txOutToUtxo = do
+    fmap (\block -> (getStorableEventFromBlock block, block)) <$> genMockchain
   where
-    f :: (Set C.TxIn, [StorableEvent UtxoHandle])
-      -> C.ChainPoint
-      -> Gen (Set C.TxIn, [StorableEvent UtxoHandle])
-    f (utxoSet, utxoEvents) cp = do
-        utxosAsTxInput <- nonEmptySubset utxoSet
-        txBodyContent <- genTxBodyContentFromTxIns $ Set.toList utxosAsTxInput
-        txBody <- either (fail . show) pure $ C.makeTransactionBody txBodyContent
+    getStorableEventFromBlock :: MockBlock C.BabbageEra -> StorableEvent UtxoHandle
+    getStorableEventFromBlock (MockBlock (MockBlockHeader slotNo blockHeaderHash _blockNo) txs) =
+        let (TxOutBalance utxos spentTxOuts) = foldMap txOutBalanceFromTx txs
+            utxoMap = foldMap getUtxosFromTx txs
+            resolvedUtxos = Set.fromList
+                          $ mapMaybe (`Map.lookup` utxoMap)
+                          $ Set.toList utxos
+         in UtxoEvent resolvedUtxos spentTxOuts (C.ChainPoint slotNo blockHeaderHash)
+
+    getUtxosFromTx :: C.Tx C.BabbageEra -> Map C.TxIn Utxo
+    getUtxosFromTx (C.Tx txBody@(C.TxBody txBodyContent) _) =
         let txId = C.getTxId txBody
-        let newUtxos = fmap (\(txIx, txOut) -> txOutToUtxo txId (C.TxIx txIx) txOut)
+         in Map.fromList
+                $ fmap (\(txIx, txOut) -> ( C.TxIn txId (C.TxIx txIx)
+                                          , txOutToUtxo txId (C.TxIx txIx) txOut))
                 $ zip [0..]
                 $ C.txOuts txBodyContent
-            newUtxoRefs = Set.fromList $ fmap (\Utxo { _txId, _txIx } -> C.TxIn _txId _txIx) newUtxos
-            newUtxoEvent = UtxoEvent (Set.fromList newUtxos) utxosAsTxInput cp
-        pure (Set.union newUtxoRefs $ Set.difference utxoSet utxosAsTxInput, utxoEvents ++ [newUtxoEvent])
+
+-- | The effect of a transaction (or a number of them) on the tx output set.
+data TxOutBalance =
+  TxOutBalance
+    { _tobUnspent :: !(Set C.TxIn)
+    -- ^ Outputs newly added by the transaction(s)
+    , _tobSpent   :: !(Set C.TxIn)
+    -- ^ Outputs spent by the transaction(s)
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance Semigroup TxOutBalance where
+    tobL <> tobR =
+        TxOutBalance
+            { _tobUnspent = _tobUnspent tobR
+                         <> (_tobUnspent tobL `Set.difference` _tobSpent tobR)
+            , _tobSpent = _tobSpent tobL <> _tobSpent tobR
+            }
+
+instance Monoid TxOutBalance where
+    mappend = (<>)
+    mempty = TxOutBalance mempty mempty
+
+txOutBalanceFromTx :: C.Tx era -> TxOutBalance
+txOutBalanceFromTx (C.Tx txBody@(C.TxBody txBodyContent) _) =
+    let txId = C.getTxId txBody
+        txInputs = Set.fromList $ fst <$> C.txIns txBodyContent
+        utxoRefs = Set.fromList
+                 $ fmap (\(txIx, _) -> C.TxIn txId $ C.TxIx txIx)
+                 $ zip [0..]
+                 $ C.txOuts txBodyContent
+     in TxOutBalance utxoRefs txInputs
 
 convertTxOutToUtxo :: C.TxId -> C.TxIx -> C.TxOut C.CtxTx C.BabbageEra -> Utxo
 convertTxOutToUtxo txId txIx (C.TxOut (C.AddressInEra _ addr) val txOutDatum refScript) =
@@ -92,20 +142,6 @@ genShelleyEraUtxoEvents = do
   addr <- CGen.genAddressShelley
   genUtxoEvents' (\_id _ix _tx ->
                     utxoAddressOverride addr $ convertTxOutToUtxo _id _ix _tx)
-
-genTxBodyContentFromTxIns
-    :: [C.TxIn]
-    -> Gen (C.TxBodyContent C.BuildTx C.BabbageEra)
-genTxBodyContentFromTxIns inputs = do
-    txBodyContent <-
-        emptyTxBodyContent (C.TxValidityNoLowerBound, C.TxValidityNoUpperBound C.ValidityNoUpperBoundInBabbageEra)
-            <$> CGen.genProtocolParameters
-    txOuts <- Gen.list (Range.linear 1 5) $ genTxOutTxContext C.BabbageEra
-    pure $ txBodyContent
-        { C.txIns = fmap (, C.BuildTxWith $ C.KeyWitness C.KeyWitnessForSpending) inputs
-        , C.txOuts = txOuts
-        }
-
 
 -- TODO Must be reworked following implementation in 'genUtxoEvents'.
 genEventWithShelleyAddressAtChainPoint :: C.ChainPoint -> Gen (Utxo.StorableEvent Utxo.UtxoHandle)

--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Mockchain.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Mockchain.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE TupleSections      #-}
+
+module Gen.Marconi.ChainIndex.Mockchain
+    ( Mockchain
+    , MockBlockHeader(..)
+    , MockBlock(..)
+    , genMockchain
+    )
+where
+
+import Cardano.Api qualified as C
+import Control.Monad (foldM)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Gen.Cardano.Api.Typed qualified as CGen
+import Gen.Marconi.ChainIndex.Types (genHashBlockHeader, genTxOutTxContext, nonEmptySubset)
+import Hedgehog (Gen)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Helpers (emptyTxBodyContent)
+
+type Mockchain era = [MockBlock era]
+
+data MockBlockHeader = MockBlockHeader
+    { mockBlockHeaderSlotNo  :: !C.SlotNo
+    , mockBlockHeaderHash    :: !(C.Hash C.BlockHeader)
+    , mockBlockHeaderBlockNo :: !C.BlockNo
+    } deriving (Show)
+
+data MockBlock era = MockBlock
+    { mockBlockChainPoint :: !MockBlockHeader
+    , mockBlockTxs        :: ![C.Tx era]
+    } deriving (Show)
+
+genMockchain :: Gen (Mockchain C.BabbageEra)
+genMockchain = do
+    maxSlots <- Gen.word64 (Range.linear 1 5)
+    blockHeaderHash <- genHashBlockHeader
+    let blockHeaders =
+            fmap (\s -> MockBlockHeader (C.SlotNo s) blockHeaderHash (C.BlockNo s))
+                 [0..maxSlots]
+    txIns <- Set.singleton <$> CGen.genTxIn
+    snd <$> foldM f (txIns, []) blockHeaders
+  where
+    f :: (Set C.TxIn, Mockchain C.BabbageEra)
+      -> MockBlockHeader
+      -> Gen (Set C.TxIn, Mockchain C.BabbageEra)
+    f (utxoSet, mockchain) bh = do
+        utxosAsTxInput <- nonEmptySubset utxoSet
+        txBodyContent <- genTxBodyContentFromTxIns $ Set.toList utxosAsTxInput
+        txBody <- either (fail . show) pure $ C.makeTransactionBody txBodyContent
+        let newTx = C.makeSignedTransaction [] txBody
+        let txId = C.getTxId txBody
+        let newUtxoRefs = Set.fromList
+                $ fmap (\(txIx, _) -> C.TxIn txId (C.TxIx txIx))
+                $ zip [0..]
+                $ C.txOuts txBodyContent
+        pure ( Set.union newUtxoRefs $ Set.difference utxoSet utxosAsTxInput
+             , mockchain ++ [MockBlock bh [newTx]]
+             )
+
+genTxBodyContentFromTxIns
+    :: [C.TxIn]
+    -> Gen (C.TxBodyContent C.BuildTx C.BabbageEra)
+genTxBodyContentFromTxIns inputs = do
+    txBodyContent <-
+        emptyTxBodyContent (C.TxValidityNoLowerBound, C.TxValidityNoUpperBound C.ValidityNoUpperBoundInBabbageEra)
+            <$> CGen.genProtocolParameters
+    txOuts <- Gen.list (Range.linear 1 5) $ genTxOutTxContext C.BabbageEra
+    pure $ txBodyContent
+        { C.txIns = fmap (, C.BuildTxWith $ C.KeyWitness C.KeyWitnessForSpending) inputs
+        , C.txOuts = txOuts
+        }


### PR DESCRIPTION
* Changed the `genUtxoEvent` generator so that I can also return the tx that was used to generate it

* The generated tx is customized, thus the modified property test is now a lot faster (runs under 1s)

* Fixed a bug in the datum extraction in the Utxo indexer

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
    - [x] Important changes are reflected in changelog.d of the affected packages
- PR
    - [ ] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
