### PR TITLE
Add V2 TXInfo test to plutus e2e tests

### DIFF
--- a/plutus-e2e-tests/plutus-e2e-tests.cabal
+++ b/plutus-e2e-tests/plutus-e2e-tests.cabal
@@ -99,6 +99,7 @@ test-suite plutus-e2e-tests-test
     PlutusScripts.Helpers
     PlutusScripts.SECP256k1
     PlutusScripts.V1TxInfo
+    PlutusScripts.V2TxInfo
     Spec.AlonzoFeatures
     Spec.BabbageFeatures
     Spec.Builtins.SECP256k1

--- a/plutus-e2e-tests/test/Helpers/Utils.hs
+++ b/plutus-e2e-tests/test/Helpers/Utils.hs
@@ -3,6 +3,7 @@ module Helpers.Utils where
 import Cardano.Api qualified as C
 import Control.Monad (when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Time.Clock.POSIX qualified as Time
 import GHC.Stack qualified as GHC
 import Hedgehog (MonadTest)
 import Hedgehog qualified as H
@@ -59,3 +60,7 @@ maybeReadAs as path = do
   maybeEither . liftIO $ C.readFileTextEnvelope as path'
   where
     maybeEither m = m >>= return . either (const Nothing) Just
+
+-- | Convert a 'POSIXTime' to the number of milliseconds since the Unix epoch.
+posixToMilliseconds :: Time.POSIXTime -> Integer
+posixToMilliseconds posixTime = round $ 1000 * (realToFrac posixTime :: Double)

--- a/plutus-e2e-tests/test/PlutusScripts/Helpers.hs
+++ b/plutus-e2e-tests/test/PlutusScripts/Helpers.hs
@@ -12,9 +12,13 @@ import Codec.Serialise (serialise)
 import Data.ByteString qualified as BS (ByteString)
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Short qualified as SBS
+import Plutus.Script.Utils.Value (CurrencySymbol)
 import Plutus.V1.Ledger.Api (MintingPolicy, Validator, unMintingPolicyScript, unValidatorScript)
+import Plutus.V1.Ledger.Api qualified as PlutusV1
 import Plutus.V1.Ledger.Bytes qualified as P (bytes, fromHex)
+import Plutus.V1.Ledger.Scripts (Datum (Datum), Redeemer (Redeemer))
 import PlutusTx qualified
+import PlutusTx.Builtins qualified as BI
 
 -- | Treat string of hexidecimal bytes literally, without encoding. Useful for hashes.
 bytesFromHex :: BS.ByteString -> BS.ByteString
@@ -31,6 +35,12 @@ defExecutionUnits = C.ExecutionUnits {C.executionSteps = 0, C.executionMemory = 
 -- | Any data to ScriptData. Used for script datum and redeemer.
 toScriptData :: PlutusTx.ToData a => a -> C.ScriptData
 toScriptData a = C.fromPlutusData $ PlutusTx.toData a
+
+asRedeemer :: PlutusTx.ToData a => a -> Redeemer
+asRedeemer a = Redeemer $ PlutusTx.dataToBuiltinData $ PlutusTx.toData a
+
+asDatum :: PlutusTx.ToData a => a -> Datum
+asDatum a = Datum $ PlutusTx.dataToBuiltinData $ PlutusTx.toData a
 
 plutusL1 :: C.ScriptLanguage C.PlutusScriptV1
 plutusL1 = C.PlutusScriptLanguage C.PlutusScriptV1
@@ -121,3 +131,6 @@ policyIdV1 = C.scriptPolicyId . unPlutusScriptV1 . policyScript
 -- | PolicyId of a V2 minting policy
 policyIdV2 :: MintingPolicy -> C.PolicyId
 policyIdV2 = C.scriptPolicyId . unPlutusScriptV2 . policyScript
+
+fromPolicyId :: C.PolicyId -> CurrencySymbol
+fromPolicyId (C.PolicyId hash) = PlutusV1.CurrencySymbol . BI.toBuiltin $ C.serialiseToRawBytes hash

--- a/plutus-e2e-tests/test/PlutusScripts/V1TxInfo.hs
+++ b/plutus-e2e-tests/test/PlutusScripts/V1TxInfo.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE TypeApplications    #-}
 
 {-# OPTIONS_GHC -Wno-missing-fields #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module PlutusScripts.V1TxInfo (
     txInfoInputs

--- a/plutus-e2e-tests/test/PlutusScripts/V2TxInfo.hs
+++ b/plutus-e2e-tests/test/PlutusScripts/V2TxInfo.hs
@@ -1,0 +1,150 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
+
+{-# OPTIONS_GHC -Wno-missing-fields #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
+module PlutusScripts.V2TxInfo (
+    txInfoInputs
+  , txInfoOutputs
+  , txInfoFee
+  , txInfoMint
+  , txInfoSigs
+  , txInfoData
+  , checkV2TxInfoScriptV2
+  , checkV2TxInfoAssetIdV2
+  , checkV2TxInfoRedeemer
+  , checkV2TxInfoMintWitnessV2
+  ) where
+
+import Cardano.Api qualified as C
+import Ledger.Tx.CardanoAPI.Internal (fromCardanoPaymentKeyHash, fromCardanoScriptData, fromCardanoTxIn,
+                                      fromCardanoTxOutToPV2TxInfoTxOut, fromCardanoTxOutToPV2TxInfoTxOut',
+                                      fromCardanoValue)
+import Plutus.Script.Utils.Typed (IsScriptContext (mkUntypedMintingPolicy))
+import Plutus.V1.Ledger.Api (mkMintingPolicyScript)
+import Plutus.V1.Ledger.Interval qualified as P
+import Plutus.V2.Ledger.Api qualified as PlutusV2
+import Plutus.V2.Ledger.Contexts (ownCurrencySymbol)
+import PlutusScripts.Helpers (mintScriptWitness', plutusL2, policyIdV2, policyScript, toScriptData)
+import PlutusTx qualified
+import PlutusTx.AssocMap qualified as AMap
+import PlutusTx.Builtins qualified as P
+import PlutusTx.Prelude qualified as P
+
+data V2TxInfo = V2TxInfo
+  { expTxInfoInputs          :: [PlutusV2.TxInInfo] -- ^ Transaction inputs; cannot be an empty list
+  , expTxInfoReferenceInputs :: [PlutusV2.TxInInfo] -- ^ /Added in V2:/ Transaction reference inputs
+  , expTxInfoOutputs         :: [PlutusV2.TxOut] -- ^ Transaction outputs
+  , expTxInfoFee             :: PlutusV2.Value -- ^ The fee paid by this transaction.
+  , expTxInfoMint            :: PlutusV2.Value -- ^ The 'Value' minted by this transaction.
+  , expTxInfoDCert           :: [PlutusV2.DCert] -- ^ Digests of certificates included in this transaction
+  , expTxInfoWdrl            :: PlutusV2.Map PlutusV2.StakingCredential Integer -- ^ Withdrawals
+  , expTxInfoValidRange      :: PlutusV2.POSIXTimeRange -- ^ The valid range for the transaction.
+  , expTxInfoSignatories     :: [PlutusV2.PubKeyHash] -- ^ Signatures provided with the transaction, attested that they all signed the tx
+  , expTxInfoRedeemers       :: PlutusV2.Map PlutusV2.ScriptPurpose PlutusV2.Redeemer
+  , expTxInfoData            :: PlutusV2.Map PlutusV2.DatumHash PlutusV2.Datum -- ^ The lookup table of datums attached to the transaction
+  -- , expTxInfoId          :: PlutusV2.TxId  -- ^ Hash of the pending transaction body (i.e. transaction excluding witnesses). Cannot be verified onchain.
+  }
+PlutusTx.unstableMakeIsData ''V2TxInfo
+
+checkV2TxInfoRedeemer ::
+  [PlutusV2.TxInInfo] ->
+  [PlutusV2.TxInInfo] ->
+  [PlutusV2.TxOut] ->
+  PlutusV2.Value ->
+  PlutusV2.Value ->
+  [PlutusV2.DCert] ->
+  PlutusV2.Map PlutusV2.StakingCredential Integer ->
+  PlutusV2.POSIXTimeRange ->
+  [PlutusV2.PubKeyHash] ->
+  PlutusV2.Map PlutusV2.ScriptPurpose PlutusV2.Redeemer ->
+  PlutusV2.Map PlutusV2.DatumHash PlutusV2.Datum ->
+  C.ScriptData
+checkV2TxInfoRedeemer expIns expRefIns expOuts expFee expMint expDCert expWdrl expRange expSigs expReds expData =
+  toScriptData $ V2TxInfo expIns expRefIns expOuts expFee expMint expDCert expWdrl expRange expSigs expReds expData
+
+txInfoInputs :: (C.TxIn, C.TxOut C.CtxUTxO era) -> PlutusV2.TxInInfo
+txInfoInputs (txIn, txOut) = do PlutusV2.TxInInfo {
+      PlutusV2.txInInfoOutRef = fromCardanoTxIn txIn
+    , PlutusV2.txInInfoResolved = fromCardanoTxOutToPV2TxInfoTxOut' txOut
+    }
+
+txInfoOutputs :: [C.TxOut C.CtxTx era] -> [PlutusV2.TxOut]
+txInfoOutputs = map fromCardanoTxOutToPV2TxInfoTxOut
+
+txInfoFee :: C.Lovelace -> PlutusV2.Value
+txInfoFee = fromCardanoValue . C.lovelaceToValue
+
+txInfoMint :: C.Value -> PlutusV2.Value
+txInfoMint = fromCardanoValue
+
+txInfoSigs :: [C.VerificationKey C.PaymentKey] -> [PlutusV2.PubKeyHash]
+txInfoSigs = map (fromCardanoPaymentKeyHash . C.verificationKeyHash)
+
+txInfoData :: [C.ScriptData] -> PlutusV2.Map PlutusV2.DatumHash PlutusV2.Datum
+txInfoData = PlutusV2.fromList . map (\ datum ->
+  (PlutusV2.DatumHash $ PlutusV2.toBuiltin $ C.serialiseToRawBytes $ C.hashScriptData datum,
+  PlutusV2.Datum $ fromCardanoScriptData datum))
+
+-- minting policy --
+
+{-# INLINABLE mkCheckV2TxInfo #-}
+mkCheckV2TxInfo :: V2TxInfo -> PlutusV2.ScriptContext -> Bool
+mkCheckV2TxInfo V2TxInfo{..} ctx =
+   P.traceIfFalse "unexpected txInfoInputs" checkTxInfoInputs &&
+   P.traceIfFalse "unexpected txInfoReferenceInputs" checkTxInfoReferenceInputs &&
+   P.traceIfFalse "unexpected txInfoOutputs" checkTxInfoOutputs &&
+   P.traceIfFalse "unexpected txInfoFee" checkTxInfoFee &&
+   P.traceIfFalse "unexpected txInfoMint" checkTxInfoMint &&
+   P.traceIfFalse "unexpected txInfoDCert" checkTxInfoDCert &&
+   P.traceIfFalse "unexpected txInfoWdrl" checkTxInfoWdrl &&
+   P.traceIfFalse "provided range doesn't contain txInfoValidRange" checkTxInfoValidRange &&
+   P.traceIfFalse "unexpected txInfoSignatories" checkTxInfoSignatories &&
+   P.traceIfFalse "unexpected txInfoRedeemers" checkTxInfoRedeemers &&
+   P.traceIfFalse "unexpected txInfoData" checkTxInfoData &&
+   P.traceIfFalse "txInfoId isn't the expected TxId length" checkTxInfoId
+ where
+  info :: PlutusV2.TxInfo
+  info = PlutusV2.scriptContextTxInfo ctx
+
+  checkTxInfoInputs = expTxInfoInputs P.== PlutusV2.txInfoInputs info
+  checkTxInfoReferenceInputs = expTxInfoReferenceInputs P.== PlutusV2.txInfoReferenceInputs info
+  checkTxInfoOutputs = expTxInfoOutputs P.== PlutusV2.txInfoOutputs info
+  checkTxInfoFee = expTxInfoFee P.== PlutusV2.txInfoFee info
+  checkTxInfoMint = expTxInfoMint P.== PlutusV2.txInfoMint info
+  checkTxInfoDCert = expTxInfoDCert P.== PlutusV2.txInfoDCert info
+  checkTxInfoWdrl = expTxInfoWdrl P.== PlutusV2.txInfoWdrl info
+  checkTxInfoValidRange = expTxInfoValidRange `P.contains` PlutusV2.txInfoValidRange info
+  checkTxInfoSignatories = expTxInfoSignatories P.== PlutusV2.txInfoSignatories info
+  checkTxInfoRedeemers = do
+    let ownScriptPurpose  = PlutusV2.Minting (ownCurrencySymbol ctx)
+        withoutOwnRedeemer = AMap.delete ownScriptPurpose (PlutusV2.txInfoRedeemers info)
+    expTxInfoRedeemers P.== withoutOwnRedeemer -- cannot check own redeemer so only check other script's redeemer
+  checkTxInfoData = expTxInfoData P.== PlutusV2.txInfoData info
+  checkTxInfoId = P.equalsInteger 32 (P.lengthOfByteString P.$ PlutusV2.getTxId P.$ PlutusV2.txInfoId info)
+
+checkV2TxInfoV2 :: PlutusV2.MintingPolicy
+checkV2TxInfoV2 = mkMintingPolicyScript
+  $$(PlutusTx.compile [|| wrap ||])
+  where
+    wrap = mkUntypedMintingPolicy @PlutusV2.ScriptContext mkCheckV2TxInfo
+
+checkV2TxInfoScriptV2 :: C.PlutusScript C.PlutusScriptV2
+checkV2TxInfoScriptV2 = policyScript checkV2TxInfoV2
+
+checkV2TxInfoAssetIdV2 :: C.AssetId
+checkV2TxInfoAssetIdV2 = C.AssetId (policyIdV2 checkV2TxInfoV2) "V2TxInfo"
+
+checkV2TxInfoMintWitnessV2 :: C.CardanoEra era
+  -> C.ScriptData
+  -> C.ExecutionUnits
+  -> (C.PolicyId, C.ScriptWitness C.WitCtxMint era)
+checkV2TxInfoMintWitnessV2 era redeemer exunits =
+  (policyIdV2 checkV2TxInfoV2,
+   mintScriptWitness' era plutusL2 (Left checkV2TxInfoScriptV2) redeemer exunits)

--- a/plutus-e2e-tests/test/Spec/AlonzoFeatures.hs
+++ b/plutus-e2e-tests/test/Spec/AlonzoFeatures.hs
@@ -19,7 +19,7 @@ import Helpers.Query qualified as Q
 import Helpers.Testnet (testnetOptionsAlonzo6, testnetOptionsBabbage7, testnetOptionsBabbage8)
 import Helpers.Testnet qualified as TN
 import Helpers.Tx qualified as Tx
-import Helpers.Utils qualified as U (workspace)
+import Helpers.Utils qualified as U (posixToMilliseconds, workspace)
 import Plutus.V1.Ledger.Api qualified as PlutusV1
 import Plutus.V1.Ledger.Interval qualified as PlutusV1
 import Plutus.V1.Ledger.Time qualified as PlutusV1
@@ -29,10 +29,6 @@ import PlutusScripts.V1TxInfo (checkV1TxInfoAssetIdV1, checkV1TxInfoMintWitnessV
 import Test.Base qualified as H
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
-
--- | Convert a 'POSIXTime' to the number of milliseconds since the Unix epoch.
-posixToMilliseconds :: Time.POSIXTime -> Integer
-posixToMilliseconds posixTime = round $ 1000 * (realToFrac posixTime :: Double)
 
 tests :: TestTree
 tests =
@@ -73,9 +69,9 @@ checkTxInfoV1Test networkOptions = H.integration . HE.runFinallies . U.workspace
     txOut2 = Tx.txOut era (C.lovelaceToValue amountReturned) w1Address
 
     lowerBound = PlutusV1.fromMilliSeconds
-      $ PlutusV1.DiffMilliSeconds $ posixToMilliseconds preTestnetTime -- before slot 1
+      $ PlutusV1.DiffMilliSeconds $ U.posixToMilliseconds preTestnetTime -- before slot 1
     upperBound = PlutusV1.fromMilliSeconds
-      $ PlutusV1.DiffMilliSeconds $ posixToMilliseconds startTime + 600_000 -- ~10mins after slot 1 (to account for testnet init time)
+      $ PlutusV1.DiffMilliSeconds $ U.posixToMilliseconds startTime + 600_000 -- ~10mins after slot 1 (to account for testnet init time)
     timeRange = PlutusV1.interval lowerBound upperBound :: PlutusV1.POSIXTimeRange
 
     expTxInfoInputs     = txInfoInputs (txIn, txInAsTxOut)
@@ -114,4 +110,3 @@ checkTxInfoV1Test networkOptions = H.integration . HE.runFinallies . U.workspace
   H.success
 
 -- TODO: datumHashSpendTest
--- TODO: mintTest

--- a/plutus-e2e-tests/test/Spec/BabbageFeatures.hs
+++ b/plutus-e2e-tests/test/Spec/BabbageFeatures.hs
@@ -50,7 +50,7 @@ tests = testGroup "Babbage Features"
     , testProperty "spend locked funds with a reference script providing datum in txbody in Babbage PV8" (referenceScriptDatumHashSpendTest testnetOptionsBabbage8)
     --, testProperty "spend locked funds with a reference script providing datum in txbody in Babbage PV8" (referenceScriptDatumHashSpendTest localNodeOptionsPreview) -- uncomment to use local node on preview testnet
 
-    , testProperty "check each attribute of V2 TxInfo in Babbage PV7 " (checkTxInfoV2Test testnetOptionsBabbage7)
+    , testProperty "check each attribute of V2 TxInfo in Babbage PV7" (checkTxInfoV2Test testnetOptionsBabbage7)
     , testProperty "check each attribute of V2 TxInfo in Babbage PV8" (checkTxInfoV2Test testnetOptionsBabbage8)
     ]
   ]

--- a/plutus-e2e-tests/test/Spec/BabbageFeatures.hs
+++ b/plutus-e2e-tests/test/Spec/BabbageFeatures.hs
@@ -17,14 +17,23 @@ import Test.Base qualified as H
 import Test.Tasty.Hedgehog (testProperty)
 
 import CardanoTestnet qualified as TN
+import Control.Monad.IO.Class (liftIO)
+import Data.Time.Clock.POSIX qualified as Time
 import Helpers.Common (makeAddress)
 import Helpers.Query qualified as Q
 import Helpers.Testnet (testnetOptionsBabbage7, testnetOptionsBabbage8)
 import Helpers.Testnet qualified as TN
 import Helpers.Tx qualified as Tx
-import Helpers.Utils qualified as U (workspace)
+import Helpers.Utils qualified as U (posixToMilliseconds, workspace)
+import Plutus.V1.Ledger.Interval qualified as PlutusV1
+import Plutus.V1.Ledger.Time qualified as PlutusV1
+import Plutus.V2.Ledger.Api qualified as PlutusV2
+import PlutusScripts.AlwaysSucceeds (alwaysSucceedMintWitnessV2', alwaysSucceedPolicyTxInfoRedeemerV2)
 import PlutusScripts.AlwaysSucceeds qualified as PS
+import PlutusScripts.Helpers (toScriptData)
 import PlutusScripts.Helpers qualified as PS
+import PlutusScripts.V2TxInfo (checkV2TxInfoAssetIdV2, checkV2TxInfoMintWitnessV2, checkV2TxInfoRedeemer, txInfoData,
+                               txInfoFee, txInfoInputs, txInfoMint, txInfoOutputs, txInfoSigs)
 
 tests :: TestTree
 tests = testGroup "Babbage Features"
@@ -40,6 +49,9 @@ tests = testGroup "Babbage Features"
     , testProperty "spend locked funds with a reference script providing datum in txbody in Babbage PV7" (referenceScriptDatumHashSpendTest testnetOptionsBabbage7)
     , testProperty "spend locked funds with a reference script providing datum in txbody in Babbage PV8" (referenceScriptDatumHashSpendTest testnetOptionsBabbage8)
     --, testProperty "spend locked funds with a reference script providing datum in txbody in Babbage PV8" (referenceScriptDatumHashSpendTest localNodeOptionsPreview) -- uncomment to use local node on preview testnet
+
+    , testProperty "check each attribute of V2 TxInfo in Babbage PV7" (checkTxInfoV2Test testnetOptionsBabbage7)
+    , testProperty "check each attribute of V2 TxInfo in Babbage PV8" (checkTxInfoV2Test testnetOptionsBabbage8)
     ]
   ]
 
@@ -212,5 +224,79 @@ referenceScriptDatumHashSpendTest networkOptions = H.integration . HE.runFinalli
   H.assert txOutHasAdaValue
   H.success
 
+checkTxInfoV2Test :: Either TN.LocalNodeOptions TN.TestnetOptions -> H.Property
+checkTxInfoV2Test networkOptions = H.integration . HE.runFinallies . U.workspace "." $ \tempAbsPath -> do
+
+  C.AnyCardanoEra era <- TN.eraFromOptions networkOptions
+  preTestnetTime <- liftIO Time.getPOSIXTime
+
+  -- 1: spin up a testnet or use local node connected to public testnet
+  (localNodeConnectInfo, pparams, networkId) <- TN.setupTestEnvironment networkOptions tempAbsPath
+  (w1SKey, w1VKey, w1Address) <- TN.w1 tempAbsPath networkId
+  startTime <- liftIO Time.getPOSIXTime
+
+  -- 2: build a transaction
+
+  txIn <- Q.adaOnlyTxInAtAddress era localNodeConnectInfo w1Address
+  txInAsTxOut@(C.TxOut _ txInValue _ _) <- Q.getTxOutAtAddress era localNodeConnectInfo w1Address txIn "txInAsTxOut <- TN.getTxOutAtAddress"
+
+  let
+    tokenValues = C.valueFromList [(checkV2TxInfoAssetIdV2, 1), (PS.alwaysSucceedAssetIdV2, 2)]
+    executionUnits1 = C.ExecutionUnits {C.executionSteps = 1_000_000_000, C.executionMemory = 10_000_000 }
+    executionUnits2 = C.ExecutionUnits {C.executionSteps = 1_000_000_000, C.executionMemory = 4_000_000 }
+    collateral = Tx.txInsCollateral era [txIn]
+    totalLovelace = C.txOutValueToLovelace txInValue
+    fee = 2_500_000 :: C.Lovelace
+    amountPaid = 10_000_000
+    amountReturned = totalLovelace - amountPaid - fee
+    datum = toScriptData (42 ::Integer)
+
+    txOut1 = Tx.txOutWithDatumInTx era (C.lovelaceToValue amountPaid <> tokenValues) w1Address datum
+    txOut2 = Tx.txOut era (C.lovelaceToValue amountReturned) w1Address
+
+    lowerBound = PlutusV1.fromMilliSeconds
+      $ PlutusV1.DiffMilliSeconds $ U.posixToMilliseconds preTestnetTime -- before slot 1
+    upperBound = PlutusV1.fromMilliSeconds
+      $ PlutusV1.DiffMilliSeconds $ U.posixToMilliseconds startTime + 600_000 -- ~10mins after slot 1 (to account for testnet init time)
+    timeRange = PlutusV1.interval lowerBound upperBound :: PlutusV1.POSIXTimeRange
+
+    expTxInfoInputs          = txInfoInputs (txIn, txInAsTxOut)
+    expTxInfoReferenceInputs = txInfoInputs (txIn, txInAsTxOut)
+    expTxInfoOutputs         = txInfoOutputs [ txOut1, txOut2 ]
+    expTxInfoFee             = txInfoFee fee
+    expTxInfoMint            = txInfoMint tokenValues
+    expDCert                 = []                   -- not testing any staking registration certificate
+    expWdrl                  = PlutusV2.fromList [] -- not testing any staking reward withdrawal
+    expTxInfoSigs            = txInfoSigs [w1VKey]
+    expTxInfoRedeemers       = alwaysSucceedPolicyTxInfoRedeemerV2
+    expTxInfoData            = txInfoData [datum]
+    expTxInfoValidRange      = timeRange
+
+    redeemer = checkV2TxInfoRedeemer [expTxInfoInputs] [expTxInfoReferenceInputs] expTxInfoOutputs expTxInfoFee expTxInfoMint
+               expDCert expWdrl expTxInfoValidRange expTxInfoSigs expTxInfoRedeemers expTxInfoData
+    mintWitnesses = Map.fromList [checkV2TxInfoMintWitnessV2 era redeemer executionUnits1, alwaysSucceedMintWitnessV2' era executionUnits2]
+
+    txBodyContent = (Tx.emptyTxBodyContent era pparams)
+      { C.txIns = Tx.pubkeyTxIns [txIn]
+      , C.txInsReference = Tx.txInsReference era [txIn]
+      , C.txInsCollateral = collateral
+      , C.txMintValue = Tx.txMintValue era tokenValues mintWitnesses
+      , C.txOuts = [txOut1, txOut2]
+      , C.txFee = Tx.txFee era fee
+      , C.txValidityRange = Tx.txValidityRange era 1 2700 -- ~9min range (200ms slots). Babbage era onwards cannot have upper slot beyond epoch boundary (10_000 slot epoch).
+      , C.txExtraKeyWits = Tx.txExtraKeyWits era [w1VKey]
+      }
+  txbody <- Tx.buildRawTx era txBodyContent
+  kw <- Tx.signTx era txbody w1SKey
+  let signedTx = C.makeSignedTransaction [kw] txbody
+
+  Tx.submitTx era localNodeConnectInfo signedTx
+
+  let expectedTxIn = Tx.txIn (Tx.txId signedTx) 0
+  resultTxOut <- Q.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn "resultTxOut <- TN.getTxOutAtAddress "
+  txOutHasTokenValue <- Q.txOutHasValue resultTxOut tokenValues
+  H.assert txOutHasTokenValue
+  H.success
+
   -- TODO: inlineDatumSpendTest (no reference script)
-  -- TODO: Check V2 TxInfo
+

--- a/plutus-e2e-tests/test/Spec/BabbageFeatures.hs
+++ b/plutus-e2e-tests/test/Spec/BabbageFeatures.hs
@@ -50,7 +50,7 @@ tests = testGroup "Babbage Features"
     , testProperty "spend locked funds with a reference script providing datum in txbody in Babbage PV8" (referenceScriptDatumHashSpendTest testnetOptionsBabbage8)
     --, testProperty "spend locked funds with a reference script providing datum in txbody in Babbage PV8" (referenceScriptDatumHashSpendTest localNodeOptionsPreview) -- uncomment to use local node on preview testnet
 
-    , testProperty "check each attribute of V2 TxInfo in Babbage PV7" (checkTxInfoV2Test testnetOptionsBabbage7)
+    , testProperty "check each attribute of V2 TxInfo in Babbage PV7 " (checkTxInfoV2Test testnetOptionsBabbage7)
     , testProperty "check each attribute of V2 TxInfo in Babbage PV8" (checkTxInfoV2Test testnetOptionsBabbage8)
     ]
   ]

--- a/plutus-ledger/src/Ledger/Tx/CardanoAPI/Internal.hs
+++ b/plutus-ledger/src/Ledger/Tx/CardanoAPI/Internal.hs
@@ -27,6 +27,7 @@ module Ledger.Tx.CardanoAPI.Internal(
   , fromCardanoTxOutToPV1TxInfoTxOut
   , fromCardanoTxOutToPV1TxInfoTxOut'
   , fromCardanoTxOutToPV2TxInfoTxOut
+  , fromCardanoTxOutToPV2TxInfoTxOut'
   , fromCardanoTxOutDatumHash
   , fromCardanoTxOutDatum
   , fromCardanoTxOutValue
@@ -657,6 +658,14 @@ fromCardanoTxOutToPV2TxInfoTxOut (C.TxOut addr value datum refScript) =
     (fromCardanoTxOutDatum datum)
     (refScriptToScriptHash refScript)
 
+fromCardanoTxOutToPV2TxInfoTxOut' :: C.TxOut C.CtxUTxO era -> PV2.TxOut
+fromCardanoTxOutToPV2TxInfoTxOut' (C.TxOut addr value datum refScript) =
+    PV2.TxOut
+    (fromCardanoAddressInEra addr)
+    (fromCardanoValue $ fromCardanoTxOutValue value)
+    (fromCardanoTxOutDatum' datum)
+    (refScriptToScriptHash refScript)
+
 refScriptToScriptHash :: C.ReferenceScript era -> Maybe PV2.ScriptHash
 refScriptToScriptHash C.ReferenceScriptNone = Nothing
 refScriptToScriptHash (C.ReferenceScript _ (C.ScriptInAnyLang _ s)) =
@@ -785,6 +794,14 @@ fromCardanoTxOutDatum (C.TxOutDatumHash _ h) =
 fromCardanoTxOutDatum (C.TxOutDatumInTx _ d) =
     PV2.OutputDatumHash $ PV2.DatumHash $ PlutusTx.toBuiltin (C.serialiseToRawBytes (C.hashScriptData d))
 fromCardanoTxOutDatum (C.TxOutDatumInline _ d) =
+    PV2.OutputDatum $ PV2.Datum $ fromCardanoScriptData d
+
+fromCardanoTxOutDatum' :: C.TxOutDatum C.CtxUTxO era -> PV2.OutputDatum
+fromCardanoTxOutDatum' C.TxOutDatumNone       =
+    PV2.NoOutputDatum
+fromCardanoTxOutDatum' (C.TxOutDatumHash _ h) =
+    PV2.OutputDatumHash $ PV2.DatumHash $ PlutusTx.toBuiltin (C.serialiseToRawBytes h)
+fromCardanoTxOutDatum' (C.TxOutDatumInline _ d) =
     PV2.OutputDatum $ PV2.Datum $ fromCardanoScriptData d
 
 toCardanoTxOutNoDatum  :: C.TxOutDatum C.CtxTx C.BabbageEra


### PR DESCRIPTION
Same as [checkTxInfoV1Test](https://github.com/input-output-hk/plutus-apps/blob/3b16bcc141e76572917020bd154948b0b0491215/plutus-e2e-tests/test/Spec/AlonzoFeatures.hs#L47) but for Plutus version 2.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
