### PR TITLE
Fix utxo query result and test cases, PLT-1540, and PLT-1536

### DIFF
--- a/__std__/cells/plutus-apps/devshells/plutus-apps-shell.nix
+++ b/__std__/cells/plutus-apps/devshells/plutus-apps-shell.nix
@@ -156,5 +156,14 @@ inputs.std.lib.dev.mkShell {
       name = "PLUTUS_CORE_OBJECTS_INV";
       value = cell.library.plutus-core-objects-inv;
     }
+    # These environemnt variables are rquired by marconi-chain-index tets
+    {
+      name = "CARDANO_CLI";
+      value = "${cell.library.cardano-node.cardano-cli}/bin/cardano-cli";
+    }
+    {
+      name = "CARDANO_NODE";
+      value = "${cell.library.cardano-node.cardano-node}/bin/cardano-node";
+    }
   ];
 }

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -144,7 +144,7 @@ utxoWorker_
   -> FilePath
   -> IO (IO (), MVar Utxo.UtxoIndexer)
 utxoWorker_ callback depth maybeTargetAddresses Coordinator{_barrier} ch path = do
-  ix <- Utxo.open path depth
+  ix <- Utxo.open path depth True -- open Sqlite with depth=depth and perform sqltie vacuum
   mIndexer <- newMVar ix
   pure (loop mIndexer, mIndexer)
   where

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -144,7 +144,8 @@ utxoWorker_
   -> FilePath
   -> IO (IO (), MVar Utxo.UtxoIndexer)
 utxoWorker_ callback depth maybeTargetAddresses Coordinator{_barrier} ch path = do
