### PR TITLE
E2E tests share testnet instances

### DIFF
--- a/plutus-e2e-tests/README.md
+++ b/plutus-e2e-tests/README.md
@@ -4,12 +4,15 @@ End-to-end tests using [cardano-testnet](https://github.com/input-output-hk/card
 
 ## Status
 
-This framework is still in early stages of development with only a handful of tests covering:
+This framework is still in development with a handful of tests covering:
 - Using plutus builtin functions `verifySchnorrSecp256k1Signature` and `verifyEcdsaSecp256k1Signature` in different protocol versions with different expected outcomes (success or particular errors).
 - Spending funds locked at script using reference script, reference inputs and providing datum as witness in txbody.
 - Minting tokens using reference script and providing script witness in txbody.
+- Check each field in Plutus V1 and V2 TxInfo.
 
-It is also possible to run these tests on a public testnet, see preconditions:
+Tests can be run on either a private or public testnet. They are grouped by target protocol version (E.g. Babbage PV8) and share an instance of private testnet during execution. `cardano-testnet` is used to manage private testnets.
+
+To run these tests on a public testnet, see preconditions:
 - Have a directory containing at least these two directories:
   - "utxo-keys" containing "test.skey" and "test.vkey" files. These must both be text envelope PaymentKey format, currently no support for PaymentExtendedKey.
   - "ipc" containing the active node.socket
@@ -19,6 +22,5 @@ It is also possible to run these tests on a public testnet, see preconditions:
 - Ensure the `LocalNodeOption`'s `localEnvDir` points to the directory containing your keys ("utxo-keys") and node socket ("ipc").
 
 There are plans to add the following features:
-- Shared instance of `cardano-testnet` for all tests targeting a common protocol version, e.g. Babbage PV8. This should make overall execution time shorter.
 - Test reporting, e.g. [tasty-html](https://hackage.haskell.org/package/tasty-html) or [Allure](https://qameta.io/allure-report/).
 - Nightly CI test execution.

--- a/plutus-e2e-tests/plutus-e2e-tests.cabal
+++ b/plutus-e2e-tests/plutus-e2e-tests.cabal
@@ -95,6 +95,7 @@ test-suite plutus-e2e-tests-test
     CardanoTestnet
     Helpers.Common
     Helpers.Query
+    Helpers.Test
     Helpers.Testnet
     Helpers.Tx
     Helpers.Utils

--- a/plutus-e2e-tests/test/Helpers/Test.hs
+++ b/plutus-e2e-tests/test/Helpers/Test.hs
@@ -1,0 +1,55 @@
+module Helpers.Test (
+    TestParams(..),
+    runTest,
+    runTestWithPosixTime
+) where
+
+import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as C
+import CardanoTestnet qualified as TN
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.Maybe (fromMaybe)
+import Data.Time (nominalDiffTimeToSeconds)
+import Data.Time.Clock.POSIX qualified as Time
+import Helpers.Testnet qualified as TN
+
+data TestParams = TestParams {
+    localNodeConnectInfo :: C.LocalNodeConnectInfo C.CardanoMode,
+    pparams              :: C.ProtocolParameters,
+    networkId            :: C.NetworkId,
+    tempAbsPath          :: FilePath
+}
+
+runTestGeneric :: MonadIO m =>
+  String ->
+  (Either TN.LocalNodeOptions TN.TestnetOptions -> TestParams -> Time.POSIXTime -> m ()) ->
+  Either TN.LocalNodeOptions TN.TestnetOptions ->
+  TestParams ->
+  Maybe Time.POSIXTime ->
+  m ()
+runTestGeneric testName test networkOptions testParams preTestnetTime = do
+  liftIO $ putStrLn $ "\nRunning: " ++ testName
+  t <- liftIO Time.getPOSIXTime
+  test networkOptions testParams (fromMaybe t preTestnetTime)
+  t2 <- liftIO Time.getPOSIXTime
+  liftIO $ putStrLn $ "Pass\nDuration: " ++ show (nominalDiffTimeToSeconds $ t2 - t) ++ "s"
+
+runTest :: MonadIO m =>
+  String ->
+  (Either TN.LocalNodeOptions TN.TestnetOptions -> TestParams -> m ()) ->
+  Either TN.LocalNodeOptions TN.TestnetOptions ->
+  TestParams ->
+  m ()
+runTest testName test networkOptions testParams =
+    runTestGeneric testName (\opts params _ -> test opts params) networkOptions testParams Nothing
+
+runTestWithPosixTime :: MonadIO m =>
+  String ->
+  (Either TN.LocalNodeOptions TN.TestnetOptions -> TestParams -> Time.POSIXTime -> m ()) ->
+  Either TN.LocalNodeOptions TN.TestnetOptions ->
+  TestParams ->
+  Time.POSIXTime ->
+  m ()
+runTestWithPosixTime testName test networkOptions testParams preTestnetTime =
+    runTestGeneric testName test networkOptions testParams (Just preTestnetTime)
+

--- a/plutus-e2e-tests/test/Helpers/Testnet.hs
+++ b/plutus-e2e-tests/test/Helpers/Testnet.hs
@@ -157,10 +157,13 @@ setupTestEnvironment options tempAbsPath = do
   case options of
     Left localNodeOptions -> do
       C.AnyCardanoEra era <- return $ era localNodeOptions
+      liftIO $ putStrLn "\nConnecting to local node..."
       connectToLocalNode era localNodeOptions tempAbsPath
     Right testnetOptions -> do
       C.AnyCardanoEra era <- return $ TN.era testnetOptions
+      pv <- pvFromOptions options
       base <- getProjectBase
+      liftIO $ putStrLn $ "\nStarting local testnet in " ++ show era ++ " PV" ++ show pv ++ "..."
       startTestnet era testnetOptions base tempAbsPath
 
 -- | Network ID of the testnet

--- a/plutus-e2e-tests/test/Spec.hs
+++ b/plutus-e2e-tests/test/Spec.hs
@@ -8,17 +8,91 @@
 -}
 module Main(main) where
 
-import Spec.AlonzoFeatures qualified
-import Spec.BabbageFeatures qualified
-import Spec.Builtins.SECP256k1 qualified
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.Time.Clock.POSIX qualified as Time
+import Hedgehog qualified as H
+import Hedgehog.Extras qualified as HE
+import Helpers.Test (TestParams (TestParams), runTest, runTestWithPosixTime)
+import Helpers.Testnet qualified as TN
+import Helpers.Utils qualified as U
+import Spec.AlonzoFeatures qualified as AlonzoFeatures
+import Spec.BabbageFeatures qualified as BabbageFeatures
+import Spec.Builtins.SECP256k1 qualified as Builtins
+import Test.Base qualified as H
 import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
 
 main :: IO ()
 main = defaultMain tests
 
+pv6Tests :: H.Property
+pv6Tests = H.integration . HE.runFinallies . U.workspace "." $ \tempAbsPath -> do
+    let options = TN.testnetOptionsAlonzo6
+    preTestnetTime <- liftIO Time.getPOSIXTime
+    (localNodeConnectInfo, pparams, networkId, mPoolNodes) <- TN.setupTestEnvironment options tempAbsPath
+    let testParams = TestParams localNodeConnectInfo pparams networkId tempAbsPath
+
+    -- checkTxInfo tests must be first to run after new testnet is initialised due to expected slot to posix time
+    runTestWithPosixTime "checkTxInfoV1Test" AlonzoFeatures.checkTxInfoV1Test options testParams preTestnetTime
+    runTest "verifySchnorrAndEcdsaTest" Builtins.verifySchnorrAndEcdsaTest options testParams
+
+    U.anyLeftFail_ $ TN.cleanupTestnet mPoolNodes
+
+pv7Tests :: H.Property
+pv7Tests = H.integration . HE.runFinallies . U.workspace "." $ \tempAbsPath -> do
+    let options = TN.testnetOptionsBabbage7
+    preTestnetTime <- liftIO Time.getPOSIXTime
+    (localNodeConnectInfo, pparams, networkId, mPoolNodes) <- TN.setupTestEnvironment options tempAbsPath
+    let testParams = TestParams localNodeConnectInfo pparams networkId tempAbsPath
+
+    -- checkTxInfo tests must be first to run after new testnet is initialised due to expected slot to posix time
+    runTestWithPosixTime "checkTxInfoV1Test" AlonzoFeatures.checkTxInfoV1Test options testParams preTestnetTime
+    runTestWithPosixTime "checkTxInfoV2Test" BabbageFeatures.checkTxInfoV2Test options testParams preTestnetTime
+    runTest "verifySchnorrAndEcdsaTest" Builtins.verifySchnorrAndEcdsaTest options testParams
+    runTest "referenceScriptMintTest" BabbageFeatures.referenceScriptMintTest options testParams
+    runTest "referenceScriptInlineDatumSpendTest" BabbageFeatures.referenceScriptInlineDatumSpendTest options testParams
+    runTest "referenceScriptDatumHashSpendTest" BabbageFeatures.referenceScriptDatumHashSpendTest options testParams
+
+    U.anyLeftFail_ $ TN.cleanupTestnet mPoolNodes
+
+pv8Tests :: H.Property
+pv8Tests = H.integration . HE.runFinallies . U.workspace "." $ \tempAbsPath -> do
+    let options = TN.testnetOptionsBabbage8
+    preTestnetTime <- liftIO Time.getPOSIXTime
+    (localNodeConnectInfo, pparams, networkId, mPoolNodes) <- TN.setupTestEnvironment options tempAbsPath
+    let testParams = TestParams localNodeConnectInfo pparams networkId tempAbsPath
+
+    -- checkTxInfo tests must be first to run after new testnet is initialised due to expected slot to posix time
+    runTestWithPosixTime "checkTxInfoV1Test" AlonzoFeatures.checkTxInfoV1Test options testParams preTestnetTime
+    runTestWithPosixTime "checkTxInfoV2Test" BabbageFeatures.checkTxInfoV2Test options testParams preTestnetTime
+    runTest "verifySchnorrAndEcdsaTest" Builtins.verifySchnorrAndEcdsaTest options testParams
+    runTest "referenceScriptMintTest" BabbageFeatures.referenceScriptMintTest options testParams
+    runTest "referenceScriptInlineDatumSpendTest" BabbageFeatures.referenceScriptInlineDatumSpendTest options testParams
+    runTest "referenceScriptDatumHashSpendTest" BabbageFeatures.referenceScriptDatumHashSpendTest options testParams
+
+    U.anyLeftFail_ $ TN.cleanupTestnet mPoolNodes
+
+-- localNodeTests :: Either TN.LocalNodeOptions TN.TestnetOptions -> H.Property
+-- localNodeTests  options = H.integration . HE.runFinallies . U.workspace "." $ \tempAbsPath -> do
+--     --preTestnetTime <- liftIO Time.getPOSIXTime
+--     (localNodeConnectInfo, pparams, networkId, mPoolNodes) <- TN.setupTestEnvironment options tempAbsPath
+--     let testParams = TestParams localNodeConnectInfo pparams networkId tempAbsPath
+
+--     -- checkTxInfo tests must be first to run after new testnet is initialised due to expected slot to posix time
+--     -- TODO: pass in or query for slot range to use in checkTxInfo tests
+--     --runTestWithPosixTime "checkTxInfoV1Test" AlonzoFeatures.checkTxInfoV1Test options testParams preTestnetTime
+--     --runTestWithPosixTime "checkTxInfoV2Test" BabbageFeatures.checkTxInfoV2Test options testParams preTestnetTime
+--     runTest "verifySchnorrAndEcdsaTest" Builtins.verifySchnorrAndEcdsaTest options testParams
+--     runTest "referenceScriptMintTest" BabbageFeatures.referenceScriptMintTest options testParams
+--     runTest "referenceScriptInlineDatumSpendTest" BabbageFeatures.referenceScriptInlineDatumSpendTest options testParams
+--     runTest "referenceScriptDatumHashSpendTest" BabbageFeatures.referenceScriptDatumHashSpendTest options testParams
+
+--     U.anyLeftFail_ $ TN.cleanupTestnet mPoolNodes
+
 tests :: TestTree
-tests = testGroup "Plutus E2E" [
-    Spec.AlonzoFeatures.tests
-  , Spec.BabbageFeatures.tests
-  , Spec.Builtins.SECP256k1.tests
+tests = testGroup "Plutus E2E Tests" [
+  testProperty "Alonzo PV6 Tests" pv6Tests,
+  testProperty "Babbage PV7 Tests" pv7Tests,
+  testProperty "Babbage PV8 Tests" pv8Tests
+  --testProperty "Babbage PV8 Tests (on Preview testnet)" $ localNodeTests TN.localNodeOptionsPreview
   ]


### PR DESCRIPTION
Rough timing comparison: local execution time is now under 2 minutes vs over 5 minutes on main.

Output now looks like:
```haskell
Running 1 test suites...
Test suite plutus-e2e-tests-test: RUNNING...

Starting local testnet in AlonzoEra PV6...
Plutus E2E Tests
  Alonzo PV6 Tests:  
Running: checkTxInfoV1Test
Pass
Duration: 3.042900687000s

Running: verifySchnorrAndEcdsaTest
Pass
Duration: 0.103253914000s
OK (18.42s)
      ✓ <interactive> passed 1 test.
  Babbage PV7 Tests: 
Starting local testnet in BabbageEra PV7...

Running: checkTxInfoV1Test
Pass
Duration: 3.045092866000s

Running: checkTxInfoV2Test
Pass
Duration: 2.053581889000s

Running: verifySchnorrAndEcdsaTest
Pass
Duration: 0.096159726000s

Running: referenceScriptMintTest
Pass
Duration: 3.378465432000s

Running: referenceScriptInlineDatumSpendTest
Pass
Duration: 3.415320918000s

Running: referenceScriptDatumHashSpendTest
Pass
Duration: 8.437644023000s
OK (35.69s)
      ✓ <interactive> passed 1 test.
  Babbage PV8 Tests: 
Starting local testnet in BabbageEra PV8...

Running: checkTxInfoV1Test
Pass
Duration: 2.042235929000s

Running: checkTxInfoV2Test
Pass
Duration: 3.049577380000s

Running: verifySchnorrAndEcdsaTest
Pass
Duration: 1.229344755000s

Running: referenceScriptMintTest
Pass
Duration: 5.397374209000s

Running: referenceScriptInlineDatumSpendTest
Pass
Duration: 10.447303478000s

Running: referenceScriptDatumHashSpendTest
Pass
Duration: 3.408115655000s
OK (41.87s)
      ✓ <interactive> passed 1 test.

All 3 tests passed (96.00s)
Test suite plutus-e2e-tests-test: PASS
```