### PR TITLE
PLT-214 Refactored the Epoch-StakePoolDelegation indexer to the Marconi interface.

### DIFF
--- a/marconi-chain-index/app/Main.hs
+++ b/marconi-chain-index/app/Main.hs
@@ -19,12 +19,12 @@ main = do
       , (Indexers.mintBurnWorker (\_ -> pure ()), Cli.mintBurnDbPath o)
       ] <> case Cli.optionsNodeConfigPath o of
       Just configPath ->
-        [(Indexers.epochStakepoolSizeWorker configPath, Cli.epochStakepoolSizeDbPath o)]
+        [(Indexers.epochStakepoolSizeWorker configPath (\_ -> pure ()), Cli.epochStakepoolSizeDbPath o)]
       Nothing         -> []
 
   Indexers.runIndexers
     (Cli.optionsSocketPath o)
     (Cli.optionsNetworkId o)
     (Cli.optionsChainPoint o)
-    "marconi"
+    "marconi-chain-index"
     indexers

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -58,8 +58,10 @@ library
     Marconi.ChainIndex.Indexers.ScriptTx
     Marconi.ChainIndex.Indexers.Utxo
     Marconi.ChainIndex.Logging
+    Marconi.ChainIndex.Node.Client.GenesisConfig
     Marconi.ChainIndex.Orphans
     Marconi.ChainIndex.Types
+    Marconi.ChainIndex.Utils
 
   --------------------
   -- Local components
@@ -74,12 +76,22 @@ library
   build-depends:
     , cardano-api
     , cardano-binary
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , cardano-data
     , cardano-ledger-alonzo
     , cardano-ledger-babbage
+    , cardano-ledger-byron
     , cardano-ledger-core
     , cardano-ledger-shelley
     , cardano-ledger-shelley-ma
+    , cardano-protocol-tpraos
+    , cardano-slotting
     , iohk-monitoring
+    , ouroboros-consensus
+    , ouroboros-consensus-byron
+    , ouroboros-consensus-protocol
+    , ouroboros-network
 
   ------------------------
   -- Non-IOG dependencies
@@ -90,7 +102,9 @@ library
     , base
     , base16-bytestring
     , bytestring
+    , cborg
     , containers
+    , directory
     , filepath
     , lens
     , mwc-random
@@ -106,7 +120,9 @@ library
     , text
     , time
     , transformers
+    , transformers-except
     , vector-map
+    , yaml
 
 library json-rpc
   import:          lang

--- a/marconi-chain-index/performance/monitor-marconi-sync-all.sh
+++ b/marconi-chain-index/performance/monitor-marconi-sync-all.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+NETWORKID=764824073
+NETWORK=mainnet
+
+monitor_indexer () {
+  indexer=$1
+  echo "Syncing ${indexer} indexer..."
+  case $indexer in
+    utxo)
+      indexers_cli="--disable-datum --disable-script-tx --disable-address-datum --disable-mintburn --disable-epoch-stakepool-size"
+      ;;
+    address-datum)
+      indexers_cli="--disable-datum --disable-script-tx --disable-utxo --disable-mintburn --disable-epoch-stakepool-size"
+      ;;
+    mintburn)
+      indexers_cli="--disable-datum --disable-script-tx --disable-utxo --disable-address-datum --disable-epoch-stakepool-size"
+      ;;
+    epochsdd)
+      indexers_cli="--disable-datum --disable-script-tx --disable-utxo --disable-address-datum --disable-mintburn"
+      ;;
+  esac
+
+  cabal build marconi-chain-index
+  $(cabal exec -- which marconi-chain-index) \
+    -s "$HOME"/cardano-node/${NETWORK}/cardano-node.socket \
+    --testnet-magic ${NETWORKID} \
+    ${indexers_cli} \
+    -d ~/cardano-node/${NETWORK}/marconi-chain-index \
+    --node-config-path "$HOME"/cardano-node/${NETWORK}/${NETWORK}-config.json >> marconi-chain-index-"${indexer}".log &
+  pid=$!
+  echo $pid
+  ./monitor-marconi-sync.sh marconi-chain-index-"${indexer}".log $pid >> >(tee marconi-chain-index-"${indexer}"-monitor.log)
+
+}
+
+# Uncomment the ones you want to use
+# monitor_indexer "utxo"
+# monitor_indexer "address-datum"
+# monitor_indexer "mintburn"
+# monitor_indexer "epochsdd"
+
+trap 'kill $(jobs -p)' EXIT

--- a/marconi-chain-index/performance/monitor-marconi-sync.sh
+++ b/marconi-chain-index/performance/monitor-marconi-sync.sh
@@ -1,23 +1,22 @@
 #!/usr/bin/env bash
 
-# For monitoring time to sync marconi. Logs cpu, mem and sync %.
+# For monitoring time to sync marconi-chain-index. Logs cpu, mem and sync %.
 
-# Run marconi with "> >(tee marconi-log.txt)" and then run this script with marconi's log as arg
-if [[ $1 ]]; then marconi_log=$1; else echo "provide marconi log file (arg0)" && exit 1; fi
+# Run marconi-chain-index with "> >(tee marconi-chain-index-log.txt)" and then run this script with marconi-chain-index's log as arg
+if [[ $1 ]]; then marconi_chain_index_log=$1; else echo "provide marconi-chain-index log file (arg0)" && exit 1; fi
+if [[ $2 ]]; then pid=$2; else echo "provide marconi-chain-index PID (arg1)" && exit 1; fi
 
 startMs=$(date +%s)
-
-pid=$(pidof marconi)
 
 if [[ -z $pid ]]
 then
 	echo -e "pid empty, exiting.\n"
 	exit 1
 else
-	echo -e "marconi pid=$pid\n"
+	echo -e "marconi-chain-index pid=$pid\n"
 fi
 
-exec > >(tee monitor-marconi-log.txt)
+exec > >(tee monitor-marconi-chain-index-log.txt)
 
 echo -e "Starting monitoring at $(date)"
 echo -e "Process started at $(ps -p "$pid" -o start_time=)\n"
@@ -25,7 +24,7 @@ ps -p "$pid" -o etime,%cpu,rss,%mem
 
 while true
 do
-	last_log=$(tail -n1 "$marconi_log")
+	last_log=$(tail -n1 "$marconi_chain_index_log")
 	sync_percent=$(echo "$last_log" | cut -d '(' -f2 | cut -d ')' -f1)
 	echo -e "Synced: $sync_percent"
 	ps -p "$pid" -o etime=,%cpu=,rss=,%mem=

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -325,13 +325,10 @@ epochStakepoolSizeWorker_
               RollBackward cp _ct ->
                   modifyMVar indexerMVar $ \ix -> do
                   newIndex <- fromMaybe ix <$> Storable.rewind cp ix
-                  -- The possible points from which we can possibly rollback should be available
-                  -- in the buffer events and from the resumable points.
-                  -- For that assumption to be correct, we absolutely need
-                  --    * to make sure that 'EpochSPD.open' was called with the correct
-                  --    'SecurityParam' (k) value of connect Cardano network.
-                  --    * that the resumablePoints correctly returns the points from which we
-                  --    have saved a LedgerState on disk.
+                  -- We query the LedgerState from disk at the point where we need to rollback to.
+                  -- For that to work, we need to be sure that any volatile LedgerState are stored
+                  -- on disk. For immutable LedgerStates, they are only stored on disk at the first
+                  -- slot of an epoch.
                   EpochSPD.LedgerStateAtPointResult maybeLedgerState <-
                       Storable.query Storable.QEverything newIndex (EpochSPD.LedgerStateAtPointQuery cp)
                   case maybeLedgerState of

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/EpochStakepoolSize.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/EpochStakepoolSize.hs
@@ -294,7 +294,7 @@ instance Buffered EpochSPDHandle where
               _noLedgerStateOrEpochNo -> pure ()
 
         -- Remove all immutable LedgerStates from the filesystem expect the most recent immutable