-  ix <- Utxo.open path depth True -- open SQLite with depth=depth and perform SQLite vacuum
+  ix <- Utxo.open path depth False -- open SQLite with depth=depth and DONOT perform SQLite vacuum
+  -- TODO consider adding a CLI param to allow user to perfomr Vaccum or not.
   mIndexer <- newMVar ix
   pure (loop mIndexer, mIndexer)
   where

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -1,31 +1,38 @@
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE DerivingStrategies   #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE NamedFieldPuns       #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE PackageImports       #-}
-{-# LANGUAGE PatternSynonyms      #-}
-{-# LANGUAGE QuasiQuotes          #-}
-{-# LANGUAGE RecordWildCards      #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PackageImports        #-}
+{-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE UndecidableInstances  #-}
 
-{-
--- | Back-end support for Utxo Indexer
+-- | Module for indexing the Utxos in the Cardano blockchain
 
--- This module will create the SQL tables:
-+ table: unspent_transactions
-|---------+------+-------+-----------+-------+-------+------------------+--------------+------+-------------|
-| Address | TxId | TxIx  | DatumHash | Datum | Value | InlineScriptHash | InlineScript | Slot | BlockNumber |
-|---------+------+-------+-----------+-------+-------+------------------+--------------+------+-------------|
+-- + This module will create the SQL tables:
+--
+-- + table: unspent_transactions
+--
+-- @
+--      |---------+------+-------+-----------+-------+-------+------------------+--------------+------|
+--      | Address | TxId | TxIx  | DatumHash | Datum | Value | InlineScriptHash | InlineScript | Slot |
+--      |---------+------+-------+-----------+-------+-------+------------------+--------------+------|
+-- @
+--
+-- + table: spent
+-- @
+--      |------+------|--------+-----------|
+--      | txId | txIx | slotNo | blockHash |
+--      |------+------|--------+-----------|
+-- @
+-- To create these tables, we extract all transactions outputs from each transactions fetched with
+-- the chain-sync protocol of the local node.
 
-+ table: spent
-  |------+------|--------+-----------|
-  | txId | txIx | slotNo | blockHash |
-  |------+------|--------+-----------|
-
--}
 module Marconi.ChainIndex.Indexers.Utxo where
 
 import Control.Concurrent.Async (concurrently_)
@@ -35,10 +42,14 @@ import Control.Lens.Operators ((^.))
 import Control.Lens.TH (makeLenses)
 import Control.Monad (unless, when)
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), Value (Object), object, (.:), (.=))
-import Data.Foldable (foldl', toList)
+import Data.Either (fromRight)
+import Data.Foldable (fold, foldl', toList)
 import Data.Functor ((<&>))
-import Data.List (elemIndex)
+import Data.List (groupBy, sortBy)
 import Data.List.NonEmpty (NonEmpty)
+import Data.Map (Map)
+import Data.Map qualified
+import Data.Maybe (mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Database.SQLite.Simple (Only (Only))
@@ -52,24 +63,26 @@ import Text.RawString.QQ (r)
 
 import Cardano.Api ()
 import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as Shelley
+import Cardano.Api.Shelley qualified as C
 import Marconi.ChainIndex.Orphans ()
 import Marconi.ChainIndex.Types (TargetAddresses, TxOut, pattern CurrentEra)
-import Marconi.Core.Storable (Buffered (getStoredEvents, persistToStorage), HasPoint (getPoint),
+
+import Marconi.Core.Storable (Buffered (getStoredEvents, persistToStorage), HasPoint,
                               QueryInterval (QEverything, QInterval), Queryable (queryStorage),
                               Resumable (resumeFromStorage), Rewindable (rewindStorage), StorableEvent, StorableMonad,
-                              StorablePoint, StorableQuery, StorableResult, emptyState, filterWithQueryInterval)
+                              StorablePoint, StorableQuery, StorableResult, emptyState)
 import Marconi.Core.Storable qualified as Storable
 
 type UtxoIndexer = Storable.State UtxoHandle
 
 data UtxoHandle = UtxoHandle
-  { hdlConnection :: SQL.Connection
-  , hdlDpeth      :: Int
+  { hdlConnection :: !SQL.Connection  -- ^ SQLite connection
+  , hdlDpeth      :: !Int             -- ^ depth before flushing to disk storage
+  , toVacuume     :: !Bool            -- ^ weather to perform SQLite vacuum to release space
   }
 
 newtype instance StorableQuery UtxoHandle =
-  UtxoAddress C.AddressAny deriving (Show, Eq)
+  UtxoAddress C.AddressAny deriving (Show, Eq, Ord)
 
 type QueryableAddresses = NonEmpty (StorableQuery UtxoHandle)
 
@@ -80,22 +93,24 @@ type instance StorablePoint UtxoHandle = C.ChainPoint
 newtype Depth = Depth Int
 
 data Utxo = Utxo
-  { _address          :: C.AddressAny
+  { _address          :: !C.AddressAny
   , _txId             :: !C.TxId
   , _txIx             :: !C.TxIx
-  , _datum            :: Maybe C.ScriptData
-  , _datumHash        :: Maybe (C.Hash C.ScriptData)
-  , _value            :: C.Value
-  , _inlineScript     :: Maybe Shelley.ScriptInAnyLang -- ^ Reference script
-  , _inlineScriptHash :: Maybe C.ScriptHash
+  , _datum            :: !(Maybe C.ScriptData)
+  , _datumHash        :: !(Maybe (C.Hash C.ScriptData))
+  , _value            :: !C.Value
+  , _inlineScript     :: !(Maybe C.ScriptInAnyLang)
+  , _inlineScriptHash :: !(Maybe C.ScriptHash)
   } deriving (Show, Eq, Generic)
 
 $(makeLenses ''Utxo)
 
 instance Ord Utxo where
-  left <= right
-    =   _txId left <= _txId right
-    &&  _txIx left <= _txIx right
+  compare (Utxo addr txid txix _ _ _ _ _) (Utxo addr' txid' txix' _ _ _ _ _) =
+    let cmp = addr `compare` addr'
+    in
+      if cmp == EQ then compare (C.TxIn txid txix) (C.TxIn txid' txix')
+      else  cmp
 
 instance FromJSON Utxo where
     parseJSON (Object v) =
@@ -111,10 +126,10 @@ instance FromJSON Utxo where
     parseJSON _ = mempty
 
 instance ToJSON Utxo where
-  toJSON (Utxo addr tId tIx dtum dtumHash val scrpt scrptHash) = object
+  toJSON (Utxo addr txid txix dtum dtumHash val scrpt scrptHash) = object
     [ "address"           .= addr
-    , "txId"              .= tId
-    , "txIx"              .= tIx
+    , "txId"              .= txid
+    , "txIx"              .= txix
     , "datum"             .= dtum
     , "datumHash"         .= dtumHash
     , "value"             .= val
@@ -124,9 +139,9 @@ instance ToJSON Utxo where
     ]
 
 data UtxoRow = UtxoRow
-  { _urUtxo      :: Utxo
-  , _urSlotNo    :: C.SlotNo
-  , _urBlockHash :: C.Hash C.BlockHeader
+  { _urUtxo      :: !Utxo
+  , _urSlotNo    :: !C.SlotNo
+  , _urBlockHash :: !(C.Hash C.BlockHeader)
   } deriving (Show, Eq, Ord, Generic)
 
 $(makeLenses ''UtxoRow)
@@ -155,22 +170,53 @@ data instance StorableEvent UtxoHandle = UtxoEvent
   , ueChainPoint  :: !C.ChainPoint
   } deriving (Eq, Ord, Show, Generic)
 
-eventIsBefore :: StorableEvent UtxoHandle  -> C.ChainPoint -> Bool
-eventIsBefore (UtxoEvent _ _ (C.ChainPoint _ slot)) (C.ChainPoint _ slot') =  slot < slot'
+eventIsBefore :: C.ChainPoint -> StorableEvent UtxoHandle -> Bool
+eventIsBefore (C.ChainPoint slot' _) (UtxoEvent _ _ (C.ChainPoint slot _)) =  slot <= slot'
 eventIsBefore _ _                                                          = False
 
+-- | mappend, combine Unspent utxoEvents:
+--
 instance Semigroup (StorableEvent UtxoHandle) where
-  e@(UtxoEvent u i cp) <> (UtxoEvent u' i' cp') =
-    if cp == cp' then
-      UtxoEvent (Set.union u u') (Set.union i i') cp
-    else e -- do not combine events from different chain points
+  (UtxoEvent us is cp) <> (UtxoEvent us' is' cp') =
+    UtxoEvent utxos txins (max cp cp')
+    where
+      toTxIn :: Utxo -> C.TxIn
+      toTxIn u = C.TxIn (u ^.txId) (u ^. txIx)
+      txins = Set.union is is'
+      utxos
+        = foldl' (\a c -> if toTxIn c `Set.notMember` txins then Set.insert c a;else a) Set.empty
+        . Set.union us
+        $ us'
 
 instance Monoid (StorableEvent UtxoHandle) where
   mempty = UtxoEvent mempty mempty C.ChainPointAtGenesis
 
+-- | The effect of a transaction (or a number of them) on the tx output set.
+data TxOutBalance =
+  TxOutBalance
+    { _tobUnspent :: !(Set C.TxIn)
+    -- ^ Outputs newly added by the transaction(s)
+    , _tobSpent   :: !(Set C.TxIn)
+    -- ^ Outputs spent by the transaction(s)
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance Semigroup TxOutBalance where
+    tobL <> tobR =
+        TxOutBalance
+            { _tobUnspent = _tobUnspent tobR
+                         <> (_tobUnspent tobL `Set.difference` _tobSpent tobR)
+            , _tobSpent = _tobSpent tobL <> _tobSpent tobR
+            }
+
+instance Monoid TxOutBalance where
+    mappend = (<>)
+    mempty = TxOutBalance mempty mempty
+
+
 data Spent = Spent
-  { _sTxInTxId  :: !C.TxId                 -- ^ from TxIn, containts the Spent txId
-  , _sTxInTxIx  :: !C.TxIx
+  { _sTxId      :: !C.TxId
+  , _sTxIx      :: !C.TxIx
   , _sSlotNo    :: !C.SlotNo
   , _sBlockHash :: !(C.Hash C.BlockHeader)
   } deriving (Show, Eq)
@@ -179,19 +225,20 @@ $(makeLenses ''Spent)
 
 instance Ord Spent where
   compare spent spent' =
-      case  (spent ^. sTxInTxId) `compare` (spent' ^. sTxInTxId) of
-        EQ  -> (spent ^. sTxInTxIx) `compare` (spent' ^. sTxInTxIx)
+      case  (spent ^. sTxId) `compare` (spent' ^. sTxId) of
+        EQ  -> (spent ^. sTxIx) `compare` (spent' ^. sTxIx)
         neq -> neq
 
 instance HasPoint (StorableEvent UtxoHandle) C.ChainPoint where
   getPoint (UtxoEvent _ _ cp) = cp
 
----------------------------------------------------------------------------------
---------------- sql mappings unspent_transactions and Spent tables -------------
----------------------------------------------------------------------------------
+------------------
+-- sql mappings --
+------------------
+
 instance ToRow UtxoRow where
-  toRow u =
-    [ toField (u ^. urUtxo . address)
+  toRow u = toRow
+    ( toField (u ^. urUtxo . address)
     , toField (u ^. urUtxo . txId)
     , toField (u ^. urUtxo . txIx)
     , toField (u ^. urUtxo . datum)
@@ -201,12 +248,13 @@ instance ToRow UtxoRow where
     , toField (u ^. urUtxo . inlineScriptHash)
     , toField (u ^. urSlotNo)
     , toField (u ^. urBlockHash)
-    ]
+    )
 
 instance FromRow UtxoRow where
   fromRow = UtxoRow
-      <$> (Utxo <$> field <*> field <*> field <*> field
-                <*> field <*> field <*> field <*> field)
+      <$> (Utxo <$> field
+           <*> field <*> field
+           <*> field <*> field <*> field <*> field <*> field)
       <*> field <*> field
 
 instance FromRow Spent where
@@ -214,24 +262,22 @@ instance FromRow Spent where
 
 instance ToRow Spent where
   toRow s =
-    [ toField (s ^. sTxInTxId)
-    , toField (s ^. sTxInTxIx)
+    [ toField (s ^. sTxId)
+    , toField (s ^. sTxIx)
     , toField (s ^. sSlotNo)
     , toField (s ^. sBlockHash)
     ]
-
----------------------------------------------------------------------------------
-------------------------------- End sql mappings ---------------------------------
 
 -- | Open a connection to DB, and create resources
 -- The parameter ((k + 1) * 2) specifies the amount of events that are buffered.
 -- The larger the number, the more RAM the indexer uses. However, we get improved SQL
 -- queries due to batching more events together.
 open
-  :: FilePath -- ^ sqlite file path
-  -> Depth    -- ^ The Depth parameter k, the larger K, the more RAM the indexer uses
+  :: FilePath   -- ^ sqlite file path
+  -> Depth      -- ^ The Depth parameter k, the larger K, the more RAM the indexer uses
+  -> Bool       -- ^ weather to perform vacuum
   -> IO UtxoIndexer
-open dbPath (Depth k) = do
+open dbPath (Depth k) isToVacuume = do
   c <- SQL.open dbPath
 
   SQL.execute_ c "PRAGMA journal_mode=WAL"
@@ -245,30 +291,31 @@ open dbPath (Depth k) = do
                       , value BLOB
                       , inlineScript BLOB
                       , inlineScriptHash BLOB
-                      , slotNo INT
-                      , blockHash BLOB
-                      , UNIQUE (txId, txIx))|]
-  SQL.execute_ c [r|CREATE TABLE IF NOT EXISTS spent
-                      ( txInTxId TEXT PRIMARY KEY NOT NULL
-                      , txInTxIx INT NOT NULL
                       , slotNo INT NOT NULL
                       , blockHash BLOB NOT NULL
-                      , UNIQUE (txInTxId, txInTxIx))|]
+                      , UNIQUE (txId, txIx))|]
+
+  SQL.execute_ c [r|CREATE TABLE IF NOT EXISTS spent
+                      ( txId TEXT NOT NULL
+                      , txIx INT NOT NULL
+                      , slotNo INT NOT NULL
+                      , blockHash BLOB NOT NULL
+                      , UNIQUE (txId, txIx))|]
 
   SQL.execute_ c [r|CREATE INDEX IF NOT EXISTS
                       spent_slotNo ON spent (slotNo)|]
+
   SQL.execute_ c [r|CREATE INDEX IF NOT EXISTS
                       unspent_transaction_address ON unspent_transactions (address)|]
-  emptyState k (UtxoHandle c k)
+  emptyState k (UtxoHandle c k isToVacuume)
 
-eventToSpent :: StorableEvent UtxoHandle -> [Spent]
-eventToSpent (UtxoEvent _ txIns cp) = case cp of
+getSpentFrom :: StorableEvent UtxoHandle -> [Spent]
+getSpentFrom (UtxoEvent _ txIns cp) = case cp of
   C.ChainPointAtGenesis -> [] -- There are no Spent in the Genesis block
   (C.ChainPoint sn bh)  ->  fmap (\(C.TxIn txid txix) -> Spent txid txix sn bh) . Set.toList $ txIns
 
 -- | Store UtxoEvents
 -- Events are stored in memory and flushed to SQL, disk, when memory buffer has reached capacity
---
 instance Buffered UtxoHandle where
   persistToStorage
     :: Foldable f
@@ -276,8 +323,8 @@ instance Buffered UtxoHandle where
     -> UtxoHandle -- ^ handler for storing events
     -> StorableMonad UtxoHandle UtxoHandle
   persistToStorage events h = do
-    let rows = concatMap eventsToRows events
-        spents = concatMap eventToSpent events
+    let rows = concatMap eventToRows events
+        spents = concatMap getSpentFrom events
         c = hdlConnection h
     bracket_
         (SQL.execute_ c "BEGIN")
@@ -286,37 +333,59 @@ instance Buffered UtxoHandle where
          (unless
           (null rows)
           (SQL.executeMany c
-            [r|INSERT OR REPLACE INTO unspent_transactions
-                ( address, txId, txIx, datum, datumHash
-                , value, inlineScript, inlineScriptHash
-                , slotNo, blockHash
-                ) VALUES (?,?,?,?,?,?,?,?,?,?)|] rows))
+            [r|INSERT
+               OR REPLACE INTO unspent_transactions (
+                 address,
+                 txId,
+                 txIx,
+                 datum,
+                 datumHash,
+                 value,
+                 inlineScript,
+                 inlineScriptHash,
+                 slotNo,
+                 blockHash
+              ) VALUES
+              (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)|] rows))
          (unless
           (null spents)
           (SQL.executeMany c
-           [r|INSERT OR REPLACE INTO spent
-               ( txInTxId, txInTxIx, slotNo, blockHash
-               ) VALUES (?,?,?,?)|] spents)))
+           [r|INSERT
+              OR REPLACE INTO spent (
+                txId,
+                txIx, slotNo, blockHash
+              ) VALUES
+              (?, ?, ?, ?)|] spents)))
     -- We want to perform vacuum about once every 100 * buffer ((k + 1) * 2)
-    rndCheck <- createSystemRandom >>= uniformR (1 :: Int, 100)
-    when (rndCheck == 42) $ do
-      SQL.execute_ c [r|DELETE FROM unspent_transactions
-                          WHERE unspent_transactions.rowid IN
-                            (SELECT unspent_transactions.rowid
-                             FROM unspent_transactions
-                               LEFT JOIN spent ON
-                                 unspent_transactions.txId = spent.txInTxId
-                               AND unspent_transactions.txIx = spent.txInTxIx
-                             WHERE spent.txInTxId IS NOT NULL)|]
-      SQL.execute_ c "VACUUM"
+    when (toVacuume h) $ do
+      rndCheck <- createSystemRandom >>= uniformR (1 :: Int, 100)
+      when (rndCheck == 42) $ do
+        SQL.execute_ c [r|DELETE FROM
+                            unspent_transactions
+                          WHERE
+                            unspent_transactions.rowid IN (
+                              SELECT
+                                unspent_transactions.rowid
+                              FROM
+                                unspent_transactions
+                                JOIN spent ON unspent_transactions.txId = spent.txId
+                                AND unspent_transactions.txIx = spent.txIx
+                            )|]  -- remove all spent
+
+        SQL.execute_ c "VACUUM"
     pure h
 
   getStoredEvents :: UtxoHandle -> StorableMonad UtxoHandle [StorableEvent UtxoHandle]
-  getStoredEvents (UtxoHandle c sz) =  do
+  getStoredEvents (UtxoHandle c sz _) = do
     sns <- SQL.query c
-        [r|SELECT slotNo FROM unspent_transactions
-           GROUP BY slotNo
-           ORDER BY slotNo DESC
+        [r|SELECT
+              slotNo
+           FROM
+              unspent_transactions
+           GROUP BY
+              slotNo
+           ORDER BY
+              slotNo DESC
            LIMIT ?|] (SQL.Only sz) :: IO [[Integer]]
 
     -- Take the slot number of the sz'th slot
@@ -325,54 +394,91 @@ instance Buffered UtxoHandle where
                 else head . last $ take sz sns
 
     rows :: [UtxoRow] <- SQL.query c
-        [r|SELECT address, txId, txIx , datum , datumHash
-                  , value, inlineScript, inlineScriptHash
-                  , slotNo, blockHash
-           FROM unspent_transactions
-           WHERE slotNo >= ?
-           GROUP by slotNo
-           ORDER BY slotNo ASC|] (SQL.Only (sn :: Integer))
+        [r|SELECT
+              u.address,
+              u.txId,
+              u.txIx,
+              u.datum,
+              u.datumHash,
+              u.value,
+              u.inlineScript,
+              u.inlineScriptHash,
+              u.slotNo,
+              u.blockHash
+           FROM
+              unspent_transactions u
+           WHERE
+              u.slotNo >= ?
+           GROUP by
+              u.slotNo
+           ORDER BY
+              u.slotNo ASC|] (SQL.Only (sn :: Integer))
 
     rowsToEvents (getTxIns c) rows
 
-getTxIns :: SQL.Connection -> C.ChainPoint -> IO (Set C.TxIn)
-getTxIns _ C.ChainPointAtGenesis = pure Set.empty
-getTxIns c (C.ChainPoint slotNo blockHash) = do
-  let bh = C.serialiseToRawBytes blockHash
-  ins :: [(C.TxId, C.TxIx)] <- SQL.query c
-    "SELECT txInTxId, txInTxIx FROM spent WHERE blockHash=? and slotNo=?" (bh, slotNo)
-  pure . Set.fromList . fmap (uncurry C.TxIn) $ ins
+-- | Retrieve TxIns at a slotNo
+-- This function is used to reconstruct the original UtxoEvent
+getTxIns :: SQL.Connection -> C.SlotNo -> IO (Set C.TxIn)
+getTxIns c sn = SQL.query c
+    "SELECT txInTxId, txInTxIx FROM spent WHERE slotNo =?" (SQL.Only (sn :: C.SlotNo))
+    <&> Set.fromList
 
 -- | Convert UtxoRows to UtxoEvents
 rowsToEvents
-  :: (C.ChainPoint -> IO (Set C.TxIn)) -- ^ Function that knows how to get corresponding TxIn
-  -> [UtxoRow] -- ^ UtxoRows, source
-  -> IO [StorableEvent UtxoHandle] -- ^ UtxoEvents
-rowsToEvents f rows = traverse eventFromRow  rows <&> foldl' g []
+  :: (C.SlotNo -> IO (Set C.TxIn))  -- ^ function to fetch TxIn
+  -> [UtxoRow]                      -- ^ rows to convert back to event
+  -> IO [StorableEvent UtxoHandle]  -- ^ utxo events
+rowsToEvents _ [] = pure []
+rowsToEvents  fetchTxIn rows
+  = traverse reduce eventsMap
+  <&> sortBy (\(UtxoEvent _ _ cp) (UtxoEvent _ _ cp') -> compare cp' cp )
   where
-    g :: [StorableEvent UtxoHandle] -> StorableEvent UtxoHandle -> [StorableEvent UtxoHandle]
-    g es e = case findIndex' e es of
-      Just n  ->
-        take n es <> [es !! n <> e] <> drop (n+1) es
-      Nothing -> e : es
+    mkEvent :: UtxoRow -> StorableEvent UtxoHandle
+    mkEvent row = UtxoEvent
+       (Set.singleton $ row ^. urUtxo)
+       Set.empty
+       (C.ChainPoint (row ^. urSlotNo) (row ^. urBlockHash))
 
-    findIndex' :: StorableEvent UtxoHandle -> [StorableEvent UtxoHandle] -> Maybe Int
-    findIndex' x xs = elemIndex (ueChainPoint x) (ueChainPoint <$> xs)
+    newEventWithSpentOnly :: Set C.TxIn -> C.ChainPoint -> StorableEvent UtxoHandle
+    newEventWithSpentOnly = UtxoEvent Set.empty
 
-    eventFromRow :: UtxoRow -> IO (StorableEvent UtxoHandle)
-    eventFromRow utxoRow = do
-      ins <- f (C.ChainPoint (utxoRow ^. urSlotNo) (utxoRow ^. urBlockHash) )
-      pure $ UtxoEvent
-        { ueUtxos  = Set.singleton (utxoRow ^. urUtxo)
-        , ueInputs = ins
-        , ueChainPoint = C.ChainPoint (utxoRow ^. urSlotNo) (utxoRow ^. urBlockHash)
-        }
+    reduce :: (C.ChainPoint, [StorableEvent UtxoHandle]) -> IO (StorableEvent UtxoHandle)
+    reduce ( C.ChainPointAtGenesis, _) = pure $ UtxoEvent Set.empty Set.empty C.ChainPointAtGenesis
+    reduce (cp@(C.ChainPoint sn _), es) = do
+                     tins <- fetchTxIn sn
+                     let newE = newEventWithSpentOnly tins cp
+                     pure. fold $ newE:es
 
--- | Convert 'UtxoEvent's to 'UtxoRow's.
-eventsToRows :: StorableEvent UtxoHandle -> [UtxoRow]
-eventsToRows (UtxoEvent utxos _ (C.ChainPoint slotno hsh)) =
-  fmap (\u -> UtxoRow u slotno hsh) . Set.toList $ utxos
-eventsToRows (UtxoEvent _ _ C.ChainPointAtGenesis) = []
+    eventsMap :: [(C.ChainPoint, [StorableEvent UtxoHandle])]
+    eventsMap
+            = fmap  (\x -> (ueChainPoint . head $ x, x) )
+            . groupBy (\el er -> ueChainPoint el == ueChainPoint er)
+            . fmap mkEvent
+            $ rows
+
+-- | merge in-memory events with SQL retreived UtxoRows
+-- Notes, a peroperty of this merge is to remove all spent utxos from the resulting [UtxoRow]
+mergeInMemoryAndSql
+  :: Foldable f
+  => f (StorableEvent UtxoHandle)
+  -> [UtxoRow]
+  -> [UtxoRow]
+mergeInMemoryAndSql events = filter (\u -> C.TxIn (u ^. urUtxo . txId)(u ^. urUtxo . txIx) `notElem` txins)
+  where
+    txins :: Set C.TxIn
+    txins = foldl' (\a c -> ueInputs c `Set.union` a) Set.empty events
+
+-- | convert utxoEvent to utxoRow
+-- Note: No `unspent` computeation is performed
+eventToRows :: StorableEvent UtxoHandle -> [UtxoRow]
+eventToRows (UtxoEvent _ _ C.ChainPointAtGenesis) = []  -- we dont save anyting at genesis.  TODO verify
+eventToRows (UtxoEvent utxos _ (C.ChainPoint sn bhsh)) =
+  fmap (\u -> UtxoRow
+           { _urUtxo = u
+           , _urSlotNo = sn
+           , _urBlockHash = bhsh
+           }
+       ) . Set.toList $ utxos
 
 -- | Filter for events at the given address
 eventsAtAddress
@@ -396,7 +502,7 @@ addressFilteredRows
   => StorableQuery UtxoHandle       -- ^ query
   -> f (StorableEvent UtxoHandle)   -- ^ Utxo Event
   -> [UtxoRow]                      -- ^ Rows at the query
-addressFilteredRows addr = concatMap eventsToRows . eventsAtAddress addr . toList
+addressFilteredRows addr = concatMap eventToRows . eventsAtAddress addr . toList
 
 -- | Query the data stored in the indexer
 -- Quries SQL + buffered data, where buffered data is the data that will be batched to SQL
@@ -407,66 +513,75 @@ instance Queryable UtxoHandle where
     -> f (StorableEvent UtxoHandle)
     -> UtxoHandle
     -> StorableQuery UtxoHandle
-    -> StorableMonad UtxoHandle (StorableResult UtxoHandle)
-  queryStorage qi es (UtxoHandle c _) q@(UtxoAddress addr) = do
-    persisted <- case qi of
+    -> IO (StorableResult UtxoHandle)
+  queryStorage qi es (UtxoHandle c _ _) q@(UtxoAddress addr) = do
+    fromSQL :: [UtxoRow] <- case qi of -- get the unspent transaction from DB
       QEverything -> SQL.query c
-          [r|SELECT u.address, u.txId, u.txIx, u.datum, u.datumHash
-                  , u.value, u.inlineScript, u.inlineScriptHash
-                  , u.slotNo, u.blockHash
-             FROM unspent_transactions u
-             LEFT JOIN spent s
-             ON u.txId = s.txInTxId
-                AND u.txId IS NOT NULL
-                AND u.txIx = s.txInTxIx
-             WHERE u.address = ?
-             ORDER BY u.slotNo ASC|] (Only (C.serialiseToRawBytes addr))
-      QInterval _ (C.ChainPoint sn _) -> SQL.query c
-          [r|SELECT u.address, u.txId, u.txIx , u.datum , u.datumHash
-                  , u.value, u.inlineScript, u.inlineScriptHash
-                  , u.slotNo, u.blockHash
-             FROM unspent_transactions u
-             LEFT JOIN spent s ON
-                    u.txId = s.txInTxId
-                AND u.txIx = s.txInTxIx
+          [r|SELECT
+                u.address,
+                u.txId,
+                u.txIx,
+                u.datum,
+                u.datumHash,
+                u.value,
+                u.inlineScript,
+                u.inlineScriptHash,
+                u.slotNo,
+                u.blockHash
+             FROM
+                unspent_transactions u
+                LEFT JOIN spent s ON u.txId = s.txId
+                AND u.txIx = s.txIx
              WHERE
-                    u.slotNo <= ?
-                AND u.txId IS NOT NULL
-                AND u.address = ?
-             ORDER BY u.slotNo ASC|] (sn, C.serialiseToRawBytes addr)
+                u.address = ?
+                AND s.txId IS NULL
+                AND s.txIx IS NULL
+             ORDER BY
+                u.slotNo ASC|] (Only (C.serialiseToRawBytes addr))
+      QInterval _ (C.ChainPoint sn _) -> SQL.query c
+          [r|SELECT
+                u.address,
+                u.txId,
+                u.txIx,
+                u.datum,
+                u.datumHash,
+                u.value,
+                u.inlineScript,
+                u.inlineScriptHash,
+                u.slotNo,
+                u.blockHash
+             FROM
+                unspent_transactions u
+             LEFT JOIN spent s ON u.txId = s.txId
+             AND u.txIx = s.txIx
+             WHERE
+                u.slotNo <= ?
+                AND  u.address = ?
+                AND s.txId IS NOT NULL
+                AND s.txIx IS NOT NULL
+             ORDER BY
+                u.slotNo ASC|] (sn, C.serialiseToRawBytes addr)
       QInterval _ C.ChainPointAtGenesis -> pure []
+    let eventAtQuery :: StorableEvent UtxoHandle = queryBuffer qi q es -- query in-memory and conver to row
+    pure
+      $ UtxoResult
+      $ mergeInMemoryAndSql
+          es
+          (fromSQL <> eventToRows eventAtQuery)
 
-    es' <- queryBuffer qi es q (getTxIns c)
-    let rows = concatMap eventsToRows es'
-    pure . UtxoResult $ persisted <> rows
-
--- | Query the in incomming UtxoEvent
+-- | Query memory buffer
 queryBuffer
   :: Foldable f
   => QueryInterval C.ChainPoint
-  -> f (StorableEvent UtxoHandle)         -- ^ Utxo events
   -> StorableQuery UtxoHandle             -- ^ Query
-  -> (C.ChainPoint -> IO (Set C.TxIn))    -- ^ Function that know how to get TxIns fron ChainPoint
-  -> IO [StorableEvent UtxoHandle]
-queryBuffer qi es q f
-  = filterSpent                   -- filter out the utxo that have had Spent
-  . filterWithQueryInterval qi    -- filter for the given slot interval
-  . eventsAtAddress q             -- query for the given address
-  $ es
-  where
-    filterSpent :: [StorableEvent UtxoHandle] -> IO [StorableEvent UtxoHandle]
-    filterSpent = traverse unspentEvents
-
-    unspentEvents :: StorableEvent UtxoHandle -> IO (StorableEvent UtxoHandle)
-    unspentEvents e = do
-      (txIns :: Set C.TxIn) <- f (ueChainPoint e)
-      let utxos = Set.filter (\(Utxo _ id' ix _ _ _ _ _) ->
-                                notElem (C.TxIn id' ix) txIns) . ueUtxos $ e
-      pure e {ueUtxos = utxos}
+  -> f (StorableEvent UtxoHandle)         -- ^ Utxo events
+  -> StorableEvent UtxoHandle
+queryBuffer QEverything q      = fold . eventsAtAddress q
+queryBuffer (QInterval _ cp) q = fold . filter (eventIsBefore cp) . eventsAtAddress q
 
 instance Rewindable UtxoHandle where
   rewindStorage :: C.ChainPoint -> UtxoHandle -> IO (Maybe UtxoHandle)
-  rewindStorage (C.ChainPoint sn _) h@(UtxoHandle c _) = do
+  rewindStorage (C.ChainPoint sn _) h@(UtxoHandle c _ _) = do
     SQL.execute c "DELETE FROM unspent_transactions WHERE slotNo > ?" (SQL.Only sn)
     SQL.execute c "DELETE FROM spent WHERE slotNo > ?" (SQL.Only sn)
     pure $ Just h
@@ -474,7 +589,7 @@ instance Rewindable UtxoHandle where
 
 -- For resuming we need to provide a list of points where we can resume from.
 instance Resumable UtxoHandle where
-  resumeFromStorage (UtxoHandle c _) = do
+  resumeFromStorage (UtxoHandle c _ _) = do
     chainPoints <- fmap (uncurry C.ChainPoint) <$>
             SQL.query c
                 [r|SELECT slotNo, blockHash
@@ -490,49 +605,89 @@ toAddr :: C.AddressInEra era -> C.AddressAny
 toAddr (C.AddressInEra C.ByronAddressInAnyEra addr)    = C.AddressByron addr
 toAddr (C.AddressInEra (C.ShelleyAddressInEra _) addr) = C.AddressShelley addr
 
--- | Extract Utxos payload from Cardano Transaction
--- Note, these Utxos will be decorated with additional data points to make a UtxoEvent
-getUtxos :: (C.IsCardanoEra era) => Maybe TargetAddresses -> C.Tx era -> [Utxo]
+-- | Extract UtxoEvents from Cardano Block
+getUtxoEventsFromBlock
+  :: C.IsCardanoEra era
+  => Maybe TargetAddresses    -- ^ target addresses to filter for
+  -> C.Block era
+  -> StorableEvent UtxoHandle -- ^ UtxoEvents are stored in storage after conversion to UtxoRow
+getUtxoEventsFromBlock maybeTargetAddresses (C.Block (C.BlockHeader slotNo hsh _) txs) =
+  getUtxoEvents maybeTargetAddresses txs (C.ChainPoint slotNo hsh)
+
+-- | Extract UtxoEvents from Cardano Transactions
+getUtxoEvents
+  :: C.IsCardanoEra era
+  => Maybe TargetAddresses    -- ^ target addresses to filter for
+  -> [C.Tx era]
+  -> C.ChainPoint
+  -> StorableEvent UtxoHandle -- ^ UtxoEvents are stored in storage after conversion to UtxoRow
+getUtxoEvents maybeTargetAddresses txs cp =
+  let utxoMap :: Map C.TxIn Utxo
+      utxoMap = foldMap (getUtxos maybeTargetAddresses) txs
+      (TxOutBalance utxos spentTxOuts) = foldMap txOutBalanceFromTx txs
+      resolvedUtxos :: Set Utxo
+      resolvedUtxos
+        = Set.fromList
+        $ mapMaybe (`Data.Map.lookup` utxoMap)
+        $ Set.toList utxos
+  in
+    UtxoEvent resolvedUtxos spentTxOuts cp
+
+-- | does the transaction contain a targetAddress
+isAddressInTarget :: Maybe TargetAddresses -> C.AddressAny -> Bool
+isAddressInTarget Nothing _ = True -- all addresses are target addresses
+isAddressInTarget (Just targetAddresses) addr =
+    case addr  of
+      C.AddressByron _       -> False
+      C.AddressShelley addr' -> addr' `elem` targetAddresses
+
+getUtxos :: (C.IsCardanoEra era) => Maybe TargetAddresses -> C.Tx era -> Map C.TxIn Utxo
 getUtxos maybeTargetAddresses (C.Tx txBody@(C.TxBody C.TxBodyContent {C.txOuts}) _) =
-  either (const []) addressDiscriminator (getUtxos' txOuts)
+  fromRight Data.Map.empty (getUtxos' txOuts)
   where
-    addressDiscriminator :: [Utxo] -> [Utxo]
-    addressDiscriminator = case maybeTargetAddresses of
-      Just targetAddresses -> filter (isAddressInTarget targetAddresses)
-      Nothing              -> id
+    getUtxos' :: C.IsCardanoEra era => [C.TxOut C.CtxTx era] -> Either C.EraCastError (Map C.TxIn Utxo)
+    getUtxos'
+      = fmap (Data.Map.fromList . concatMap Data.Map.toList . imap txoutToUtxo)
+      . traverse (C.eraCast CurrentEra)
 
-    getUtxos' :: C.IsCardanoEra era => [C.TxOut C.CtxTx era] -> Either C.EraCastError [Utxo]
-    getUtxos' = fmap (imap txoutToUtxo) . traverse (C.eraCast CurrentEra)
-
-    txoutToUtxo :: Int -> TxOut -> Utxo
-    txoutToUtxo ix out = Utxo {..}
+    txoutToUtxo :: Int -> TxOut -> Map C.TxIn Utxo
+    txoutToUtxo ix (C.TxOut addr value' datum' refScript) =
+      if isAddressInTarget maybeTargetAddresses addrAny then
+        Data.Map.singleton txin Utxo
+        { _txId = txid
+        , _txIx = txix
+        , _address = addrAny
+        , _value = C.txOutValueToValue value'
+        , _datum = __datum
+        , _datumHash = __datumHash
+        , _inlineScript = __inlineScript
+        , _inlineScriptHash = __inlineScriptHash
+        }
+      else
+        Data.Map.empty
       where
-        _txIx = C.TxIx $ fromIntegral ix
-        _txId = C.getTxId txBody
-        C.TxOut address' value' datum' refScript = out
-        _address = toAddr address'
-        _value = C.txOutValueToValue value'
-        (_datum, _datumHash) = getScriptDataAndHash datum'
-        (_inlineScript, _inlineScriptHash) =
-            getRefScriptAndHash refScript
+        addrAny = toAddr addr
+        (__datum, __datumHash) = getScriptDataAndHash datum'
+        (__inlineScript, __inlineScriptHash) = getRefScriptAndHash refScript
+        txin@(C.TxIn txid txix) = C.TxIn (C.getTxId txBody)(C.TxIx $ fromIntegral ix)
 
 -- | get the inlineScript and inlineScriptHash
 --
 getRefScriptAndHash
-  :: Shelley.ReferenceScript era
-  -> (Maybe Shelley.ScriptInAnyLang, Maybe C.ScriptHash)
+  :: C.ReferenceScript era
+  -> (Maybe C.ScriptInAnyLang, Maybe C.ScriptHash)
 getRefScriptAndHash refScript = case refScript of
-  Shelley.ReferenceScriptNone -> (Nothing, Nothing)
-  Shelley.ReferenceScript _ s@(Shelley.ScriptInAnyLang(C.SimpleScriptLanguage C.SimpleScriptV1) script) ->
+  C.ReferenceScriptNone -> (Nothing, Nothing)
+  C.ReferenceScript _ s@(C.ScriptInAnyLang(C.SimpleScriptLanguage C.SimpleScriptV1) script) ->
       ( Just  s
       , Just . C.hashScript $ script)
-  Shelley.ReferenceScript _ s@(Shelley.ScriptInAnyLang (C.SimpleScriptLanguage C.SimpleScriptV2) script)->
+  C.ReferenceScript _ s@(C.ScriptInAnyLang (C.SimpleScriptLanguage C.SimpleScriptV2) script)->
     ( Just s
     , Just . C.hashScript $ script)
-  Shelley.ReferenceScript _ s@(Shelley.ScriptInAnyLang (C.PlutusScriptLanguage C.PlutusScriptV1) script)->
+  C.ReferenceScript _ s@(C.ScriptInAnyLang (C.PlutusScriptLanguage C.PlutusScriptV1) script)->
     ( Just s
     , Just . C.hashScript $ script)
-  Shelley.ReferenceScript _ s@(Shelley.ScriptInAnyLang (C.PlutusScriptLanguage C.PlutusScriptV2) script)->
+  C.ReferenceScript _ s@(C.ScriptInAnyLang (C.PlutusScriptLanguage C.PlutusScriptV2) script)->
     ( Just s
     , Just . C.hashScript $ script)
 
@@ -551,20 +706,7 @@ rmSpent txins = filter (not . isUtxoSpent txins)
   where
     isUtxoSpent :: Set C.TxIn -> Utxo -> Bool
     isUtxoSpent txIns u =
-        C.TxIn (u ^. txId) (u ^. txIx) `Set.member` txIns
-
--- | Extract UtxoEvents from Cardano Transactions
-getUtxoEvents
-  :: C.IsCardanoEra era
-  => Maybe TargetAddresses -- ^ target addresses to filter for
-  -> [C.Tx era]
-  -> C.ChainPoint
-  -> StorableEvent UtxoHandle -- ^ UtxoEvents are stored in storage after conversion to UtxoRow
-getUtxoEvents maybeTargetAddresses txs cp =
-  let
-    utxos = Set.fromList $ concatMap (getUtxos maybeTargetAddresses) txs
-    ins = foldl' Set.union Set.empty $ getInputs <$> txs
-  in UtxoEvent utxos ins cp
+        C.TxIn (u ^. txId)(u ^. txIx) `Set.member` txIns
 
 getInputs :: C.Tx era -> Set C.TxIn
 getInputs (C.Tx (C.TxBody C.TxBodyContent
@@ -589,11 +731,48 @@ txScriptValidityToScriptValidity C.TxScriptValidityNone                = C.Scrip
 txScriptValidityToScriptValidity (C.TxScriptValidity _ scriptValidity) = scriptValidity
 
 -- | does the transaction contain a targetAddress
-isAddressInTarget :: TargetAddresses -> Utxo -> Bool
-isAddressInTarget targetAddresses utxo =
+isAddressInTarget' :: TargetAddresses -> Utxo -> Bool
+isAddressInTarget' targetAddresses utxo =
     case utxo ^. address  of
       C.AddressByron _       -> False
       C.AddressShelley addr' -> addr' `elem` targetAddresses
 
 mkQueryableAddresses :: TargetAddresses -> QueryableAddresses
 mkQueryableAddresses = fmap (UtxoAddress . C.toAddressAny)
+
+txOutBalanceFromTxs :: [C.Tx era] -> TxOutBalance
+txOutBalanceFromTxs = foldMap txOutBalanceFromTx
+
+txOutBalanceFromTx :: C.Tx era -> TxOutBalance
+txOutBalanceFromTx (C.Tx txBody@(C.TxBody txBodyContent) _) =
+    let
+        txInputs = Set.fromList $ fst <$> C.txIns txBodyContent
+        utxoRefs = Set.fromList
+                 $ fmap (\(txix, _) -> C.TxIn (C.getTxId txBody) (C.TxIx txix))
+                 $ zip [0..]
+                 $ C.txOuts txBodyContent
+     in TxOutBalance utxoRefs txInputs
+
+convertTxOutToUtxo :: C.TxId -> C.TxIx -> C.TxOut C.CtxTx C.BabbageEra -> Utxo
+convertTxOutToUtxo txid txix (C.TxOut (C.AddressInEra _ addr) val txOutDatum refScript) =
+    let (scriptDataHash, scriptData) =
+            case txOutDatum of
+              C.TxOutDatumNone       -> (Nothing, Nothing)
+              C.TxOutDatumHash _ dh  -> (Just dh, Nothing)
+              C.TxOutDatumInTx _ d   -> (Just $ C.hashScriptData d, Just d)
+              C.TxOutDatumInline _ d -> (Just $ C.hashScriptData d, Just d)
+        (scriptHash, script) =
+            case refScript of
+              C.ReferenceScriptNone -> (Nothing, Nothing)
+              C.ReferenceScript _ scriptInAnyLang@(C.ScriptInAnyLang _ s) ->
+                  (Just $ C.hashScript s, Just scriptInAnyLang)
+     in Utxo
+            { _address = C.toAddressAny addr
+            , _txId = txid
+            , _txIx = txix
+            , _datum = scriptData
+            , _datumHash = scriptDataHash
+            , _value = C.txOutValueToValue val
+            , _inlineScript = script
+            , _inlineScriptHash = scriptHash
+            }

--- a/marconi-chain-index/src/Marconi/ChainIndex/Orphans.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Orphans.hs
@@ -137,13 +137,6 @@ mapLeft _ (Right v) = Right v
 instance ToJSON C.ScriptData where
     toJSON v = Aeson.String $ Text.decodeLatin1 $ Base16.encode $ C.serialiseToCBOR v
 
-instance SQL.FromRow C.ChainPoint where
-  fromRow = C.ChainPoint <$> SQL.field <*> SQL.field
-
-instance SQL.ToRow C.ChainPoint where
-  toRow (C.ChainPoint sn bh)  = SQL.toRow (sn, bh)
-  toRow C.ChainPointAtGenesis = []
-
 instance SQL.FromRow Int where
   fromRow = SQL.field
 

--- a/marconi-chain-index/src/Marconi/ChainIndex/Orphans.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Orphans.hs
@@ -137,6 +137,16 @@ mapLeft _ (Right v) = Right v
 instance ToJSON C.ScriptData where
     toJSON v = Aeson.String $ Text.decodeLatin1 $ Base16.encode $ C.serialiseToCBOR v
 
+instance SQL.FromRow C.ChainPoint where
+  fromRow = C.ChainPoint <$> SQL.field <*> SQL.field
+
+instance SQL.ToRow C.ChainPoint where
+  toRow (C.ChainPoint sn bh)  = SQL.toRow (sn, bh)
+  toRow C.ChainPointAtGenesis = []
+
+instance SQL.FromRow Int where
+  fromRow = SQL.field
+
 -- * C.TxIn
 
 instance SQL.ToRow C.TxIn where

--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -1,29 +1,23 @@
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE RecordWildCards    #-}
 
 module Gen.Marconi.ChainIndex.Indexers.Utxo
     ( genUtxoEvents
     , genShelleyEraUtxoEvents
     , genUtxoEventsWithTxs
-    , genEventWithShelleyAddressAtChainPoint
     )
 where
 
 import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C
 import Control.Monad (forM)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (mapMaybe)
-import Data.Set (Set)
 import Data.Set qualified as Set
-import GHC.Generics (Generic)
 import Gen.Cardano.Api.Typed qualified as CGen
 import Gen.Marconi.ChainIndex.Mockchain (BlockHeader (BlockHeader), MockBlock (MockBlock), genMockchain)
 import Hedgehog (Gen)
-import Hedgehog.Gen qualified as Gen
-import Hedgehog.Range qualified as Range
-import Marconi.ChainIndex.Indexers.Utxo (StorableEvent (UtxoEvent), Utxo (Utxo), UtxoHandle, _address)
+import Marconi.ChainIndex.Indexers.Utxo (StorableEvent (UtxoEvent), TxOutBalance (TxOutBalance), Utxo, UtxoHandle,
+                                         _address, convertTxOutToUtxo, txOutBalanceFromTx)
 import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 
 -- | Generates a list of UTXO events.
@@ -74,91 +68,22 @@ genUtxoEventsWithTxs' txOutToUtxo = do
                 $ zip [0..]
                 $ C.txOuts txBodyContent
 
--- | The effect of a transaction (or a number of them) on the tx output set.
-data TxOutBalance =
-  TxOutBalance
-    { _tobUnspent :: !(Set C.TxIn)
-    -- ^ Outputs newly added by the transaction(s)
-    , _tobSpent   :: !(Set C.TxIn)
-    -- ^ Outputs spent by the transaction(s)
-    }
-    deriving stock (Eq, Show, Generic)
-
-instance Semigroup TxOutBalance where
-    tobL <> tobR =
-        TxOutBalance
-            { _tobUnspent = _tobUnspent tobR
-                         <> (_tobUnspent tobL `Set.difference` _tobSpent tobR)
-            , _tobSpent = _tobSpent tobL <> _tobSpent tobR
-            }
-
-instance Monoid TxOutBalance where
-    mappend = (<>)
-    mempty = TxOutBalance mempty mempty
-
-txOutBalanceFromTx :: C.Tx era -> TxOutBalance
-txOutBalanceFromTx (C.Tx txBody@(C.TxBody txBodyContent) _) =
-    let txId = C.getTxId txBody
-        txInputs = Set.fromList $ fst <$> C.txIns txBodyContent
-        utxoRefs = Set.fromList
-                 $ fmap (\(txIx, _) -> C.TxIn txId $ C.TxIx txIx)
-                 $ zip [0..]
-                 $ C.txOuts txBodyContent
-     in TxOutBalance utxoRefs txInputs
-
-convertTxOutToUtxo :: C.TxId -> C.TxIx -> C.TxOut C.CtxTx C.BabbageEra -> Utxo
-convertTxOutToUtxo txId txIx (C.TxOut (C.AddressInEra _ addr) val txOutDatum refScript) =
-    let (scriptDataHash, scriptData) =
-            case txOutDatum of
-              C.TxOutDatumNone       -> (Nothing, Nothing)
-              C.TxOutDatumHash _ dh  -> (Just dh, Nothing)
-              C.TxOutDatumInTx _ d   -> (Just $ C.hashScriptData d, Just d)
-              C.TxOutDatumInline _ d -> (Just $ C.hashScriptData d, Just d)
-        (scriptHash, script) =
-            case refScript of
-              C.ReferenceScriptNone -> (Nothing, Nothing)
-              C.ReferenceScript _ scriptInAnyLang@(C.ScriptInAnyLang _ s) ->
-                  (Just $ C.hashScript s, Just scriptInAnyLang)
-     in Utxo
-            (C.toAddressAny addr)
-            txId
-            txIx
-            scriptData
-            scriptDataHash
-            (C.txOutValueToValue val)
-            script
-            scriptHash
 -- | Override the Utxo address with ShelleyEra address
 -- This is used to generate ShelleyEra Utxo events
 utxoAddressOverride
   :: C.Address C.ShelleyAddr
   -> Utxo
   -> Utxo
-utxoAddressOverride addr utxo =  utxo {_address=C.toAddressAny addr}
+utxoAddressOverride addr utxo = utxo { _address = C.toAddressAny addr }
 
 -- | Generate ShelleyEra Utxo Events
-genShelleyEraUtxoEvents :: Gen [StorableEvent UtxoHandle]
+genShelleyEraUtxoEvents :: Gen [StorableEvent Utxo.UtxoHandle]
 genShelleyEraUtxoEvents = do
-  addr <- CGen.genAddressShelley
-  genUtxoEvents' (\_id _ix _tx ->
-                    utxoAddressOverride addr $ convertTxOutToUtxo _id _ix _tx)
-
--- TODO Must be reworked following implementation in 'genUtxoEvents'.
-genEventWithShelleyAddressAtChainPoint :: C.ChainPoint -> Gen (Utxo.StorableEvent Utxo.UtxoHandle)
-genEventWithShelleyAddressAtChainPoint ueChainPoint = do
-  txOutRefs <- Gen.list (Range.linear 1 5) CGen.genTxIn
-  ueUtxos <- Set.fromList <$> forM txOutRefs genUtxo
-  ueInputs <- Gen.set (Range.linear 1 5) CGen.genTxIn
-  pure $ Utxo.UtxoEvent {..}
-
-genUtxo :: C.TxIn -> Gen Utxo.Utxo
-genUtxo txOutRef = CGen.genAddressShelley >>= genUtxo' txOutRef . C.toAddressAny
-
-genUtxo' :: C.TxIn -> C.AddressAny -> Gen Utxo.Utxo
-genUtxo' (C.TxIn _txId _txIx) _address = do
-  sc <- CGen.genTxOutDatumHashTxContext C.BabbageEra
-  let (_datum, _datumHash)  = Utxo.getScriptDataAndHash sc
-  script            <- CGen.genReferenceScript C.ShelleyEra
-  _value            <- CGen.genValueForTxOut
-  let (_inlineScript, _inlineScriptHash)=  Utxo.getRefScriptAndHash script
-  pure $ Utxo.Utxo {..}
+  events <- genUtxoEvents
+  forM events (\e -> do
+                  let utxos = Utxo.ueUtxos e
+                  us <- forM (Set.toList utxos) (\u -> do
+                                 a <- CGen.genAddressShelley
+                                 pure $ utxoAddressOverride a u)
+                  pure e {Utxo.ueUtxos=Set.fromList us}
+              )

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
@@ -3,45 +3,55 @@
 
 module Spec.Marconi.ChainIndex.Indexers.Utxo.UtxoIndex (tests) where
 
-import Cardano.Api qualified as C
-import Control.Lens (filtered, folded, toListOf)
+import Control.Lens (each, filtered, folded, toListOf)
+import Control.Lens.Operators ((%~), (&), (^.))
 import Control.Monad (forM, forM_, void)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson qualified as Aeson
+import Data.Functor ((<&>))
 import Data.List qualified as List
 import Data.List.NonEmpty (nonEmpty)
-import Data.Maybe (isJust, isNothing, mapMaybe)
+import Data.Map (Map)
+import Data.Map qualified
+import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
-import Gen.Marconi.ChainIndex.Indexers.Utxo (genEventWithShelleyAddressAtChainPoint, genShelleyEraUtxoEvents,
-                                             genUtxoEvents)
+
+import Cardano.Api qualified as C
+import Gen.Marconi.ChainIndex.Indexers.Utxo (genShelleyEraUtxoEvents, genUtxoEvents)
 import Gen.Marconi.ChainIndex.Indexers.Utxo qualified as UtxoGen
-import Gen.Marconi.ChainIndex.Mockchain (mockBlockTxs)
+import Gen.Marconi.ChainIndex.Mockchain (MockBlock (mockBlockChainPoint, mockBlockTxs))
 import Gen.Marconi.ChainIndex.Types (genChainPoints)
-import Hedgehog (Property, cover, forAll, property, (===))
-import Hedgehog qualified
-import Hedgehog.Gen qualified as Gen
-import Hedgehog.Range qualified as Range
 import Helpers (addressAnyToShelley)
 import Marconi.ChainIndex.Indexers.Utxo (StorableEvent (ueInputs, ueUtxos))
 import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 import Marconi.ChainIndex.Types (TargetAddresses)
 import Marconi.Core.Storable (StorableQuery)
 import Marconi.Core.Storable qualified as Storable
+
+import Hedgehog (Gen, Property, cover, forAll, property, (===))
+import Hedgehog qualified
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 
 tests :: TestTree
 tests = testGroup "Spec.Marconi.ChainIndex.Indexers.Utxo"
-    [ testPropertyNamed
-        "filter UtxoEvent for Utxos with address in the TargetAddress"
-        "eventsAtAddressTest"
-        eventsAtAddressTest
+      [ testPropertyNamed
+        "marconi-chain-index-utxo regression-test, store and retrieve UtxoEvents by address, then test that there are no `Spent` in the retrieved Utxo(s)"
+        "allqueryUtxosShouldBeUnspent"
+        allqueryUtxosShouldBeUnspent
+
+      , testPropertyNamed
+        "marconi-chain-index-utxo compute utxos with address in TargetAddresses property"
+        "propComputeEventsAtAddress"
+        propComputeEventsAtAddress
 
     , testPropertyNamed
-        "marconi-utxo event-to-sqlRows property"
-        "eventsToRowsRoundTripTest"
-        eventsToRowsRoundTripTest
+        "marconi-chain-index-utxo roundtrip event-to-sqlRows conversion property"
+        "propRoundTripEventsToRowConversion"
+        propRoundTripEventsToRowConversion
 
     , testPropertyNamed
         "getUtxoEvents with target addresses corresponding to all addresses in generated txs should return the same 'UtxoEvent' as if no target addresses were provided"
@@ -49,20 +59,19 @@ tests = testGroup "Spec.Marconi.ChainIndex.Indexers.Utxo"
         propUsingAllAddressesOfTxsAsTargetAddressesShouldReturnUtxosAsIfNoFilterWasApplied
 
     , testPropertyNamed
-        "marconi-utxo storage-roundtrip property"
-        "utxoStorageTest"
-        utxoStorageTest
-
-    -- TODO BROKEN
-    -- , testPropertyNamed
-    --     "marconi-utxo insert-query property"
-    --     "utxoInsertAndQueryTest"
-    --     utxoInsertAndQueryTest
+        "marconi-chain-index-utxo in-memory store save/retrieve of events property"
+        "propSaveToAndRetrieveFromUtxoInMemoryStore"
+        propSaveToAndRetrieveFromUtxoInMemoryStore
 
     , testPropertyNamed
-        "marconi-utxo query-interval property"
-        "utxoQueryIntervalTest"
-        utxoQueryIntervalTest
+        "marconi-chain-index-utxo save, and retrieve by address of events from both disk and in-memory storage property"
+        "propSaveAndRetrieveUtxoEvents"
+        propSaveAndRetrieveUtxoEvents
+
+    , testPropertyNamed
+        "marconi-chain-index-utxo insert and retrieve events by address-query and query-interval property"
+        "propUtxoQueryByAddressAndQueryInterval"
+        propUtxoQueryByAddressAndQueryInterval
 
     , testPropertyNamed
           "The points that indexer can be resumed from should return at least non-genesis point when some data was indexed on disk"
@@ -70,7 +79,7 @@ tests = testGroup "Spec.Marconi.ChainIndex.Indexers.Utxo"
           propResumingShouldReturnAtLeastOneNonGenesisPointIfStoredOnDisk
 
     , testPropertyNamed
-          "The points that indexer can be resumed from should return an ordered list of points"
+          "marconi-chain-index-utxo resume: The points that indexer can be resumed from should return an ordered list of points"
           "propResumingShouldReturnOrderedListOfPoints"
           propResumingShouldReturnOrderedListOfPoints
 
@@ -78,67 +87,153 @@ tests = testGroup "Spec.Marconi.ChainIndex.Indexers.Utxo"
           "ToJSON/FromJSON roundtrip for UtxoRow"
           "propJsonRoundtripUtxoRow"
           propJsonRoundtripUtxoRow
+
+    , testPropertyNamed
+          "marconi-chain-index-utxo getUtxoEvent should get the same event from the Block as the event generator"
+          "propGetUtxoEventFromBlock"
+          propGetUtxoEventFromBlock
+
     ]
 
-eventsToRowsRoundTripTest :: Property
-eventsToRowsRoundTripTest  = property $ do
+-- | The purpose of test is to make sure All Queried Utxo's are unSpent.
+--  The Utxo store consists of:
+--  * in-memory store:  UtxoEvents before they're flushed to SQlite
+--  * SQL-database store:  UtxoRows that are stored in SQLite
+--  In this test, We want to make sure:
+--    (1) all utxo query results from SQL-database store are unspent
+--    (2) all utxos query results from in-memory store are unspent
+--    (3) the edge case where although we satisfy (1) and (2),
+--        one or many of the query results from SQLite store may have `Spent` in the in-memory store.
+--    (4) furthermore, we want to prove that there is always at least one utxoRow returned from sotre.
+--  Point (4) is a consequence of the `genShelleyEraUtxoEvents` specifications:  __there is only Spent for previous generated UtxoEvent__
+-- Assumption:  SQLite vacuum is disabled, so that we can accouhnt for generated Spents
+-- Note:        We expect this test to fail in this branch.
+allqueryUtxosShouldBeUnspent :: Property
+allqueryUtxosShouldBeUnspent = property $ do
   events <- forAll genShelleyEraUtxoEvents
-  let f :: C.ChainPoint -> IO (Set C.TxIn)
-      f C.ChainPointAtGenesis
-        = pure  Set.empty
-      f cp'
-        = pure
-        . Set.fromList
-        . concatMap (Set.toList . Utxo.ueInputs)
-        . filter(\(Utxo.UtxoEvent _ _ cp) -> cp == cp')
-        $ events
-      rows = concatMap Utxo.eventsToRows events
+  let numOfEvents = length events
+  -- We choose the `depth` such that we can prove the boundery condtion, see point (3).
+  -- this will ensure we have adequate coverage where events are in both, in-memory store and SQLite store
+  depth <- forAll $ Gen.int (Range.constantFrom (numOfEvents - 1) 1 (numOfEvents + 1))
+  Hedgehog.classify "Query both in-memory and storage " $ depth < numOfEvents
+  Hedgehog.classify "Query in-memory only" $ depth > numOfEvents
+
+  indexer <- liftIO (Utxo.open ":memory:" (Utxo.Depth depth) False >>= Storable.insertMany events )
+  let
+    addressQueries :: [StorableQuery Utxo.UtxoHandle] -- we want to query for all addresses
+    addressQueries
+      = List.nub
+      . fmap (Utxo.UtxoAddress . Utxo._address)
+      . concatMap (Set.toList . Utxo.ueUtxos)
+      $ events
+  results <- liftIO . traverse (Storable.query Storable.QEverything indexer) $ addressQueries
+  let retrievedUtxoRows :: [Utxo.UtxoRow] = concatMap (\(Utxo.UtxoResult rs) -> rs ) results
+      txinsFromRetrievedUtsoRows :: [C.TxIn]  -- get all the TxIn from quried UtxoRows
+        = retrievedUtxoRows & each %~ (\r ->
+                                       C.TxIn (r ^. Utxo.urUtxo . Utxo.txId)(r ^. Utxo.urUtxo . Utxo.txIx))
+      txInsFromGeneratedEvents :: [C.TxIn]    -- get all the TxIn from quried UtxoRows
+        = concatMap (\(Utxo.UtxoEvent _ ins _ ) -> Set.toList ins ) events
+
+  -- A property of the generator is that there is at least one unspent transaction
+  -- this property also ensures that the next test will not succeed for the trivila case
+  -- when retrievedUtxoRows is an empty list
+  Hedgehog.assert (not . null $ retrievedUtxoRows)
+
+-- There should be no `Spent` in the retrieved UtxoRows
+  Hedgehog.footnote "Regression test must return at least one Utxo. Utxo's may not have any Spent in the Orig. event"
+  Hedgehog.assert
+    $ all (== True)
+    [u `notElem` txInsFromGeneratedEvents| u <- txinsFromRetrievedUtsoRows]
+
+-- | Round trip UtxoEvents to UtxoRow conversion
+-- The purpose of this test is to show that there is a isomorphism between `UtxoRow` and UtxoEvent.
+propRoundTripEventsToRowConversion :: Property
+propRoundTripEventsToRowConversion  = property $ do
+  events <- forAll UtxoGen.genUtxoEvents
+  let
+    txInsMap :: Map C.SlotNo (Set C.TxIn)
+    txInsMap
+      = Data.Map.fromList
+      . concatMap g
+      $ events
+    f :: C.SlotNo -> IO (Set C.TxIn)
+    f sn  = pure $ fromMaybe Set.empty (Data.Map.lookup sn txInsMap)
+    g :: StorableEvent Utxo.UtxoHandle -> [(C.SlotNo, Set C.TxIn)]
+    g (Utxo.UtxoEvent _ ins (C.ChainPoint sn _)) = [ (sn, ins)]
+    g _                                          = []
+
+    postGenesisEvents = filter (\e -> C.ChainPointAtGenesis /= Utxo.ueChainPoint e) events
+    rows :: [Utxo.UtxoRow]
+    rows = concatMap Utxo.eventToRows postGenesisEvents
   computedEvent <- liftIO . Utxo.rowsToEvents f $ rows
-  let postGenesisEvents = filter (\e -> C.ChainPointAtGenesis /= Utxo.ueChainPoint e) events
-  length computedEvent === (length . fmap Utxo.ueChainPoint $ postGenesisEvents)
+  Set.fromList computedEvent === Set.fromList postGenesisEvents
   Set.fromList computedEvent === Set.fromList events
 
--- Insert Utxo events in storage, and retreive the events
---
-utxoStorageTest :: Property
-utxoStorageTest = property $ do
+{-|
+  Insert Utxo events in storage, and retreive the events
+  Note:
+  we are intetested in testing the in-memory storage only for this test.
+-}
+propSaveToAndRetrieveFromUtxoInMemoryStore :: Property
+propSaveToAndRetrieveFromUtxoInMemoryStore = property $ do
   events <- forAll UtxoGen.genUtxoEvents
+  let depth = Utxo.Depth (length events + 1)
   (storedEvents :: [StorableEvent Utxo.UtxoHandle]) <-
-    (liftIO . Utxo.open ":memory:") (Utxo.Depth 10)
+    (liftIO $ Utxo.open ":memory:" depth False) -- don't vacuum sqlite
      >>= liftIO . Storable.insertMany events
      >>= liftIO . Storable.getEvents
   Set.fromList storedEvents === Set.fromList events
 
--- Insert Utxo events in storage, and retrieve the events by address
---
--- utxoInsertAndQueryTest :: Property
--- utxoInsertAndQueryTest = property $ do
---   events <- forAll genUtxoEvents
---   depth <- forAll $ Gen.int (Range.linear 1 5)
---   indexer <- liftIO $ Utxo.open ":memory:" (Utxo.Depth depth)
---              >>= liftIO . Storable.insertMany events
---   let
---     qs :: [StorableQuery Utxo.UtxoHandle]
---     qs = fmap (Utxo.UtxoAddress . Utxo._address) . concatMap (Set.toList . Utxo.ueUtxos) $ events
---   results <- liftIO . traverse (Storable.query Storable.QEverything indexer) $ qs
---   let rows = concatMap (\(Utxo.UtxoResult rs) -> rs ) results
---   computedEvent <-
---     liftIO . Utxo.rowsToEvents (Utxo.getTxIns (getConn indexer) ) $ rows
---   Hedgehog.assert (equivalentLists
---                    computedEvent
---                    (filter (\e -> Utxo.ueChainPoint e /= C.ChainPointAtGenesis) events) )
-
--- Insert Utxo events in storage, and retreive the events by address and query interval
---
-utxoQueryIntervalTest :: Property
-utxoQueryIntervalTest = property $ do
-  highSlotNo <- forAll $ Gen.integral $ Range.constantFrom 7 5 20
-  chainPoints :: [C.ChainPoint]  <- forAll $ genChainPoints 2 highSlotNo
-  events::[StorableEvent Utxo.UtxoHandle] <-
-    forAll $ forM chainPoints genEventWithShelleyAddressAtChainPoint -- <&> concat
+{-|
+  Insert Utxo events in storage, and retrieve the events
+  The property we're checking here is:
+    - retreived at least one unspent utxo
+    - only retreive unspent utxo's
+    - test `spent` filtering at the boundry of in-memory & disk storage
+-}
+propSaveAndRetrieveUtxoEvents :: Property
+propSaveAndRetrieveUtxoEvents = property $ do
+  -- events <- forAll genUtxoEvents'' -- TODO
+  events <- forAll genShelleyEraUtxoEvents
   let numOfEvents = length events
   depth <- forAll $ Gen.int (Range.constantFrom (numOfEvents - 1) 1 (numOfEvents + 1))
-  indexer <- liftIO $ Utxo.open ":memory:" (Utxo.Depth depth)
+  indexer <- liftIO $ Utxo.open ":memory:" (Utxo.Depth depth) False
+             >>= liftIO . Storable.insertMany events
+  let
+    qs :: [StorableQuery Utxo.UtxoHandle]
+    qs = List.nub . fmap (Utxo.UtxoAddress . Utxo._address) . concatMap (Set.toList . Utxo.ueUtxos) $ events
+  results <- liftIO . traverse (Storable.query Storable.QEverything indexer) $ qs
+  let rowsFromStorage :: [Utxo.UtxoRow] = concatMap (\(Utxo.UtxoResult rs) -> rs ) results
+      fromStorageTxIns :: [C.TxIn]
+        = rowsFromStorage & each %~ (\r ->
+                                       C.TxIn (r ^. Utxo.urUtxo . Utxo.txId)(r ^. Utxo.urUtxo . Utxo.txIx))
+      fromEventsTxIns :: [C.TxIn]
+        = concatMap (\(Utxo.UtxoEvent _ ins _ ) -> Set.toList ins ) events
+
+  Hedgehog.classify "Query both in-memory and storage " $ depth < numOfEvents
+  Hedgehog.classify "Query in-memory only" $ depth > numOfEvents
+
+  -- A property of the generator is that there is at least one unspent transaction
+  Hedgehog.assert (not . null $ rowsFromStorage)
+-- The result set should only contain `unspent` utxos
+  Hedgehog.assert
+    $ all (== True)
+    [u `notElem` fromEventsTxIns| u <- fromStorageTxIns]
+
+
+-- Insert Utxo events in storage, and retreive the events by address and query interval
+-- Note: The property we are checking is:
+--   - Insert many events with at various chainPoints
+--   - Fetch for all the evenent addresses in the ChainPoint interval [lowChainPoint, highChainPoint]
+--   - There should not be any results with ChainPoint > highChainPoint
+propUtxoQueryByAddressAndQueryInterval :: Property
+propUtxoQueryByAddressAndQueryInterval = property $ do
+  highSlotNo <- forAll $ Gen.integral $ Range.constantFrom 7 5 20
+  chainPoints :: [C.ChainPoint]  <- forAll $ genChainPoints 2 highSlotNo
+  events::[StorableEvent Utxo.UtxoHandle] <- forAll $ forM chainPoints genEventWithShelleyAddressAtChainPoint <&> concat
+  let numOfEvents = length events
+  depth <- forAll $ Gen.int (Range.constantFrom (numOfEvents - 1) 1 (numOfEvents + 1))
+  indexer <- liftIO $ Utxo.open ":memory:" (Utxo.Depth depth) False -- don't vacuum sqlite
              >>= liftIO . Storable.insertMany events
   let _start :: C.ChainPoint = head chainPoints -- the generator will alwys provide a non empty list
       _end :: C.ChainPoint = chainPoints !! (length chainPoints `div` 2)
@@ -155,12 +250,15 @@ utxoQueryIntervalTest = property $ do
         C.ChainPointAtGenesis -> C.SlotNo 0
         C.ChainPoint sn _     -> sn
 
+  Hedgehog.classify "Query both in-memory and storage " $ depth <= numOfEvents
+  Hedgehog.classify "Query in-memory only" $ depth > numOfEvents
+
   last slotNoFromStorage === endIntervalSlotNo
 
 -- TargetAddresses are the addresses in UTXO that we filter for.
 -- Puporse of this test is to filter out utxos that have a different address than those in the TargetAddress list.
-eventsAtAddressTest :: Property
-eventsAtAddressTest = property $ do
+propComputeEventsAtAddress :: Property
+propComputeEventsAtAddress = property $ do
     event <- head <$> forAll UtxoGen.genUtxoEvents
     let (addresses :: [StorableQuery Utxo.UtxoHandle]) =
           map (Utxo.UtxoAddress . Utxo._address) $ Set.toList $ Utxo.ueUtxos event
@@ -238,37 +336,51 @@ propResumingShouldReturnAtLeastOneNonGenesisPointIfStoredOnDisk = property $ do
     depth <- forAll $ Gen.int (Range.linear 1 $ length events - 1)
 
     -- We insert the events in the indexer, but for the test assertions, we discard the events in
-    -- memory.
-    indexer <- liftIO $ Utxo.open ":memory:" (Utxo.Depth depth)
+    indexer <- liftIO $ Utxo.open ":memory:" (Utxo.Depth depth) False -- don't vacuum sqlite
     void $ liftIO $ Storable.insertMany events indexer
 
     actualResumablePoints <- liftIO $ Storable.resume indexer
     -- TODO Given current implementation, we only expect to be able to resume from events which
     -- contain at least one UTXO. In the future, this should be changed to take into account
-    -- 'UtxoEvent's which have no utxos and no inputs
-    -- let expectedResumablePoints =
-    --         ChainPointAtGenesis
-    --         : fmap Utxo.ueChainPoint
-    --             (filter (\UtxoEvent { ueUtxos } -> not (Set.null ueUtxos)) events)
-    -- Set.fromList actualResumablePoints === Set.fromList expectedResumablePoints
     Hedgehog.assert $ length actualResumablePoints >= 2
 
 -- | The property verifies that the 'Storable.resumeFromStorage' returns an ordered list of points.
 propResumingShouldReturnOrderedListOfPoints :: Property
 propResumingShouldReturnOrderedListOfPoints = property $ do
-    events <- forAll UtxoGen.genUtxoEvents
-    depth <- forAll $ Gen.int (Range.linear 1 $ length events)
-
+  events <- forAll UtxoGen.genUtxoEvents
+  let numOfEvents = length events
+  depth <- forAll $ Gen.int (Range.constantFrom (numOfEvents - 1) 1 (numOfEvents + 1))
     -- We insert the events in the indexer, but for the test assertions, we discard the events in
     -- memory.
-    indexer <- liftIO $ Utxo.open ":memory:" (Utxo.Depth depth)
-    void $ liftIO $ Storable.insertMany events indexer
+  indexer <- liftIO $ Utxo.open ":memory:" (Utxo.Depth depth) False -- don't vacuum sqlite
+    >>= Storable.insertMany events
+  resumablePoints <- liftIO $ Storable.resume indexer
 
-    resumablePoints <- liftIO $ Storable.resume indexer
-    List.reverse (List.sort resumablePoints) === resumablePoints
+  Hedgehog.classify "Events on disk and memory" $ depth < numOfEvents
+  Hedgehog.classify "Events are in memory only" $ depth >= numOfEvents
+
+  List.reverse (List.sort resumablePoints) === resumablePoints
 
 propJsonRoundtripUtxoRow :: Property
 propJsonRoundtripUtxoRow = property $ do
     utxoEvents <- forAll genUtxoEvents
-    let utxoRows = concatMap Utxo.eventsToRows utxoEvents
+    let utxoRows = concatMap Utxo.eventToRows utxoEvents
     forM_ utxoRows $ \utxoRow -> Hedgehog.tripping utxoRow Aeson.encode Aeson.decode
+
+-- -- getUtxoEven should compute the same event as the event generator
+-- This test should prove the getUtxoEvent is correctly computing Unspent Transactions
+--
+propGetUtxoEventFromBlock :: Property
+propGetUtxoEventFromBlock = property $ do
+  utxoEventsWithTxs <- forAll UtxoGen.genUtxoEventsWithTxs
+  forM_ utxoEventsWithTxs $ \(expectedUtxoEvent, block) -> do
+    let (C.BlockHeader sno hBh _) = mockBlockChainPoint  block
+        (txs, cp) :: ([C.Tx C.BabbageEra], C.ChainPoint) = (mockBlockTxs block, C.ChainPoint sno hBh)
+        computedEvent = Utxo.getUtxoEvents Nothing txs cp
+    length (Utxo.ueUtxos computedEvent)  === length (Utxo.ueUtxos expectedUtxoEvent)
+    length (Utxo.ueInputs computedEvent) === length (Utxo.ueInputs expectedUtxoEvent)
+    computedEvent === expectedUtxoEvent
+
+genEventWithShelleyAddressAtChainPoint :: C.ChainPoint -> Hedgehog.Gen[Utxo.StorableEvent Utxo.UtxoHandle]
+genEventWithShelleyAddressAtChainPoint cp =
+ genShelleyEraUtxoEvents <&> fmap (\e -> e {Utxo.ueChainPoint = cp})

--- a/marconi-sidechain/db-utils/exe/Main.hs
+++ b/marconi-sidechain/db-utils/exe/Main.hs
@@ -15,10 +15,10 @@ cliParser = CliOptions
                               <> short 'd'
                               <> metavar "FILENAME"
                               <>  showDefault
-                              <> value "./.marconidb/utxodb"
+                              <> value "./.marconidb/utxo.db"
                               <> help "Path to the marconi database.")
 main :: IO ()
-main  = do
+main = do
     (CliOptions dbpath) <- execParser $ info (cliParser <**> helper) mempty
     dbEnv <- bootstrap dbpath
     freqUtxoTable dbEnv

--- a/marconi-sidechain/examples/json-rpc-server/src/Main.hs
+++ b/marconi-sidechain/examples/json-rpc-server/src/Main.hs
@@ -31,8 +31,7 @@ data CliOptions = CliOptions
     }
 
 utxoDbFileName :: String
-utxoDbFileName = "utxodb"
-
+utxoDbFileName = "utxo.db"
 cliParser :: Parser CliOptions
 cliParser = CliOptions
     <$> strOption (long "utxo-db"
@@ -62,7 +61,7 @@ main = do
 -- Effectively we are going to query SQLite only
 mocUtxoIndexer :: FilePath -> SidechainEnv -> IO ()
 mocUtxoIndexer dbpath env =
-        Utxo.open dbpath (Utxo.Depth 4) >>= callback >> innerLoop
+        Utxo.open dbpath (Utxo.Depth 4) True >>= callback >> innerLoop
     where
       callback :: Utxo.UtxoIndexer -> IO ()
       callback = atomically . UIQ.updateEnvState (env ^. sidechainEnvIndexers . sidechainAddressUtxoIndexer)

--- a/marconi-sidechain/examples/start-json-rpc-server.sh
+++ b/marconi-sidechain/examples/start-json-rpc-server.sh
@@ -1,18 +1,17 @@
 #!/usr/bin/env sh
 
-DB_DIR="~/dev/var/iohk/marconi/1675803710"
-UTXO_FILE="utxodb"
+_D=~/dev/var/iohk
+C_NETWORK="preview-testnet"
+C_RUN_NO="1679067886"
+M_DIR="$_D/$C_RUN_NO/marconi/$C_NETWORK"
+DB_DIR="$M_DIR/marconidb"
 
-DB="$DB_DIR/$UTXO_FILE"
-mkdir -p $DB_DIR
-ls -la $DB_DIR
 
 ## Noes
 ## We use db-utils-exe/exe/Main.hs to get a list of most re occuring addresses from utxo-db
 ## Therefor these addresses my not always be the best addresses to use.
 ##
-cabal run examples-json-rpc-server -- \
-    --utxo-db "$DB" \
+cabal run examples-json-rpc-server --  --utxo-db "$DB_DIR" \
     --addresses-to-index addr_test1wrpn0ad8rj3pgfpzae5tghpf325nyvh94zfkj3kzgvxzvcc2zuac6 \
     --addresses-to-index addr_test1vryusxht8rgz4g6twrjz4y8gss66w202vtfyk84wahmguzgh5mejc \
     --addresses-to-index addr_test1wpzewuy339m9l8ax7gz8g08q2j9478lgntzv9qhmwvy3hwg0cwsaf

--- a/marconi-sidechain/examples/test-json-rpc.http
+++ b/marconi-sidechain/examples/test-json-rpc.http
@@ -7,10 +7,10 @@ POST http://localhost:3000/json-rpc
 Content-Type: application/json-rpc
 {"jsonrpc": "2.0", "method": "echo", "params": "plutus-apps rocks", "id": 0}
 #
-# should fail. `add` method is unknown
+# should return targetAddresses, if any
 POST http://localhost:3000/json-rpc
 Content-Type: application/json
-{"jsonrpc": "2.0", "method": "add", "params": [1,1], "id": 0}
+{"jsonrpc": "2.0", "method": "getTargetAddresses", "params": "hello", "id": 1}
 #
 # should fail, Unknown method: unknownMethod
 POST http://localhost:3000/json-rpc
@@ -28,8 +28,8 @@ Content-Type: application/json
 {
 "jsonrpc": "2.0"
 , "method": "getUtxoFromAddress"
-, "params": "addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc"
-, "id": 92
+, "params": "addr_test1wpzewuy339m9l8ax7gz8g08q2j9478lgntzv9qhmwvy3hwg0cwsaf"
+, "id": 3
 }
 #
 # lookup for UTXOs, should generate error if the address is not in the target list
@@ -39,18 +39,7 @@ Content-Type: application/json
 "jsonrpc": "2.0"
 , "method": "getUtxoFromAddress"
 , "params": "addr_test1wqr4uz0tp75fu8wrg6gm83t20aphuc9vt6n8kvu09ctkugq6ch8kj"
-, "id":21
-}
-
-#
-# lookup for UTXOs, should generate error if the address is not in the target list
-POST http://localhost:3000/json-rpc
-Content-Type: application/json
-{
-"jsonrpc": "2.0"
-, "method": "getUtxoFromAddress"
-, "params": ["addr_test1wqr4uz0tp75fu8wrg6gm83t20aphuc9vt6n8kvu09ctkugq6ch8kj"]
-, "id":21
+, "id":4
 }
 
 
@@ -75,19 +64,9 @@ Content-Type: application/json
 "jsonrpc": "2.0"
 , "method": "getUtxoFromAddress"
 , "params": 100
-, "id": 14
+, "id": 5
 }
 #
-# fetch plutus converted addresses the user had provided
-# This version of marconi-sidechain simply ignores `100` and returns all rows from database. This is a todo item for next release
-POST http://localhost:3000/json-rpc
-Content-Type: application/json
-{
-"jsonrpc": "2.0"
-, "method": "getTargetAddresses"
-, "params": ""
-, "id": 11
-}
 #
 #
 ####  REST calls ####

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
@@ -4,20 +4,25 @@
 
 module Spec.Marconi.Sidechain.Api.Query.Indexers.Utxo (tests) where
 
-import Cardano.Api qualified as C
 import Control.Concurrent.STM (atomically)
 import Control.Lens.Operators ((^.))
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson qualified as Aeson
-import Data.Foldable (fold)
 import Data.Maybe (mapMaybe)
 import Data.Proxy (Proxy (Proxy))
-import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (unpack)
 import Data.Traversable (for)
-import Gen.Marconi.ChainIndex.Indexers.Utxo (genShelleyEraUtxoEvents, genUtxoEvents)
-import Hedgehog (Property, forAll, property, (===))
+import Network.HTTP.Client (defaultManagerSettings, newManager)
+import Network.JsonRpc.Client.Types ()
+import Network.JsonRpc.Types (JsonRpcResponse (Result))
+import Network.Wai.Handler.Warp qualified as Warp
+import Servant.API ((:<|>) ((:<|>)))
+import Servant.Client (BaseUrl (BaseUrl), ClientEnv, HasClient (Client), Scheme (Http), client, hoistClient,
+                       mkClientEnv, runClientM)
+
+import Cardano.Api qualified as C
+import Gen.Marconi.ChainIndex.Indexers.Utxo (genShelleyEraUtxoEvents)
 import Helpers (addressAnyToShelley)
 import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 import Marconi.Core.Storable qualified as Storable
@@ -27,21 +32,17 @@ import Marconi.Sidechain.Api.Query.Indexers.Utxo qualified as UIQ
 import Marconi.Sidechain.Api.Routes (AddressUtxoResult (AddressUtxoResult), JsonRpcAPI)
 import Marconi.Sidechain.Api.Types (SidechainEnv, sidechainAddressUtxoIndexer, sidechainEnvIndexers)
 import Marconi.Sidechain.Bootstrap (initializeSidechainEnv)
-import Network.HTTP.Client (defaultManagerSettings, newManager)
-import Network.JsonRpc.Client.Types ()
-import Network.JsonRpc.Types (JsonRpcResponse (Result))
-import Network.Wai.Handler.Warp qualified as Warp
-import Servant.API ((:<|>) ((:<|>)))
-import Servant.Client (BaseUrl (BaseUrl), ClientEnv, HasClient (Client), Scheme (Http), client, hoistClient,
-                       mkClientEnv, runClientM)
+
+import Hedgehog (Property, forAll, property, (===))
+import Hedgehog qualified
 import Test.Tasty (TestTree, testGroup, withResource)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 
 tests :: TestTree
 tests = testGroup "marconi-sidechain-utxo query Api Specs"
     [ testPropertyNamed
-        "marconi-sidechain-utxo query-target-addresses"
-        "Spec. Insert events and query for utxo's with address in the generated ShelleyEra targetAddresses"
+        "marconi-sidechain-utxo, Insert events and query for utxo's with address in the generated ShelleyEra targetAddresses"
+        "queryTargetAddressTest"
         queryTargetAddressTest
 
     , utxoJsonRpcTestTree
@@ -84,7 +85,7 @@ initRpcTestEnv = do
   pure (mkRpcEnv env, f)
 
 depth :: Utxo.Depth
-depth = Utxo.Depth 5
+depth = Utxo.Depth 200
 
 -- | Insert events, and perform the callback
 -- Note, the in-memory DB provides the isolation we need per property test as the memory cache
@@ -94,12 +95,13 @@ mocUtxoWorker
   -> [Utxo.StorableEvent Utxo.UtxoHandle]
   -> IO ()
 mocUtxoWorker callback events  =
-  Utxo.open ":memory:" depth >>= Storable.insertMany events >>= callback
+  Utxo.open ":memory:" depth False >>= Storable.insertMany events >>= callback
 
--- | generate some Utxo events, store them and fetch them.
+-- | generate some Utxo events, store them and fetch the Unspent Utxos, and make sure JSON conversion is idempotent
+
 queryTargetAddressTest :: Property
 queryTargetAddressTest = property $ do
-  events <- forAll genUtxoEvents
+  events <- forAll genShelleyEraUtxoEvents
   env <- liftIO $ initializeSidechainEnv Nothing Nothing
   let
     callback :: Utxo.UtxoIndexer -> IO ()
@@ -116,14 +118,12 @@ queryTargetAddressTest = property $ do
     . concatMap (Set.toList . Utxo.ueUtxos)
     $ events
 
-  let rows = Utxo.eventsToRows $ fold events
+  let numOfFetched = length fetchedRows
+  Hedgehog.classify "Retrieved Utxos are greater than or Equal to 5" $ numOfFetched >= 5
+  Hedgehog.classify "Retrieved Utxos are greater than 1" $ numOfFetched > 1
 
-  -- We compare the serialized result because that is how the 'UIQ.findByAddress' sends the result.
-  -- TODO BROKEN.
-  -- fmap Aeson.encode fetchedRows === fmap Aeson.encode rows
-  -- To remove once the assert above is fixed
-  fmap Aeson.encode fetchedRows === fmap Aeson.encode fetchedRows
-  fmap Aeson.encode rows === fmap Aeson.encode rows
+  Hedgehog.assert (not . null $ fetchedRows)
+  (Set.fromList . mapMaybe (Aeson.decode .  Aeson.encode ) $ fetchedRows) === Set.fromList fetchedRows
 
 -- | Create http JSON-RPC client function to test RPC route and handlers
 queryUtxoFromRpcServer
@@ -158,9 +158,10 @@ propUtxoEventInsertionAndJsonRpcQueryRoundTrip action = property $ do
         $ events
   rpcResponses <- liftIO $ for qAddresses rpcClient
   let
-    inserted :: Set Utxo.UtxoRow = Set.fromList . concatMap Utxo.eventsToRows $ events
-    fetched :: Set Utxo.UtxoRow =  Set.fromList . concatMap fromQueryResult $ rpcResponses
-  fetched === inserted
+    fetched :: [Utxo.UtxoRow] = concatMap fromQueryResult rpcResponses
+
+  Hedgehog.assert (not . null $ fetched)
+  (Set.fromList . mapMaybe (Aeson.decode .  Aeson.encode ) $ fetched) === Set.fromList fetched
 
 hoistClientApi :: Proxy JsonRpcAPI
 hoistClientApi = Proxy

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Marconi.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Marconi.hs
@@ -26,6 +26,7 @@ import Control.Monad.Freer.State qualified as Eff (State, get, put, runState)
 import Control.Monad.Freer.TH (makeEffect)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Foldable (foldl')
+import Data.Map (elems)
 import Data.Set qualified as Set
 import Ledger.Address (CardanoAddress)
 import Ledger.Tx (CardanoTx (CardanoTx))
@@ -138,7 +139,7 @@ getUtxoEvents
   -> C.ChainPoint
   -> StorableEvent UtxoHandle -- ^ UtxoEvents are stored in storage after conversion to UtxoRow
 getUtxoEvents txs cp =
-  let utxosFromCardanoTx (CardanoTx c _) = getUtxos Nothing c
+  let utxosFromCardanoTx (CardanoTx c _) = elems $ getUtxos Nothing c
       inputsFromCardanoTx (CardanoTx c _) = getInputs c
       utxos = Set.fromList $ concatMap utxosFromCardanoTx txs
       ins = foldl' Set.union Set.empty $ inputsFromCardanoTx <$> txs

--- a/plutus-chain-index-core/test/Plutus/ChainIndex/MarconiSpec.hs
+++ b/plutus-chain-index-core/test/Plutus/ChainIndex/MarconiSpec.hs
@@ -53,7 +53,7 @@ genBlocks = fmap fromMockBlock <$> genMockchain
 newChainIndexIndexers :: IO ChainIndexIndexersMVar
 newChainIndexIndexers = do
     indexers <- ChainIndexIndexers
-        <$> Utxo.open ":memory:" (Utxo.Depth 10)
+        <$> Utxo.open ":memory:" (Utxo.Depth 10) False -- do not perfrom SQLite vacuum, see: https://www.sqlite.org/lang_vacuum.html
     boxChainIndexIndexers indexers
 
 getUtxoEvents :: MonadIO m => ChainIndexIndexersMVar -> m [StorableEvent UtxoHandle]


### PR DESCRIPTION
Fixes are:
- fix the broken property tests in Utxo
- remove the `equivalent` test criteria, replace with sort/compare
- add `isToVacuume` switch indicating SQLite vacuum operation. The switch is not in CLI, and set to True. In test we set that to False.
- fix the Query results
-  Balance the in-memory Utxos in regards to `Spent`
- minor change in the JSON form of the UtxoResponse. 
### Additional notes:
Regression test showing the failure see [PR-1032](https://github.com/input-output-hk/plutus-apps/pull/1032)
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