-        -- one which is from the last slot of latest epoch.
+        -- one which is from the first slot of latest epoch.
         -- A 'LedgerState' is considered immutable if its 'blockNo' is '< latestBlockNo - securityParam'.
         case NE.nonEmpty eventsList of
           Nothing -> pure ()

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/EpochStakepoolSize.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/EpochStakepoolSize.hs
@@ -1,187 +1,502 @@
-{-# OPTIONS_GHC -Wno-orphans      #-}
-{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs             #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE MultiWayIf        #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE QuasiQuotes        #-}
+{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE TupleSections      #-}
 
-module Marconi.ChainIndex.Indexers.EpochStakepoolSize where
-
-import Control.Monad.Trans.Class (lift)
-import Data.Coerce (coerce)
-import Data.Foldable (forM_)
-import Data.Function (on, (&))
-import Data.List (groupBy)
-import Data.Map qualified as M
-import Data.Maybe qualified as P
-import Data.Sequence qualified as Seq
-import Data.Tuple (swap)
-import Data.VMap qualified as VMap
-import Database.SQLite.Simple qualified as SQL
-import Database.SQLite.Simple.FromField qualified as SQL
-import Database.SQLite.Simple.ToField qualified as SQL
-import Streaming.Prelude qualified as S
+-- | Module for indexing the stakepool delegation per epoch in the Cardano blockchain.
+--
+-- This module will create the SQL tables:
+--
+-- + table: epoch_spd
+--
+-- @
+--    |---------+--------+----------+--------+-----------------+---------|
+--    | epochNo | poolId | lovelace | slotNo | blockHeaderHash | blockNo |
+--    |---------+--------+----------+--------+-----------------+---------|
+-- @
+--
+-- To create this table, we need to compute the `LedgerState` from `ouroboros-network` (called
+-- `NewEpochState` in `cardano-ledger`) at each 'Rollforward' chain sync event. Using the
+-- 'LegderState', we can easily compute the epochNo as well as the stake pool delegation for that
+-- epoch.
+--
+-- The main issue with this indexer is that building the LedgerState and saving it on disk for being
+-- able to resume is VERY resource intensive. Syncing time for this indexer is over 20h and uses
+-- about ~16GB of RAM (which will keep increasing as the blockchain continues to grow).
+--
+-- Here is a synopsis of what this indexer does.
+--
+-- We assume that the construction of 'LedgerState' is done outside of this indexer (this module).
+--
+--   * the 'Storable.insert' function is called with the *last* event of an epoch (therefore, the
+--   last 'LedgerState' before starting a new epoch). We do that because we only care about the SPD
+--   (Stake Pool Delegation) from the last block before a new epoch.
+--
+-- Once the 'Storable.StorableEvent' is stored on disk, we perform various steps:
+--
+--   1. we save the SPD for the current epoch in the `epoch_spd` table
+--   2. we save the 'LedgerState's in the filesystem as binary files (the ledger state file path has
+--   the format: `ledgerState_<SLOT_NO>_<BLOCK_HEADER_HASH>_<BLOCK_NO>.bin`). We only store a
+--   'LedgerState' if it's rollbackable or if the last one of a given epoch. This step is necessary
+--   for resuming the indexer.
+--   3. we delete immutable 'LedgerState' binary files expect latest one (this step is necessary for
+--
+-- The indexer provides the following queries:
+--
+--   * C.EpochNo -> SPD (the actualy query that clients will be interested in)
+--   * C.ChainPoint -> LedgerState (query that is necessary for resuming)
+module Marconi.ChainIndex.Indexers.EpochStakepoolSize
+  ( -- * EpochSPDIndex
+    EpochSPDIndex
+  , EpochSPDDepth (..)
+  , EpochSPDHandle
+  , EpochSPDRow (..)
+  , StorableEvent(..)
+  , StorableQuery(..)
+  , StorableResult(..)
+  , toStorableEvent
+  , open
+  , getEpochNo
+  ) where
 
 import Cardano.Api qualified as C
 import Cardano.Api.Shelley qualified as C
-import Cardano.Streaming qualified as CS
-
-import Cardano.Ledger.Coin qualified as L
-import Cardano.Ledger.Compactible qualified as L
-import Cardano.Ledger.Credential qualified as LC
-import Cardano.Ledger.Era qualified as LE
-import Cardano.Ledger.Keys qualified as LK
-import Cardano.Ledger.Shelley.EpochBoundary qualified as Shelley
-import Cardano.Ledger.Shelley.LedgerState qualified as SL
-import Cardano.Ledger.Shelley.LedgerState qualified as Shelley
+import Cardano.Ledger.Coin qualified as Ledger
+import Cardano.Ledger.Compactible qualified as Ledger
+import Cardano.Ledger.Era qualified as Ledger
+import Cardano.Ledger.Shelley.API qualified as Ledger
+import Cardano.Slotting.Slot (EpochNo)
+import Codec.CBOR.Read qualified as CBOR
+import Codec.CBOR.Write qualified as CBOR
+import Control.Monad (forM_, when)
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Lazy qualified as BS
+import Data.Coerce (coerce)
+import Data.Data (Proxy (Proxy))
+import Data.Foldable (toList)
+import Data.List qualified as List
+import Data.List.NonEmpty qualified as NE
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (catMaybes, mapMaybe)
+import Data.Ord (Down (Down))
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Data.Tuple (swap)
+import Data.VMap qualified as VMap
+import Data.Word (Word64)
+import Database.SQLite.Simple qualified as SQL
+import GHC.Generics (Generic)
+import Marconi.ChainIndex.Orphans (decodeLedgerState, encodeLedgerState)
+import Marconi.ChainIndex.Utils (isBlockRollbackable)
+import Marconi.Core.Storable (Buffered (persistToStorage), HasPoint (getPoint), QueryInterval, Queryable (queryStorage),
+                              Resumable, Rewindable (rewindStorage), State, StorableEvent, StorableMonad, StorablePoint,
+                              StorableQuery, StorableResult, emptyState)
+import Marconi.Core.Storable qualified as Storable
 import Ouroboros.Consensus.Cardano.Block qualified as O
 import Ouroboros.Consensus.Shelley.Ledger qualified as O
+import System.Directory (listDirectory, removeFile)
+import System.FilePath (dropExtension, (</>))
+import Text.RawString.QQ (r)
+import Text.Read (readMaybe)
 
-import Cardano.Streaming.Helpers (getEpochNo)
+data EpochSPDHandle = EpochSPDHandle
+    { _epochSDPHandleConnection         :: !SQL.Connection
+    , _epochSDPHandleLedgerStateDirPath :: !FilePath
+    , _epochSDPHandleSecurityParam      :: !Word64
+    }
 
--- * Event
+type instance StorableMonad EpochSPDHandle = IO
 
-newtype Event = Event (C.EpochNo, M.Map C.PoolId C.Lovelace)
+data instance StorableEvent EpochSPDHandle =
+    EpochSPDEvent
+        { epochSPDEventLedgerState :: Maybe (O.LedgerState (O.CardanoBlock O.StandardCrypto))
+        , epochSPDEventEpochNo :: Maybe C.EpochNo
+        , epochSPDEventSPD :: Map C.PoolId C.Lovelace
+        , epochSPDEventSlotNo :: C.SlotNo
+        , epochSPDEventBlockHeaderHash :: C.Hash C.BlockHeader
+        , epochSPDEventBlockNo :: C.BlockNo
+        , epochSPDEventChainTip :: C.ChainTip -- ^ Actual tip of the chain
+        , epochSPDEventIsFirstEventOfEpoch :: Bool
+        }
+    deriving (Eq, Show)
 
--- | Convert a stream of ledger states for every block to a stream of
--- ledger states for every epoch. We also skip the Byron era because
--- it doesn't have any staking information.
-toEvents :: S.Stream (S.Of C.LedgerState) IO r -> S.Stream (S.Of Event) IO r
-toEvents source = source
-  & S.mapMaybe toNoByron
-  & firstEventOfEveryEpoch
-  where
-    -- Skip Byron era as it doesn't have staking.
-    toNoByron :: C.LedgerState -> Maybe Event
-    toNoByron ls = if
-      | Just epochNo <- getEpochNo ls
-      , Just m <- getStakeMap ls -> Just $ Event (epochNo, m)
-      | otherwise -> Nothing
+type instance StorablePoint EpochSPDHandle = C.ChainPoint
 
-    -- We get LedgerState at every block from the ledgerStates
-    -- streamer but we only want the first one of every epoch, so we
-    -- zip them and only emit ledger states at epoch boundaries.
-    firstEventOfEveryEpoch :: S.Stream (S.Of Event) IO r -> S.Stream (S.Of Event) IO r
-    firstEventOfEveryEpoch source' = source'
-      & S.slidingWindow 2
-      & S.mapMaybe (\case
-                  (Event (e0, _) Seq.:<| t@(Event (e1, _)) Seq.:<| Seq.Empty)
-                    | succ e0 == e1 -> Just t
-                    | e0 == e1 -> Nothing
-                    | otherwise -> error $ "This should never happen: consequent epochs wider apart than by one: " <> show (e0, e1)
-                  _ -> error "This should never happen"
-              )
+instance HasPoint (StorableEvent EpochSPDHandle) C.ChainPoint where
+  getPoint (EpochSPDEvent _ _ _ s bhh _ _ _) = C.ChainPoint s bhh
 
--- | From LedgerState get epoch stakepool size: a mapping of pool ID
--- to amount staked. We do this by getting the _pstatkeSet stake
--- snapshot and then use _delegations and _stake to resolve it into
--- the desired mapping.
-getStakeMap :: C.LedgerState -> Maybe (M.Map C.PoolId C.Lovelace)
+data instance StorableQuery EpochSPDHandle =
+    SPDByEpochNoQuery C.EpochNo
+  | LedgerStateAtPointQuery C.ChainPoint
+
+data instance StorableResult EpochSPDHandle =
+    SPDByEpochNoResult [EpochSPDRow]
+  | LedgerStateAtPointResult (Maybe (O.LedgerState (O.CardanoBlock O.StandardCrypto)))
+    deriving (Eq, Show)
+
+newtype EpochSPDDepth = EpochSPDDepth Int
+
+type EpochSPDIndex = State EpochSPDHandle
+
+toStorableEvent
+    :: O.LedgerState (O.HardForkBlock (O.CardanoEras O.StandardCrypto))
+    -> C.SlotNo
+    -> C.Hash C.BlockHeader
+    -> C.BlockNo
+    -> C.ChainTip
+    -> Word64 -- ^ Security param
+    -> Bool -- ^ Is the last event of the current epoch
+    -> StorableEvent EpochSPDHandle
+toStorableEvent ledgerState slotNo bhh bn chainTip securityParam isFirstEventOfEpoch = do
+    let doesStoreLedgerState = isBlockRollbackable securityParam bn chainTip || isFirstEventOfEpoch
+    EpochSPDEvent
+        (if doesStoreLedgerState then Just ledgerState else Nothing)
+        (getEpochNo ledgerState)
+        (getStakeMap ledgerState)
+        slotNo
+        bhh
+        bn
+        chainTip
+        isFirstEventOfEpoch
+
+-- | From LedgerState, get epoch stake pool delegation: a mapping of pool ID to amount staked in
+-- lovelace. We do this by getting the '_pstakeSet' stake snapshot and then use '_delegations' and
+-- '_stake' to resolve it into the desired mapping.
+getStakeMap
+    :: O.LedgerState (O.CardanoBlock O.StandardCrypto)
+    -> Map C.PoolId C.Lovelace
 getStakeMap ledgerState' = case ledgerState' of
-  C.LedgerStateByron _st                  -> Nothing
-  C.LedgerStateShelley st                 -> fromState st
-  C.LedgerStateAllegra st                 -> fromState st
-  C.LedgerStateMary st                    -> fromState st
-  C.LedgerStateAlonzo st                  -> fromState st
-  -- TODO Pattern LedgerStateBabbage missing in cardano-node
-  -- https://github.com/input-output-hk/cardano-node/blob/release/1.35/cardano-api/src/Cardano/Api/LedgerState.hs#L252-L281,
-  -- swap this to a pattern when it appears.
-  C.LedgerState (O.LedgerStateBabbage st) -> fromState st
+  O.LedgerStateByron _    -> mempty
+  O.LedgerStateShelley st -> getStakeMapFromShelleyBlock st
+  O.LedgerStateAllegra st -> getStakeMapFromShelleyBlock st
+  O.LedgerStateMary st    -> getStakeMapFromShelleyBlock st
+  O.LedgerStateAlonzo st  -> getStakeMapFromShelleyBlock st
+  O.LedgerStateBabbage st -> getStakeMapFromShelleyBlock st
   where
-    fromState
+    getStakeMapFromShelleyBlock
       :: forall proto era c
-       . (c ~ LE.Crypto era, c ~ O.StandardCrypto)
+       . (c ~ Ledger.Crypto era, c ~ O.StandardCrypto)
       => O.LedgerState (O.ShelleyBlock proto era)
-      -> Maybe (M.Map C.PoolId C.Lovelace)
-    fromState st = Just res
+      -> Map C.PoolId C.Lovelace
+    getStakeMapFromShelleyBlock st = spd
       where
-        nes = O.shelleyLedgerState st :: SL.NewEpochState era
+        nes = O.shelleyLedgerState st :: Ledger.NewEpochState era
 
-        stakeSnapshot = Shelley._pstakeSet . Shelley.esSnapshots . Shelley.nesEs $ nes :: Shelley.SnapShot c
-        stakes = Shelley.unStake $ Shelley._stake stakeSnapshot :: VMap.VMap VMap.VB VMap.VP (LC.Credential 'LK.Staking c) (L.CompactForm L.Coin)
+        stakeSnapshot = Ledger._pstakeSet . Ledger.esSnapshots . Ledger.nesEs $ nes :: Ledger.SnapShot c
 
-        delegations :: VMap.VMap VMap.VB VMap.VB (LC.Credential 'LK.Staking c) (LK.KeyHash 'LK.StakePool c)
-        delegations = Shelley._delegations stakeSnapshot
+        stakes = Ledger.unStake
+               $ Ledger._stake stakeSnapshot
 
-        res :: M.Map C.PoolId C.Lovelace
-        res = M.fromListWith (+) $ map swap $ P.catMaybes $ VMap.elems $
-          VMap.mapWithKey (\cred spkHash -> (\c -> (C.Lovelace $ coerce $ L.fromCompact c, f spkHash)) <$> VMap.lookup cred stakes) delegations
+        delegations :: VMap.VMap VMap.VB VMap.VB (Ledger.Credential 'Ledger.Staking c) (Ledger.KeyHash 'Ledger.StakePool c)
+        delegations = Ledger._delegations stakeSnapshot
 
-        f :: LK.KeyHash 'LK.StakePool c -> C.PoolId
-        f xk = C.StakePoolKeyHash xk
+        spd :: Map C.PoolId C.Lovelace
+        spd = Map.fromListWith (+)
+            $ map swap
+            $ catMaybes
+            $ VMap.elems
+            $ VMap.mapWithKey
+                (\cred spkHash ->
+                    (\c -> ( C.Lovelace $ coerce $ Ledger.fromCompact c
+                           , C.StakePoolKeyHash spkHash
+                           )
+                    )
+                    <$> VMap.lookup cred stakes)
+                delegations
 
-indexer
-  :: FilePath -> FilePath -> SQL.Connection
-  -> S.Stream (S.Of Event) IO r
-indexer conf socket dbCon =
-    CS.ledgerStates conf socket C.QuickValidation
-  & toEvents
-  & sqlite dbCon
-
--- * Sqlite back-end
-
--- | Consume a stream of events and write them to the database. Also
--- passes events on after they are persisted -- useful to knwow when
--- something has been persisted.
-sqlite :: SQL.Connection -> S.Stream (S.Of Event) IO r -> S.Stream (S.Of Event) IO r
-sqlite c source = do
-  lift $ SQL.execute_ c
-      "CREATE TABLE IF NOT EXISTS stakepool_delegation (poolId BLOB NOT NULL, lovelace INT NOT NULL, epochNo INT NOT NULL)"
-  loop source
-
+getEpochNo :: O.LedgerState (O.CardanoBlock O.StandardCrypto) -> Maybe EpochNo
+getEpochNo ledgerState' = case ledgerState' of
+  O.LedgerStateByron _st  -> Nothing
+  O.LedgerStateShelley st -> getEpochNoFromShelleyBlock st
+  O.LedgerStateAllegra st -> getEpochNoFromShelleyBlock st
+  O.LedgerStateMary st    -> getEpochNoFromShelleyBlock st
+  O.LedgerStateAlonzo st  -> getEpochNoFromShelleyBlock st
+  O.LedgerStateBabbage st -> getEpochNoFromShelleyBlock st
   where
-    toRows :: Event -> [(C.EpochNo, C.PoolId, C.Lovelace)]
-    toRows (Event (epochNo, m)) = map (\(keyHash, lovelace) -> (epochNo, keyHash, lovelace)) $ M.toList m
+    getEpochNoFromShelleyBlock = Just . Ledger.nesEL . O.shelleyLedgerState
 
-    loop :: S.Stream (S.Of Event) IO r -> S.Stream (S.Of Event) IO r
-    loop source' = lift (S.next source') >>= \case
-        Left r -> pure r
-        Right (event, source'') -> do
-          lift $ forM_ (toRows event) $ \row ->
-            SQL.execute c "INSERT INTO stakepool_delegation (epochNo, poolId, lovelace) VALUES (?, ?, ?)" row
-          S.yield event
-          loop source''
+data EpochSPDRow = EpochSPDRow
+    { epochSPDRowEpochNo         :: !C.EpochNo
+    , epochSPDRowPoolId          :: !C.PoolId
+    , epochSPDRowLovelace        :: !C.Lovelace
+    , epochSPDRowSlotNo          :: !C.SlotNo
+    , epochSPDRowBlockHeaderHash :: !(C.Hash C.BlockHeader)
+    , epochSPDRowBlockNo         :: !C.BlockNo
+    } deriving (Eq, Ord, Show, Generic, SQL.FromRow, SQL.ToRow)
 
+instance Buffered EpochSPDHandle where
+    -- We should only store on disk SPD from the last slot of each epoch.
+    persistToStorage
+        :: Foldable f
+        => f (StorableEvent EpochSPDHandle)
+        -> EpochSPDHandle
+        -> IO EpochSPDHandle
+    persistToStorage events h@(EpochSPDHandle c ledgerStateDirPath securityParam) = do
+        let eventsList = toList events
 
-instance SQL.ToField C.EpochNo where
-  toField (C.EpochNo word64) = SQL.toField word64
-instance SQL.FromField C.EpochNo where
-  fromField f = C.EpochNo <$> SQL.fromField f
+        SQL.execute_ c "BEGIN"
+        forM_ (concatMap eventToEpochSPDRows $ filter epochSPDEventIsFirstEventOfEpoch eventsList) $ \row ->
+          SQL.execute c
+              [r|INSERT INTO epoch_spd
+                  ( epochNo
+                  , poolId
+                  , lovelace
+                  , slotNo
+                  , blockHeaderHash
+                  , blockNo
+                  ) VALUES (?, ?, ?, ?, ?, ?)|] row
+        SQL.execute_ c "COMMIT"
 
-instance SQL.ToField C.Lovelace where
-  toField = SQL.toField @Integer . coerce
-instance SQL.FromField C.Lovelace where
-  fromField = coerce . SQL.fromField @Integer
+        -- We store the LedgerState if one of following conditions hold:
+        --   * the LedgerState cannot be rollbacked and is the last of an epoch
+        --   * the LedgerState can be rollbacked
+        let writeLedgerState ledgerState (C.SlotNo slotNo) blockHeaderHash (C.BlockNo blockNo) isRollbackable = do
+                let fname = ledgerStateDirPath
+                        </> "ledgerState_"
+                         <> (if isRollbackable then "volatile_" else "")
+                         <> show slotNo
+                         <> "_"
+                         <> Text.unpack (C.serialiseToRawBytesHexText blockHeaderHash)
+                         <> "_"
+                         <> show blockNo
+                         <> ".bin"
+                -- TODO We should delete the file is the write operation was interrumpted by the
+                -- user. Tried using something like `onException`, but it doesn't run the cleanup
+                -- function. Not sure how to do the cleanup here without restoring doing it outside
+                -- the thread where this indexer is running.
+                BS.writeFile fname (CBOR.toLazyByteString $ encodeLedgerState ledgerState)
+        forM_ eventsList
+              $ \(EpochSPDEvent
+                    maybeLedgerState
+                    maybeEpochNo
+                    _
+                    slotNo
+                    blockHeaderHash
+                    blockNo
+                    chainTip
+                    isFirstEventOfEpoch) -> do
+            case (maybeEpochNo, maybeLedgerState) of
+              (Just _, Just ledgerState) -> do
+                  let isRollbackable = isBlockRollbackable securityParam blockNo chainTip
+                  when (isRollbackable || isFirstEventOfEpoch) $ do
+                    writeLedgerState ledgerState slotNo blockHeaderHash blockNo isRollbackable
+              -- We don't store any 'LedgerState' if the era doesn't have epochs (Byron era) or if
+              -- we don't have access to the 'LedgerState'.
+              _noLedgerStateOrEpochNo -> pure ()
 
-instance SQL.FromField C.PoolId where
-  fromField f = do
-    bs <- SQL.fromField f
-    case C.deserialiseFromRawBytes (C.AsHash C.AsStakePoolKey) bs of
-      Just h -> pure h
-      _      -> SQL.returnError SQL.ConversionFailed f " PoolId"
+        -- Remove all immutable LedgerStates from the filesystem expect the most recent immutable
+        -- one which is from the last slot of latest epoch.
+        -- A 'LedgerState' is considered immutable if its 'blockNo' is '< latestBlockNo - securityParam'.
+        case NE.nonEmpty eventsList of
+          Nothing -> pure ()
+          Just nonEmptyEvents -> do
+              let chainTip =
+                      NE.head
+                      $ NE.sortWith (\case C.ChainTipAtGenesis -> Down Nothing;
+                                           C.ChainTip _ _ bn   -> Down (Just bn)
+                                    )
+                      $ fmap epochSPDEventChainTip nonEmptyEvents
 
-instance SQL.ToField C.PoolId where
-  toField = SQL.toField . C.serialiseToRawBytes
+              ledgerStateFilePaths <-
+                  mapMaybe (\fp -> fmap (fp,) $ chainTipsFromLedgerStateFilePath fp)
+                  <$> listDirectory ledgerStateDirPath
 
-queryByEpoch :: SQL.Connection -> C.EpochNo -> IO Event
-queryByEpoch c epochNo = do
-  xs :: [(C.PoolId, C.Lovelace)] <- SQL.query c "SELECT poolId, lovelace FROM stakepool_delegation WHERE epochNo = ?" (SQL.Only epochNo)
-  return $ Event (epochNo, M.fromList xs)
+              -- Delete volatile LedgerState which have become immutable.
+              let oldVolatileLedgerStateFilePaths =
+                      fmap fst
+                      $ filter (\(_, (isVolatile, _, _, blockNo)) ->
+                          isVolatile && not (isBlockRollbackable securityParam blockNo chainTip))
+                      ledgerStateFilePaths
+              forM_ oldVolatileLedgerStateFilePaths $ \fp -> removeFile $ ledgerStateDirPath </> fp
 
-queryPoolId :: SQL.Connection -> C.PoolId -> IO [(C.EpochNo, C.Lovelace)]
-queryPoolId c poolId = do
-  SQL.query c "SELECT epochNo, lovelace FROM stakepool_delegation WHERE poolId = ?" (SQL.Only poolId)
+              -- Delete all immutable LedgerStates expect the latest one
+              let immutableLedgerStateFilePaths =
+                      filter (\(_, (isVolatile, _, _, _)) -> not isVolatile) ledgerStateFilePaths
+              case NE.nonEmpty immutableLedgerStateFilePaths of
+                Nothing -> pure ()
+                Just nonEmptyLedgerStateFilePaths -> do
+                  let oldImmutableLedgerStateFilePaths =
+                          fmap (\(fp, _, _) -> fp)
+                          $ filter (\(_, _, isImmutableBlock) -> isImmutableBlock)
+                          $ NE.tail
+                          $ NE.sortWith (\(_, (_, _, blockNo), isImmutableBlock) ->
+                              Down (blockNo, isImmutableBlock))
+                          $ fmap (\(fp, (_, slotNo, bhh, blockNo)) ->
+                              ( fp
+                              , (slotNo, bhh, blockNo)
+                              , not $ isBlockRollbackable securityParam blockNo chainTip)
+                              )
+                          nonEmptyLedgerStateFilePaths
+                  forM_ oldImmutableLedgerStateFilePaths
+                    $ \fp -> removeFile $ ledgerStateDirPath </> fp
 
-queryAll :: SQL.Connection -> IO [Event]
-queryAll c = do
-  all' :: [(C.EpochNo, C.PoolId, C.Lovelace)] <- SQL.query_ c "SELECT epochNo, poolId, lovelace FROM stakepool_delegation ORDER BY epochNo ASC"
-  let
-    lastTwo (_, a, b) = (a, b)
-    result = all'
-      & groupBy ((==) `on` (\(e, _, _) -> e))
-      & map (\case xs@((e, _, _) : _) -> Just $ Event (e, M.fromList $ map lastTwo xs); _ -> Nothing)
-      & P.catMaybes
-  pure result
+        pure h
+
+    -- | Buffering is not in use in this indexer and we don't need to retrieve stored events in our
+    -- implementation. Therefore, this function returns an empty list.
+    getStoredEvents
+        :: EpochSPDHandle
+        -> IO [StorableEvent EpochSPDHandle]
+    getStoredEvents EpochSPDHandle {} = do
+        pure []
+
+eventToEpochSPDRows
+    :: StorableEvent EpochSPDHandle
+    -> [EpochSPDRow]
+eventToEpochSPDRows (EpochSPDEvent _ maybeEpochNo m slotNo blockHeaderHash blockNo _ _) =
+    mapMaybe
+        (\(keyHash, lovelace) ->
+            fmap (\epochNo -> EpochSPDRow
+                                  epochNo
+                                  keyHash
+                                  lovelace
+                                  slotNo
+                                  blockHeaderHash
+                                  blockNo) maybeEpochNo)
+        $ Map.toList m
+
+instance Queryable EpochSPDHandle where
+    queryStorage
+        :: Foldable f
+        => QueryInterval C.ChainPoint
+        -> f (StorableEvent EpochSPDHandle)
+        -> EpochSPDHandle
+        -> StorableQuery EpochSPDHandle
+        -> IO (StorableResult EpochSPDHandle)
+
+    queryStorage _ events (EpochSPDHandle c _ _) (SPDByEpochNoQuery epochNo) = do
+        case List.find (\e -> epochSPDEventEpochNo e == Just epochNo) (toList events) of
+          Just e ->
+              pure $ SPDByEpochNoResult $ eventToEpochSPDRows e
+          Nothing -> do
+              res :: [EpochSPDRow] <- SQL.query c
+                  [r|SELECT epochNo, poolId, lovelace, slotNo, blockHeaderHash, blockNo
+                     FROM epoch_spd
+                     WHERE epochNo = ?
+                  |] (SQL.Only epochNo)
+              pure $ SPDByEpochNoResult res
+
+    queryStorage _ _ EpochSPDHandle {} (LedgerStateAtPointQuery C.ChainPointAtGenesis) = do
+        pure $ LedgerStateAtPointResult Nothing
+    queryStorage
+            _
+            events
+            (EpochSPDHandle _ ledgerStateDirPath _)
+            (LedgerStateAtPointQuery (C.ChainPoint slotNo _)) = do
+        case List.find (\e -> epochSPDEventSlotNo e == slotNo) (toList events) of
+            Nothing -> do
+                ledgerStateFilePaths <- listDirectory ledgerStateDirPath
+                let ledgerStateFilePath =
+                        List.find
+                            (\fp -> fmap (\(_, sn, _, _) -> sn)
+                                         (chainTipsFromLedgerStateFilePath fp) == Just slotNo
+                            )
+                            ledgerStateFilePaths
+                case ledgerStateFilePath of
+                  Nothing -> pure $ LedgerStateAtPointResult Nothing
+                  Just fp -> do
+                      ledgerStateBs <- BS.readFile $ ledgerStateDirPath </> fp
+                      let ledgerState =
+                              either
+                                (const Nothing)
+                                (Just . snd)
+                                $ CBOR.deserialiseFromBytes decodeLedgerState ledgerStateBs
+                      pure $ LedgerStateAtPointResult ledgerState
+            Just event -> pure $ LedgerStateAtPointResult $ epochSPDEventLedgerState event
+
+instance Rewindable EpochSPDHandle where
+    rewindStorage
+        :: C.ChainPoint
+        -> EpochSPDHandle
+        -> IO (Maybe EpochSPDHandle)
+    rewindStorage C.ChainPointAtGenesis h@(EpochSPDHandle c ledgerStateDirPath _) = do
+        SQL.execute_ c "DELETE FROM epoch_spd"
+
+        ledgerStateFilePaths <- listDirectory ledgerStateDirPath
+        forM_ ledgerStateFilePaths (\f -> removeFile $ ledgerStateDirPath </> f)
+        pure $ Just h
+    rewindStorage (C.ChainPoint sn _) h@(EpochSPDHandle c ledgerStateDirPath _) = do
+        SQL.execute c "DELETE FROM epoch_spd WHERE slotNo > ?" (SQL.Only sn)
+
+        ledgerStateFilePaths <- listDirectory ledgerStateDirPath
+        forM_ ledgerStateFilePaths $ \fp -> do
+            case chainTipsFromLedgerStateFilePath fp of
+              Nothing                              -> pure ()
+              Just (_, slotNo, _, _) | slotNo > sn -> removeFile $ ledgerStateDirPath </> fp
+              Just _                               -> pure ()
+
+        pure $ Just h
+
+instance Resumable EpochSPDHandle where
+    resumeFromStorage
+        :: EpochSPDHandle
+        -> IO [C.ChainPoint]
+    resumeFromStorage (EpochSPDHandle c ledgerStateDirPath _) = do
+        epochSPDChainPoints :: Set C.ChainPoint <- Set.fromList . fmap (uncurry C.ChainPoint) <$>
+                SQL.query c
+                    [r|SELECT slotNo, blockHeaderHash
+                       FROM epoch_spd|] ()
+
+        ledgerStateFilepaths <- listDirectory ledgerStateDirPath
+        let ledgerStateChainPoints =
+                Set.fromList
+                $ fmap (\(_, sn, bhh, _) -> C.ChainPoint sn bhh)
+                $ mapMaybe chainTipsFromLedgerStateFilePath ledgerStateFilepaths
+
+        let resumablePoints =
+                List.sortOn Down
+                $ Set.toList
+                $ Set.intersection epochSPDChainPoints ledgerStateChainPoints
+
+        pure $ resumablePoints ++ [C.ChainPointAtGenesis]
+
+chainTipsFromLedgerStateFilePath :: FilePath -> Maybe (Bool, C.SlotNo, C.Hash C.BlockHeader, C.BlockNo)
+chainTipsFromLedgerStateFilePath ledgerStateFilepath =
+    case Text.splitOn "_" (Text.pack $ dropExtension ledgerStateFilepath) of
+      [_, slotNoStr, bhhStr, blockNoStr] -> do
+          (False,,,)
+            <$> parseSlotNo slotNoStr
+            <*> parseBlockHeaderHash bhhStr
+            <*> parseBlockNo blockNoStr
+      [_, "volatile", slotNoStr, bhhStr, blockNoStr] -> do
+          (True,,,)
+            <$> parseSlotNo slotNoStr
+            <*> parseBlockHeaderHash bhhStr
+            <*> parseBlockNo blockNoStr
+      _anyOtherFailure -> Nothing
+ where
+     parseSlotNo slotNoStr = C.SlotNo <$> readMaybe (Text.unpack slotNoStr)
+     parseBlockHeaderHash bhhStr = do
+          bhhBs <- either (const Nothing) Just $ Base16.decode $ Text.encodeUtf8 bhhStr
+          C.deserialiseFromRawBytes (C.proxyToAsType Proxy) bhhBs
+     parseBlockNo blockNoStr = C.BlockNo <$> readMaybe (Text.unpack blockNoStr)
+
+open
+  :: FilePath
+  -- ^ SQLite database file path
+  -> FilePath
+  -- ^ Directory from which we will save the various 'LedgerState' as different points in time.
+  -> Word64
+  -> IO (State EpochSPDHandle)
+open dbPath ledgerStateDirPath securityParam = do
+    c <- SQL.open dbPath
+    SQL.execute_ c "PRAGMA journal_mode=WAL"
+    SQL.execute_ c
+        [r|CREATE TABLE IF NOT EXISTS epoch_spd
+            ( epochNo INT NOT NULL
+            , poolId BLOB NOT NULL
+            , lovelace INT NOT NULL
+            , slotNo INT NOT NULL
+            , blockHeaderHash BLOB NOT NULL
+            , blockNo INT NOT NULL
+            )|]
+    emptyState 1 (EpochSPDHandle c ledgerStateDirPath securityParam)

--- a/marconi-chain-index/src/Marconi/ChainIndex/Node/Client/GenesisConfig.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Node/Client/GenesisConfig.hs
@@ -1,0 +1,437 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+
+{-| This module is a duplication of functionality from the `Cardano.Api.LedgerState`
+module in the `cardano-api` Haskell project which is not exposed .
+
+TODO: If `cardano-api` ever exposes this module, then we should use that.
+-}
+module Marconi.ChainIndex.Node.Client.GenesisConfig where
+
+import Cardano.Chain.Genesis qualified as Byron
+import Cardano.Chain.Update qualified as Byron
+import Cardano.Crypto.Hash qualified as Crypto
+import Cardano.Crypto.Hashing (decodeAbstractHash)
+import Cardano.Crypto.ProtocolMagic (RequiresNetworkMagic)
+import Cardano.Ledger.Alonzo.Genesis qualified as Ledger
+import Cardano.Ledger.Shelley.API qualified as Ledger
+import Control.Exception (IOException, catch)
+import Control.Monad (when)
+import Control.Monad.Trans.Except (ExceptT (ExceptT), except)
+import Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither, left)
+import Data.Aeson as Aeson (FromJSON (parseJSON), Object, eitherDecodeStrict', withObject, (.:), (.:?))
+import Data.Aeson.Types (Parser)
+import Data.ByteString as BS (ByteString, readFile)
+import Data.ByteString.Base16 qualified as Base16
+import Data.Foldable (asum)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Data.Yaml qualified as Yaml
+import Ouroboros.Consensus.Cardano qualified as Consensus
+import Ouroboros.Consensus.Cardano.Block qualified as Consensus
+import Ouroboros.Consensus.Cardano.Block qualified as HFC
+import Ouroboros.Consensus.Cardano.Node qualified as Consensus
+import Ouroboros.Consensus.Ledger.Extended qualified as Ledger
+import Ouroboros.Consensus.Mempool.TxLimits qualified as TxLimits
+import Ouroboros.Consensus.Node qualified as Consensus
+import Ouroboros.Consensus.Protocol.Praos.Translate ()
+import Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
+import Ouroboros.Consensus.Shelley.Node.Praos qualified as Consensus
+import System.FilePath (takeDirectory, (</>))
+
+-- Usually only one constructor, but may have two when we are preparing for a HFC event.
+data GenesisConfig
+  = GenesisCardano
+      !NodeConfig
+      !Byron.Config
+      !ShelleyConfig
+      !Ledger.AlonzoGenesis
+
+data ShelleyGenesisError
+     = ShelleyGenesisReadError !FilePath !Text
+     | ShelleyGenesisHashMismatch !GenesisHashShelley !GenesisHashShelley -- actual, expected
+     | ShelleyGenesisDecodeError !FilePath !Text
+     deriving Show
+
+data AlonzoGenesisError
+     = AlonzoGenesisReadError !FilePath !Text
+     | AlonzoGenesisHashMismatch !GenesisHashAlonzo !GenesisHashAlonzo -- actual, expected
+     | AlonzoGenesisDecodeError !FilePath !Text
+     deriving Show
+
+renderAlonzoGenesisError :: AlonzoGenesisError -> Text
+renderAlonzoGenesisError sge =
+    case sge of
+      AlonzoGenesisReadError fp err ->
+        mconcat
+          [ "There was an error reading the genesis file: ", Text.pack fp
+          , " Error: ", err
+          ]
+
+      AlonzoGenesisHashMismatch actual expected ->
+        mconcat
+          [ "Wrong Alonzo genesis file: the actual hash is ", renderHash (unGenesisHashAlonzo actual)
+          , ", but the expected Alonzo genesis hash given in the node "
+          , "configuration file is ", renderHash (unGenesisHashAlonzo expected), "."
+          ]
+
+      AlonzoGenesisDecodeError fp err ->
+        mconcat
+          [ "There was an error parsing the genesis file: ", Text.pack fp
+          , " Error: ", err
+          ]
+
+renderShelleyGenesisError :: ShelleyGenesisError -> Text
+renderShelleyGenesisError sge =
+    case sge of
+      ShelleyGenesisReadError fp err ->
+        mconcat
+          [ "There was an error reading the genesis file: ", Text.pack fp
+          , " Error: ", err
+          ]
+
+      ShelleyGenesisHashMismatch actual expected ->
+        mconcat
+          [ "Wrong Shelley genesis file: the actual hash is ", renderHash (unGenesisHashShelley actual)
+          , ", but the expected Shelley genesis hash given in the node "
+          , "configuration file is ", renderHash (unGenesisHashShelley expected), "."
+          ]
+
+      ShelleyGenesisDecodeError fp err ->
+        mconcat
+          [ "There was an error parsing the genesis file: ", Text.pack fp
+          , " Error: ", err
+          ]
+
+renderHash :: Crypto.Hash Crypto.Blake2b_256 ByteString -> Text
+renderHash h = Text.decodeUtf8 $ Base16.encode (Crypto.hashToBytes h)
+
+data ShelleyConfig = ShelleyConfig
+  { scConfig      :: !(Ledger.ShelleyGenesis Consensus.StandardShelley)
+  , scGenesisHash :: !GenesisHashShelley
+  }
+
+newtype GenesisFile = GenesisFile
+  { unGenesisFile :: FilePath
+  } deriving Show
+
+newtype GenesisHashByron = GenesisHashByron
+  { unGenesisHashByron :: Text
+  } deriving newtype (Eq, Show)
+
+newtype GenesisHashShelley = GenesisHashShelley
+  { unGenesisHashShelley :: Crypto.Hash Crypto.Blake2b_256 ByteString
+  } deriving newtype (Eq, Show)
+
+newtype GenesisHashAlonzo = GenesisHashAlonzo
+  { unGenesisHashAlonzo :: Crypto.Hash Crypto.Blake2b_256 ByteString
+  } deriving newtype (Eq, Show)
+
+newtype LedgerStateDir = LedgerStateDir
+  {  unLedgerStateDir :: FilePath
+  } deriving Show
+
+newtype NetworkName = NetworkName
+  { unNetworkName :: Text
+  } deriving Show
+
+newtype NetworkConfigFile = NetworkConfigFile
+  { unNetworkConfigFile :: FilePath
+  } deriving Show
+
+newtype SocketPath = SocketPath
+  { unSocketPath :: FilePath
+  } deriving Show
+
+data NodeConfig = NodeConfig
+  { ncPBftSignatureThreshold :: !(Maybe Double)
+  , ncByronGenesisFile :: !GenesisFile
+  , ncByronGenesisHash :: !GenesisHashByron
+  , ncShelleyGenesisFile :: !GenesisFile
+  , ncShelleyGenesisHash :: !GenesisHashShelley
+  , ncAlonzoGenesisFile :: !GenesisFile
+  , ncAlonzoGenesisHash :: !GenesisHashAlonzo
+  , ncRequiresNetworkMagic :: !RequiresNetworkMagic
+  , ncByronSoftwareVersion :: !Byron.SoftwareVersion
+  , ncByronProtocolVersion :: !Byron.ProtocolVersion
+
+  -- Per-era parameters for the hardfok transitions:
+  , ncByronToShelley   :: !(Consensus.ProtocolTransitionParamsShelleyBased
+                              Consensus.StandardShelley)
+  , ncShelleyToAllegra :: !(Consensus.ProtocolTransitionParamsShelleyBased
+                              Consensus.StandardAllegra)
+  , ncAllegraToMary    :: !(Consensus.ProtocolTransitionParamsShelleyBased
+                              Consensus.StandardMary)
+  , ncMaryToAlonzo     :: !Consensus.TriggerHardFork
+  , ncAlonzoToBabbage  :: !Consensus.TriggerHardFork
+  }
+
+instance FromJSON NodeConfig where
+  parseJSON =
+      Aeson.withObject "NodeConfig" parse
+    where
+      parse :: Object -> Parser NodeConfig
+      parse o =
+        NodeConfig
+          <$> o .:? "PBftSignatureThreshold"
+          <*> fmap GenesisFile (o .: "ByronGenesisFile")
+          <*> fmap GenesisHashByron (o .: "ByronGenesisHash")
+          <*> fmap GenesisFile (o .: "ShelleyGenesisFile")
+          <*> fmap GenesisHashShelley (o .: "ShelleyGenesisHash")
+          <*> fmap GenesisFile (o .: "AlonzoGenesisFile")
+          <*> fmap GenesisHashAlonzo (o .: "AlonzoGenesisHash")
+          <*> o .: "RequiresNetworkMagic"
+          <*> parseByronSoftwareVersion o
+          <*> parseByronProtocolVersion o
+          <*> (Consensus.ProtocolTransitionParamsShelleyBased ()
+                 <$> parseShelleyHardForkEpoch o)
+          <*> (Consensus.ProtocolTransitionParamsShelleyBased ()
+                 <$> parseAllegraHardForkEpoch o)
+          <*> (Consensus.ProtocolTransitionParamsShelleyBased ()
+                 <$> parseMaryHardForkEpoch o)
+          <*> parseAlonzoHardForkEpoch o
+          <*> parseBabbageHardForkEpoch o
+
+      parseByronProtocolVersion :: Object -> Parser Byron.ProtocolVersion
+      parseByronProtocolVersion o =
+        Byron.ProtocolVersion
+          <$> o .: "LastKnownBlockVersion-Major"
+          <*> o .: "LastKnownBlockVersion-Minor"
+          <*> o .: "LastKnownBlockVersion-Alt"
+
+      parseByronSoftwareVersion :: Object -> Parser Byron.SoftwareVersion
+      parseByronSoftwareVersion o =
+        Byron.SoftwareVersion
+          <$> fmap Byron.ApplicationName (o .: "ApplicationName")
+          <*> o .: "ApplicationVersion"
+
+      parseShelleyHardForkEpoch :: Object -> Parser Consensus.TriggerHardFork
+      parseShelleyHardForkEpoch o =
+        asum
+          [ Consensus.TriggerHardForkAtEpoch <$> o .: "TestShelleyHardForkAtEpoch"
+          , pure $ Consensus.TriggerHardForkAtVersion 2 -- Mainnet default
+          ]
+
+      parseAllegraHardForkEpoch :: Object -> Parser Consensus.TriggerHardFork
+      parseAllegraHardForkEpoch o =
+        asum
+          [ Consensus.TriggerHardForkAtEpoch <$> o .: "TestAllegraHardForkAtEpoch"
+          , pure $ Consensus.TriggerHardForkAtVersion 3 -- Mainnet default
+          ]
+
+      parseMaryHardForkEpoch :: Object -> Parser Consensus.TriggerHardFork
+      parseMaryHardForkEpoch o =
+        asum
+          [ Consensus.TriggerHardForkAtEpoch <$> o .: "TestMaryHardForkAtEpoch"
+          , pure $ Consensus.TriggerHardForkAtVersion 4 -- Mainnet default
+          ]
+
+      parseAlonzoHardForkEpoch :: Object -> Parser Consensus.TriggerHardFork
+      parseAlonzoHardForkEpoch o =
+        asum
+          [ Consensus.TriggerHardForkAtEpoch <$> o .: "TestAlonzoHardForkAtEpoch"
+          , pure $ Consensus.TriggerHardForkAtVersion 5 -- Mainnet default
+          ]
+      parseBabbageHardForkEpoch :: Object -> Parser Consensus.TriggerHardFork
+      parseBabbageHardForkEpoch o =
+        asum
+          [ Consensus.TriggerHardForkAtEpoch <$> o .: "TestBabbageHardForkAtEpoch"
+          , pure $ Consensus.TriggerHardForkAtVersion 7 -- Mainnet default
+          ]
+
+readNetworkConfig :: NetworkConfigFile -> ExceptT Text IO NodeConfig
+readNetworkConfig (NetworkConfigFile ncf) = do
+    ncfg <- (except . parseNodeConfig) =<< readByteString ncf "node"
+    return ncfg
+      { ncByronGenesisFile = adjustGenesisFilePath (mkAdjustPath ncf) (ncByronGenesisFile ncfg)
+      , ncShelleyGenesisFile = adjustGenesisFilePath (mkAdjustPath ncf) (ncShelleyGenesisFile ncfg)
+      , ncAlonzoGenesisFile = adjustGenesisFilePath (mkAdjustPath ncf) (ncAlonzoGenesisFile ncfg)
+      }
+
+adjustGenesisFilePath :: (FilePath -> FilePath) -> GenesisFile -> GenesisFile
+adjustGenesisFilePath f (GenesisFile p) = GenesisFile (f p)
+
+mkAdjustPath :: FilePath -> (FilePath -> FilePath)
+mkAdjustPath nodeConfigFilePath fp = takeDirectory nodeConfigFilePath </> fp
+
+parseNodeConfig :: ByteString -> Either Text NodeConfig
+parseNodeConfig bs =
+  case Yaml.decodeEither' bs of
+    Left err -> Left $ "Error parsing node config: " <> textShow err
+    Right nc -> Right nc
+
+readCardanoGenesisConfig
+        :: NodeConfig
+        -> ExceptT GenesisConfigError IO GenesisConfig
+readCardanoGenesisConfig enc =
+  GenesisCardano enc
+    <$> readByronGenesisConfig enc
+    <*> readShelleyGenesisConfig enc
+    <*> readAlonzoGenesisConfig enc
+
+readByronGenesisConfig
+        :: NodeConfig
+        -> ExceptT GenesisConfigError IO Byron.Config
+readByronGenesisConfig enc = do
+  let file = unGenesisFile $ ncByronGenesisFile enc
+  genHash <- firstExceptT NEError
+                . hoistEither
+                $ decodeAbstractHash (unGenesisHashByron $ ncByronGenesisHash enc)
+  firstExceptT (NEByronConfig file)
+                $ Byron.mkConfigFromFile (ncRequiresNetworkMagic enc) file genHash
+
+readShelleyGenesisConfig
+    :: NodeConfig
+    -> ExceptT GenesisConfigError IO ShelleyConfig
+readShelleyGenesisConfig enc = do
+  let file = unGenesisFile $ ncShelleyGenesisFile enc
+  firstExceptT (NEShelleyConfig file . renderShelleyGenesisError)
+    $ readShelleyGenesis (GenesisFile file) (ncShelleyGenesisHash enc)
+
+readAlonzoGenesisConfig
+    :: NodeConfig
+    -> ExceptT GenesisConfigError IO Ledger.AlonzoGenesis
+readAlonzoGenesisConfig enc = do
+  let file = unGenesisFile $ ncAlonzoGenesisFile enc
+  firstExceptT (NEAlonzoConfig file . renderAlonzoGenesisError)
+    $ readAlonzoGenesis (GenesisFile file) (ncAlonzoGenesisHash enc)
+
+readAlonzoGenesis
+    :: GenesisFile -> GenesisHashAlonzo
+    -> ExceptT AlonzoGenesisError IO Ledger.AlonzoGenesis
+readAlonzoGenesis (GenesisFile file) expectedGenesisHash = do
+    content <- handleIOExceptT (AlonzoGenesisReadError file . textShow) $ BS.readFile file
+    let genesisHash = GenesisHashAlonzo (Crypto.hashWith id content)
+    checkExpectedGenesisHash genesisHash
+    firstExceptT (AlonzoGenesisDecodeError file . Text.pack)
+                  . hoistEither
+                  $ Aeson.eitherDecodeStrict' content
+  where
+    checkExpectedGenesisHash :: GenesisHashAlonzo -> ExceptT AlonzoGenesisError IO ()
+    checkExpectedGenesisHash actual =
+      when (actual /= expectedGenesisHash) $
+        left (AlonzoGenesisHashMismatch actual expectedGenesisHash)
+
+readShelleyGenesis
+    :: GenesisFile -> GenesisHashShelley
+    -> ExceptT ShelleyGenesisError IO ShelleyConfig
+readShelleyGenesis (GenesisFile file) expectedGenesisHash = do
+    content <- handleIOExceptT (ShelleyGenesisReadError file . textShow) $ BS.readFile file
+    let genesisHash = GenesisHashShelley (Crypto.hashWith id content)
+    checkExpectedGenesisHash genesisHash
+    genesis <- firstExceptT (ShelleyGenesisDecodeError file . Text.pack)
+                  . hoistEither
+                  $ Aeson.eitherDecodeStrict' content
+    pure $ ShelleyConfig genesis genesisHash
+  where
+    checkExpectedGenesisHash :: GenesisHashShelley -> ExceptT ShelleyGenesisError IO ()
+    checkExpectedGenesisHash actual =
+      when (actual /= expectedGenesisHash) $
+        left (ShelleyGenesisHashMismatch actual expectedGenesisHash)
+
+data GenesisConfigError
+  = NEError !Text
+  | NEByronConfig !FilePath !Byron.ConfigurationError
+  | NEShelleyConfig !FilePath !Text
+  | NEAlonzoConfig !FilePath !Text
+  | NECardanoConfig !Text
+
+renderGenesisConfigError :: GenesisConfigError -> Text
+renderGenesisConfigError ne =
+  case ne of
+    NEError t -> "Error: " <> t
+    NEByronConfig fp ce ->
+      mconcat
+        [ "Failed reading Byron genesis file ", textShow fp, ": ", textShow ce
+        ]
+    NEShelleyConfig fp txt ->
+      mconcat
+        [ "Failed reading Shelley genesis file ", textShow fp, ": ", txt
+        ]
+    NEAlonzoConfig fp txt ->
+      mconcat
+        [ "Failed reading Alonzo genesis file ", textShow fp, ": ", txt
+        ]
+    NECardanoConfig err ->
+      mconcat
+        [ "With Cardano protocol, Byron/Shelley config mismatch:\n"
+        , "   ", err
+        ]
+
+initExtLedgerStateVar :: GenesisConfig -> Ledger.ExtLedgerState (HFC.HardForkBlock (Consensus.CardanoEras Consensus.StandardCrypto))
+initExtLedgerStateVar genesisConfig = Consensus.pInfoInitLedger protocolInfo
+  where
+    protocolInfo = mkProtocolInfoCardano genesisConfig
+
+mkProtocolInfoCardano ::
+  GenesisConfig ->
+  Consensus.ProtocolInfo
+    IO
+    (HFC.HardForkBlock
+            (Consensus.CardanoEras Consensus.StandardCrypto))
+mkProtocolInfoCardano (GenesisCardano dnc byronGenesis shelleyGenesis alonzoGenesis)
+  = Consensus.protocolInfoCardano
+          Consensus.ProtocolParamsByron
+            { Consensus.byronGenesis = byronGenesis
+            , Consensus.byronPbftSignatureThreshold = Consensus.PBftSignatureThreshold <$> ncPBftSignatureThreshold dnc
+            , Consensus.byronProtocolVersion = ncByronProtocolVersion dnc
+            , Consensus.byronSoftwareVersion = ncByronSoftwareVersion dnc
+            , Consensus.byronLeaderCredentials = Nothing
+            , Consensus.byronMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
+            }
+          Consensus.ProtocolParamsShelleyBased
+            { Consensus.shelleyBasedGenesis = scConfig shelleyGenesis
+            , Consensus.shelleyBasedInitialNonce = shelleyPraosNonce shelleyGenesis
+            , Consensus.shelleyBasedLeaderCredentials = []
+            }
+          Consensus.ProtocolParamsShelley
+            { Consensus.shelleyProtVer = shelleyProtVer dnc
+            , Consensus.shelleyMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
+            }
+          Consensus.ProtocolParamsAllegra
+            { Consensus.allegraProtVer = shelleyProtVer dnc
+            , Consensus.allegraMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
+            }
+          Consensus.ProtocolParamsMary
+            { Consensus.maryProtVer = shelleyProtVer dnc
+            , Consensus.maryMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
+            }
+          Consensus.ProtocolParamsAlonzo
+            { Consensus.alonzoProtVer = shelleyProtVer dnc
+            , Consensus.alonzoMaxTxCapacityOverrides  = TxLimits.mkOverrides TxLimits.noOverridesMeasure
+            }
+          Consensus.ProtocolParamsBabbage
+            { Consensus.babbageProtVer = shelleyProtVer dnc
+            , Consensus.babbageMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
+            }
+          (ncByronToShelley dnc)
+          (ncShelleyToAllegra dnc)
+          (ncAllegraToMary dnc)
+          (Consensus.ProtocolTransitionParamsShelleyBased alonzoGenesis (ncMaryToAlonzo dnc))
+          (Consensus.ProtocolTransitionParamsShelleyBased alonzoGenesis (ncAlonzoToBabbage dnc))
+
+shelleyProtVer :: NodeConfig -> Ledger.ProtVer
+shelleyProtVer dnc =
+  let bver = ncByronProtocolVersion dnc in
+  Ledger.ProtVer
+    (fromIntegral $ Byron.pvMajor bver)
+    (fromIntegral $ Byron.pvMinor bver)
+
+shelleyPraosNonce :: ShelleyConfig -> Ledger.Nonce
+shelleyPraosNonce sCfg = Ledger.Nonce (Crypto.castHash . unGenesisHashShelley $ scGenesisHash sCfg)
+
+textShow :: Show a => a -> Text
+textShow = Text.pack . show
+
+readByteString :: FilePath -> Text -> ExceptT Text IO ByteString
+readByteString fp cfgType = ExceptT $
+  catch (Right <$> BS.readFile fp) $ \(_ :: IOException) ->
+    return $ Left $ mconcat
+      [ "Cannot read the ", cfgType, " configuration file at : ", Text.pack fp ]

--- a/marconi-chain-index/src/Marconi/ChainIndex/Utils.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Utils.hs
@@ -1,0 +1,15 @@
+module Marconi.ChainIndex.Utils
+    ( isBlockRollbackable
+    ) where
+
+import Cardano.Api qualified as C
+import Data.Word (Word64)
+
+isBlockRollbackable :: Word64 -> C.BlockNo -> C.ChainTip -> Bool
+isBlockRollbackable securityParam (C.BlockNo chainSyncBlockNo) localChainTip =
+    let chainTipBlockNo =
+            case localChainTip of
+              C.ChainTipAtGenesis             -> 0
+              (C.ChainTip _ _ (C.BlockNo bn)) -> bn
+     -- TODO Need to confirm if it's "<" or "<="
+     in chainTipBlockNo - chainSyncBlockNo <= securityParam

--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Types.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Types.hs
@@ -23,12 +23,15 @@ module Gen.Marconi.ChainIndex.Types
   , genAssetId
   , genPolicyId
   , genQuantity
+  , genEpochNo
+  , genPoolId
   ) where
 
 import Cardano.Api qualified as C
 import Cardano.Api.Shelley qualified as C
 import Cardano.Binary qualified as CBOR
 import Cardano.Crypto.Hash.Class qualified as CRYPTO
+import Cardano.Ledger.Keys (KeyHash (KeyHash))
 import Cardano.Ledger.SafeHash (unsafeMakeSafeHash)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
@@ -284,10 +287,6 @@ genProtocolParametersForPlutusScripts =
         ratioToRational = toRational
 
     -- Copied from cardano-api. Delete when this function is reexported
-    genEpochNo :: Gen C.EpochNo
-    genEpochNo = C.EpochNo <$> Gen.word64 (Range.linear 0 10)
-
-    -- Copied from cardano-api. Delete when this function is reexported
     genNat :: Gen Natural
     genNat = Gen.integral (Range.linear 0 10)
 
@@ -315,3 +314,13 @@ genPolicyId =
 -- TODO Copied from cardano-api. Delete once reexported
 genQuantity :: Range Integer -> Gen C.Quantity
 genQuantity range = fromInteger <$> Gen.integral range
+
+-- TODO Copied from cardano-api. Delete once reexported
+genEpochNo :: Gen C.EpochNo
+genEpochNo = C.EpochNo <$> Gen.word64 (Range.linear 0 10)
+
+genPoolId :: Gen (C.Hash C.StakePoolKey)
+genPoolId = C.StakePoolKeyHash  . KeyHash . mkDummyHash <$> Gen.int (Range.linear 0 10)
+  where
+    mkDummyHash :: forall h a. CRYPTO.HashAlgorithm h => Int -> CRYPTO.Hash h a
+    mkDummyHash = coerce . CRYPTO.hashWithSerialiser @h CBOR.toCBOR

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/EpochStakepoolSize.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/EpochStakepoolSize.hs
@@ -5,34 +5,39 @@
 
 module Spec.Marconi.ChainIndex.Indexers.EpochStakepoolSize (tests) where
 
+import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as C
+import Cardano.BM.Configuration.Static (defaultConfigStdout)
+import Cardano.BM.Setup (withTrace)
+import Cardano.BM.Trace (logError)
+import Cardano.Streaming (ChainSyncEventException (NoIntersectionFound), withChainSyncEventStream)
 import Control.Concurrent qualified as IO
+import Control.Concurrent qualified as STM
 import Control.Concurrent.Async qualified as IO
+import Control.Concurrent.STM qualified as STM
+import Control.Exception (catch)
 import Control.Monad (forever, void, when)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson ((.=))
 import Data.Aeson qualified as J
 import Data.ByteString.Lazy qualified as BL
-import Data.Function ((&))
+import Data.List qualified as List
 import Data.Map qualified as Map
-import Database.SQLite.Simple qualified as SQL
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test qualified as HE
+import Helpers qualified as TN
+import Marconi.ChainIndex.Indexers qualified as Indexers
+import Marconi.ChainIndex.Indexers.EpochStakepoolSize qualified as EpochStakepoolSize
+import Marconi.Core.Storable qualified as Storable
+import Prettyprinter (Pretty (pretty), defaultLayoutOptions, layoutPretty, (<+>))
+import Prettyprinter.Render.Text (renderStrict)
 import Streaming.Prelude qualified as S
 import System.Directory qualified as IO
 import System.FilePath.Posix ((</>))
-
-import Hedgehog qualified as H
-import Hedgehog.Extras.Test qualified as HE
 import Test.Base qualified as H
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
-
-import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C
-import Cardano.Streaming qualified as CS
 import Testnet.Cardano qualified as TN
-
-import Helpers qualified as TN
-import Marconi.ChainIndex.Indexers.EpochStakepoolSize qualified as EpochStakepoolSize
-
 
 tests :: TestTree
 tests = testGroup "EpochStakepoolSize"
@@ -113,37 +118,63 @@ test = H.integration . HE.runFinallies . TN.workspace "chairman" $ \tempAbsPath 
   -- Prepare transaction to register stakepool and stake funds
   (poolVKey :: C.PoolId, tx, txBody) <- registerPool con networkId pparams tempAbsPath keyWitnesses [stakeCredential, stakeCredential2] genesisAddress
 
-  -- start indexer
-  found <- liftIO IO.newEmptyMVar
-  let dbPath = tempAbsPath </> "epoch_stakepool_sizes.db"
-  dbCon <- liftIO $ SQL.open dbPath
-  void $ liftIO $ do
-    chan <- IO.newChan
-    let indexer = CS.ledgerStates (TN.configurationFile runtime) socketPath C.QuickValidation
-          & EpochStakepoolSize.toEvents
-          & EpochStakepoolSize.sqlite dbCon
-          & S.chain (IO.writeChan chan) -- After indexer has written the event to database, we write it to the chan
-    void $ (IO.link =<<) $ IO.async $ void $ S.effects indexer
-
-    -- Consume the channel until an event is found which (1) has the
-    -- pool ID and (2) has the right amount of lovelace staked.
-    (IO.link =<<) $ IO.async $ forever $ do
-      EpochStakepoolSize.Event (_epochNo, stakeMap) <- IO.readChan chan
-      case Map.lookup poolVKey stakeMap of
-        Just lovelace -> when (lovelace == totalStakedLovelace) $ IO.putMVar found () -- Event found!
-        _             -> return ()
-
   -- Submit transaction to create stakepool and stake the funds
   TN.submitAwaitTx con (tx, txBody)
 
+  -- This is the channel we wait on to know if the event has been indexed
+  indexedTxs <- liftIO IO.newChan
+  -- Start indexer
+  coordinator <- liftIO $ Indexers.initialCoordinator 1
+  ch <- liftIO $ STM.atomically . STM.dupTChan $ Indexers._channel coordinator
+  let dbPath = tempAbsPath </> "epoch_stakepool_sizes.db"
+  (loop, _indexerMVar) <- liftIO $ Indexers.epochStakepoolSizeWorker_
+      (TN.configurationFile runtime)
+      (STM.writeChan indexedTxs)
+      123
+      coordinator
+      ch
+      dbPath
+  liftIO $ do
+      void $ IO.async loop
+      -- Receive ChainSyncEvents and pass them on to indexer's channel
+      void $ IO.async $ do
+        let chainPoint = C.ChainPointAtGenesis
+        c <- defaultConfigStdout
+        withTrace c "marconi" $ \trace ->
+            let indexerWorker =
+                    withChainSyncEventStream socketPath networkId [chainPoint]
+                    $ S.mapM_
+                    $ \chainSyncEvent -> STM.atomically $ STM.writeTChan ch chainSyncEvent
+                handleException NoIntersectionFound =
+                    logError trace
+                    $ renderStrict
+                    $ layoutPretty defaultLayoutOptions
+                    $ "No intersection found for chain point" <+> pretty chainPoint <> "."
+             in indexerWorker `catch` handleException :: IO ()
+
+  found <- liftIO IO.newEmptyMVar
+  liftIO $ (IO.link =<<) $ IO.async $ forever $ do
+      (_, event) <- IO.readChan indexedTxs
+      case Map.lookup poolVKey (EpochStakepoolSize.epochSPDEventSPD event) of
+          Just lovelace ->
+              when (lovelace == totalStakedLovelace) $
+                  IO.putMVar found (EpochStakepoolSize.epochSPDEventEpochNo event) -- Event found!
+          Nothing       ->
+              return ()
+
   -- This is filled when the epoch stakepool size has been indexed
-  liftIO $ IO.takeMVar found
+  Just epochNo <- liftIO $ IO.takeMVar found
 
   -- Let's find it in the database as well
-  epochStakes <- liftIO $ EpochStakepoolSize.queryPoolId dbCon poolVKey
-  case epochStakes of
-    ((_, lovelace) : _) -> H.assert $ lovelace == totalStakedLovelace
-    _                   -> fail "Can't find the stake for pool in sqlite!"
+  indexer <- liftIO $ STM.readMVar _indexerMVar
+  queryResult <- liftIO $ Storable.query Storable.QEverything indexer (EpochStakepoolSize.SPDByEpochNoQuery epochNo)
+  case queryResult of
+      EpochStakepoolSize.SPDByEpochNoResult stakeMap ->
+          let actualTotalStakedLovelace =
+                  fmap EpochStakepoolSize.epochSPDRowLovelace
+                       (List.find (\epochSpdRow -> EpochStakepoolSize.epochSPDRowPoolId epochSpdRow == poolVKey) stakeMap)
+           in H.assert $ actualTotalStakedLovelace == Just totalStakedLovelace
+      _otherResult -> fail "Wrong response from the given query"
 
 -- | This is a pure version of `runStakePoolRegistrationCert` defined in /cardano-node/cardano-cli/src/Cardano/CLI/Shelley/Run/Pool.hs::60
 makeStakePoolRegistrationCert_

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/EpochStakepoolSize.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/EpochStakepoolSize.hs
@@ -130,7 +130,7 @@ test = H.integration . HE.runFinallies . TN.workspace "chairman" $ \tempAbsPath 
   (loop, _indexerMVar) <- liftIO $ Indexers.epochStakepoolSizeWorker_
       (TN.configurationFile runtime)
       (STM.writeChan indexedTxs)
-      123
+      10
       coordinator
       ch
       dbPath

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Orphans.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Orphans.hs
@@ -77,6 +77,21 @@ tests = testGroup "Spec.Marconi.ChainIndex.Orphans"
               "C.PolicyId"
               "propSQLFieldRoundtripPolicyId"
               propSQLFieldRoundtripPolicyId
+
+        , testPropertyNamed
+              "C.EpochNo"
+              "propSQLFieldRoundtripEpochNo"
+              propSQLFieldRoundtripEpochNo
+
+        , testPropertyNamed
+              "C.Lovelace"
+              "propSQLFieldRoundtripLovelace"
+              propSQLFieldRoundtripLovelace
+
+        , testPropertyNamed
+              "C.PoolId"
+              "propSQLFieldRoundtripPoolId"
+              propSQLFieldRoundtripPoolId
         ]
 
   , testGroup "ToJSON/FromJSON rountrip"
@@ -160,5 +175,20 @@ propSQLFieldRoundtripScriptHash = property $ do
 propSQLFieldRoundtripPolicyId :: Property
 propSQLFieldRoundtripPolicyId = property $ do
     p <- forAll Gen.genPolicyId
+    tripping p SQL.toField (\sqlData -> SQL.fromField $ SQL.Field sqlData 0)
+
+propSQLFieldRoundtripEpochNo :: Property
+propSQLFieldRoundtripEpochNo = property $ do
+    p <- forAll Gen.genEpochNo
+    tripping p SQL.toField (\sqlData -> SQL.fromField $ SQL.Field sqlData 0)
+
+propSQLFieldRoundtripLovelace :: Property
+propSQLFieldRoundtripLovelace = property $ do
+    p <- forAll CGen.genLovelace
+    tripping p SQL.toField (\sqlData -> SQL.fromField $ SQL.Field sqlData 0)
+
+propSQLFieldRoundtripPoolId :: Property
+propSQLFieldRoundtripPoolId = property $ do
+    p <- forAll Gen.genPoolId
     tripping p SQL.toField (\sqlData -> SQL.fromField $ SQL.Field sqlData 0)
 


### PR DESCRIPTION
* Rewrote the Epoch-StakePoolDelegation using the marconi-core interface and to make it support rollbacks and resuming.

* Computed the LedgerState directly with functions in `ouroboros-network` instead of using `cardano-api` and `cardano-streaming` (allows more fined grained control of what to extract).

* Moved orphan instances of EpochStakepoolSize indexer to the Orphans module and added rountrip ToField/FromField tests.

* Added LedgerState serialization/deserialization functions in Orphans module.

IMPORTANT NOTE: 

Not very performant, but not clear on how to make it better. The use of `LedgerState` uses lots of memory. Could not fully sync on my machine as I don't have enough memory (32GB). The node by itself uses about 12GB. I have 6GB for other processes. Then, I only managed to sync the indexer at 85% before using all of my memory. I'll try again by removing some of the other processes, and see if I can complete it.

However, I think I have optimized it as much as I can (given the functions from `ouroboros-network` and `cardano-ledger`). I believe that memory usage is inevitable if we're going to continue using cardano core functions.

Edit 1:

Removed that used 6GB of different processes, and resynced again. This time, it managed to fully sync in about 24h and max RAM usage was just a bit under 16GB.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
