### PR TITLE
PLT-1311 Add JSON-RPC querying of the stake pool delegation (SPD) by epoch in `marconi-sidechain`.

### DIFF
--- a/marconi-sidechain/README.md
+++ b/marconi-sidechain/README.md
@@ -217,18 +217,21 @@ OR
 }
 ```
 
-#### getUtxoFromAddress
+#### getUtxoFromAddress (NOT IMPLEMENTED YET)
 
-Retrieves user provided addresses.
+Retrieves UTXOs of a given address until a given point in time (measured in slots).
 
-**Parameters**: Address encoded in the Bech32 representation
+**Parameters**:
 
-**Returns**: List of UTXOs linked to the provided address.
+* `address`: address encoded in the Bech32 format
+* `slotNo`: slot number.
+
+**Returns**: List of resolved UTXOs.
 
 **Example**:
 
 ```sh
-$ curl -d '{"jsonrpc": "2.0" , "method": "getUtxoFromAddress" , "params": "addr_test1qz0ru2w9suwv8mcskg8r9ws3zvguekkkx6kpcnn058pe2ql2ym0y64huzhpu0wl8ewzdxya0hj0z5ejyt3g98lpu8xxs8faq0m", "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:3000/json-rpc | jq
+$ curl -d '{"jsonrpc": "2.0" , "method": "getUtxoFromAddress" , "params": { "address": "addr_test1qz0ru2w9suwv8mcskg8r9ws3zvguekkkx6kpcnn058pe2ql2ym0y64huzhpu0wl8ewzdxya0hj0z5ejyt3g98lpu8xxs8faq0m", "slotNo": 1 }, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:3000/json-rpc | jq
 {
   "id": 1,
   "jsonrpc": "2.0",
@@ -278,16 +281,19 @@ $ curl -d '{"jsonrpc": "2.0" , "method": "getUtxoFromAddress" , "params": "addr_
 
 #### getTxWithMintingPolicy (NOT IMPLEMENTED YET)
 
-Retrieves transactions that include a minting policy for minting/burning tokens.
+Retrieves transactions that include a minting policy for minting/burning tokens until a given point in time (measured in slots).
 
-**Parameters**: Hash of the minting policy
+**Parameters**:
+
+* `mps`: Hash of the minting policy
+* `slotNo`: slot number
 
 **Returns**: List of transaction IDs
 
 **Example**:
 
 ```sh
-$ curl -d '{"jsonrpc": "2.0" , "method": "getTxWithMintingPolicy" , "params": "...", "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:3000/json-rpc | jq
+$ curl -d '{"jsonrpc": "2.0" , "method": "getTxWithMintingPolicy" , "params": { "mps": "284d60f7e56f5fd54faed4c50fd5cab0307da1c4034d6a92c5dbb940", "slotNo": 1 }, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:3000/json-rpc | jq
 {
   "id": 1,
   "jsonrpc": "2.0",
@@ -316,27 +322,48 @@ $ curl -d '{"jsonrpc": "2.0" , "method": "getTxWithMintingPolicy" , "params": ".
 }
 ```
 
-#### getStakePoolDelegationByEpoch (NOT IMPLEMENTED YET)
+#### getStakePoolDelegationByEpoch
 
 Retrieves the stake pool delegation per epoch.
 
 **Parameters**: Epoch number
 
-**Returns**: List of stake pool IDs with the amount of staked lovelace
+**Returns**: List of stake pool IDs in Bech32 format with the total staked lovelace for that epoch.
 
 **Example**:
 
 ```sh
-$ curl -d '{"jsonrpc": "2.0" , "method": "getStakePoolDelegationByEpoch" , "params": "...", "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:3000/json-rpc | jq
+$ curl -d '{"jsonrpc": "2.0" , "method": "getStakePoolDelegationByEpoch" , "params": 6, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:3000/json-rpc | jq
 {
   "id": 1,
   "jsonrpc": "2.0",
-  "result": [
-    {
-      "poolId": "...",
-      "lovelace": 10000000
-    }
-  ]
+  "result":
+    [
+        {
+            "blockHeaderHash": "578f3cb70f4153e1622db792fea9005c80ff80f83df028210c7a914fb780a6f6",
+            "blockNo": 64903,
+            "epochNo": 6,
+            "lovelace": 100000000000000,
+            "poolId": "pool1z22x50lqsrwent6en0llzzs9e577rx7n3mv9kfw7udwa2rf42fa",
+            "slotNo": 1382422
+        },
+        {
+            "blockHeaderHash": "578f3cb70f4153e1622db792fea9005c80ff80f83df028210c7a914fb780a6f6",
+            "blockNo": 64903,
+            "epochNo": 6,
+            "lovelace": 100000000000000,
+            "poolId": "pool1547tew8vmuj0g6vj3k5jfddudextcw6hsk2hwgg6pkhk7lwphe6",
+            "slotNo": 1382422
+        },
+        {
+            "blockHeaderHash": "578f3cb70f4153e1622db792fea9005c80ff80f83df028210c7a914fb780a6f6",
+            "blockNo": 64903,
+            "epochNo": 6,
+            "lovelace": 100000000000000,
+            "poolId": "pool174mw7e20768e8vj4fn8y6p536n8rkzswsapwtwn354dckpjqzr8",
+            "slotNo": 1382422
+        }
+    ]
 }
 ```
 
@@ -351,7 +378,7 @@ Retrieves transactions that include a minting policy for minting/burning tokens.
 **Example**:
 
 ```sh
-$ curl -d '{"jsonrpc": "2.0" , "method": "getNonceByEpoch " , "params": 398, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:3000/json-rpc | jq
+$ curl -d '{"jsonrpc": "2.0" , "method": "getNonceByEpoch" , "params": 398, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:3000/json-rpc | jq
 {
   "id": 1,
   "jsonrpc": "2.0",

--- a/marconi-sidechain/app/Main.hs
+++ b/marconi-sidechain/app/Main.hs
@@ -4,7 +4,7 @@ module Main where
 import Control.Concurrent.Async (race_)
 import Marconi.Sidechain.Api.HttpServer qualified as Http
 import Marconi.Sidechain.Api.Types (CliArgs (CliArgs, httpPort, targetAddresses))
-import Marconi.Sidechain.Bootstrap (bootstrapIndexers, initializeIndexerEnv)
+import Marconi.Sidechain.Bootstrap (bootstrapIndexers, initializeSidechainEnv)
 import Marconi.Sidechain.CLI (parseCli)
 
 -- | Concurrently start:
@@ -16,8 +16,7 @@ import Marconi.Sidechain.CLI (parseCli)
 main :: IO ()
 main = do
     cli@CliArgs { httpPort, targetAddresses } <- parseCli
-
-    rpcEnv <- initializeIndexerEnv httpPort targetAddresses
+    rpcEnv <- initializeSidechainEnv httpPort targetAddresses
 
     race_
        (Http.bootstrap rpcEnv) -- Start HTTP server

--- a/marconi-sidechain/marconi-sidechain.cabal
+++ b/marconi-sidechain/marconi-sidechain.cabal
@@ -45,11 +45,13 @@ library
   hs-source-dirs:  src
   exposed-modules:
     Marconi.Sidechain.Api.HttpServer
+    Marconi.Sidechain.Api.Query.Indexers.EpochSPD
     Marconi.Sidechain.Api.Query.Indexers.Utxo
     Marconi.Sidechain.Api.Routes
     Marconi.Sidechain.Api.Types
     Marconi.Sidechain.Bootstrap
     Marconi.Sidechain.CLI
+    Marconi.Sidechain.Utils
 
   --------------------
   -- Local components
@@ -69,6 +71,7 @@ library
   build-depends:
     , aeson
     , base                  >=4.9 && <5
+    , containers
     , filepath
     , lens
     , optparse-applicative
@@ -77,6 +80,7 @@ library
     , stm                   >=2.5
     , text
     , time
+    , vector
     , warp
 
 executable marconi-sidechain

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/EpochSPD.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/EpochSPD.hs
@@ -1,0 +1,52 @@
+module Marconi.Sidechain.Api.Query.Indexers.EpochSPD
+    ( initializeEnv
+    , updateEnvState
+    , querySPDByEpochNo
+    ) where
+
+import Cardano.Api qualified as C
+import Control.Concurrent.STM.TMVar (TMVar, newEmptyTMVarIO, tryReadTMVar)
+import Control.Lens ((^.))
+import Control.Monad.STM (STM, atomically)
+import Data.Word (Word64)
+import Marconi.ChainIndex.Indexers.EpochStakepoolSize (EpochSPDHandle, StorableQuery (SPDByEpochNoQuery),
+                                                       StorableResult (SPDByEpochNoResult))
+import Marconi.Core.Storable (State)
+import Marconi.Core.Storable qualified as Storable
+import Marconi.Sidechain.Api.Routes (EpochStakePoolDelegationResult (EpochStakePoolDelegationResult))
+import Marconi.Sidechain.Api.Types (EpochSPDIndexerEnv (EpochSPDIndexerEnv), QueryExceptions (QueryError), SidechainEnv,
+                                    epochSpdIndexerEnvIndexer, sidechainEnvIndexers,
+                                    sidechainEpochStakePoolDelegationIndexer)
+import Marconi.Sidechain.Utils (writeTMVar)
+
+-- | Bootstraps the EpochSPD query environment.
+-- The module is responsible for accessing SQLite for queries.
+-- The main issue we try to avoid here is mixing inserts and quries in SQLite to avoid locking the database
+initializeEnv
+    :: IO EpochSPDIndexerEnv -- ^ returns Query runtime environment
+initializeEnv = EpochSPDIndexerEnv <$> newEmptyTMVarIO
+
+updateEnvState :: TMVar (State EpochSPDHandle) -> State EpochSPDHandle -> STM ()
+updateEnvState = writeTMVar
+
+-- | Retrieve SPD associated at the given 'EpochNo'
+-- We return an empty list if the 'EpochNo' is not found.
+querySPDByEpochNo
+    :: SidechainEnv -- ^ Query run time environment
+    -> Word64 -- ^ Bech32 Address
+    -> IO (Either QueryExceptions EpochStakePoolDelegationResult)  -- ^ Plutus address conversion error may occur
+querySPDByEpochNo env epochNo = do
+    -- We must stop the indexer inserts before doing the query.
+    epochSpdIndexer <-
+        atomically
+        $ tryReadTMVar
+        $ env ^. sidechainEnvIndexers . sidechainEpochStakePoolDelegationIndexer . epochSpdIndexerEnvIndexer
+    case epochSpdIndexer of
+      Nothing      -> pure $ Left $ QueryError "Failed to read EpochSPD indexer"
+      Just indexer -> query indexer
+
+    where
+        query indexer = do
+            (SPDByEpochNoResult epochSpdRows) <-
+                Storable.query Storable.QEverything indexer (SPDByEpochNoQuery $ C.EpochNo epochNo)
+            pure $ Right $ EpochStakePoolDelegationResult epochSpdRows

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
@@ -7,11 +7,11 @@
 module Marconi.Sidechain.Api.Routes where
 
 import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), Value (Object), object, (.:), (.=))
 import Data.Text (Text)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
+import Marconi.ChainIndex.Indexers.EpochStakepoolSize qualified as EpochSPD
 import Marconi.ChainIndex.Indexers.MintBurn qualified as MpsTx
 import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 import Network.JsonRpc.Types (JsonRpc, RawJsonRpc)
@@ -124,7 +124,7 @@ newtype MintingPolicyHashTxResult =
     deriving (Eq, Ord, Show, Generic, ToJSON, FromJSON)
 
 newtype EpochStakePoolDelegationResult =
-    EpochStakePoolDelegationResult [(C.PoolId, C.Lovelace)]
+    EpochStakePoolDelegationResult [EpochSPD.EpochSPDRow]
     deriving (Eq, Ord, Show, Generic, ToJSON, FromJSON)
 
 newtype EpochNonceResult =

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Types.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Types.hs
@@ -13,49 +13,60 @@
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
-{-# OPTIONS_GHC -Wno-orphans #-}
-
 -- | This module provides support for writing handlers for JSON-RPC endpoints.
-module Marconi.Sidechain.Api.Types  where
+module Marconi.Sidechain.Api.Types where
 
 import Cardano.Api qualified as C
 import Control.Concurrent.STM.TMVar (TMVar)
 import Control.Exception (Exception)
-import Control.Lens (makeClassy)
-import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
+import Control.Lens (makeLenses)
+import Marconi.ChainIndex.Indexers.EpochStakepoolSize (EpochSPDHandle)
+import Marconi.ChainIndex.Indexers.Utxo (UtxoHandle)
 import Marconi.ChainIndex.Types as Export (TargetAddresses)
+import Marconi.Core.Storable (State)
 import Network.Wai.Handler.Warp (Settings)
 
 -- | Type represents http port for JSON-RPC
 
 data CliArgs = CliArgs
-  { socket          :: FilePath -- ^ POSIX socket file to communicate with cardano node
-  , dbDir           :: FilePath -- ^ Directory path containing the SQLite database files
-  , httpPort        :: Maybe Int -- ^ optional tcp/ip port number for JSON-RPC http server
-  , networkId       :: C.NetworkId -- ^ cardano network id
-  , targetAddresses :: Maybe TargetAddresses -- ^ white-space sepparated list of Bech32 Cardano Shelley addresses
+  { socket          :: !FilePath -- ^ POSIX socket file to communicate with cardano node
+  , nodeConfigPath  :: !FilePath -- ^ Path to the node config
+  , dbDir           :: !FilePath -- ^ Directory path containing the SQLite database files
+  , httpPort        :: !(Maybe Int) -- ^ optional tcp/ip port number for JSON-RPC http server
+  , networkId       :: !C.NetworkId -- ^ cardano network id
+  , targetAddresses :: !(Maybe TargetAddresses) -- ^ white-space sepparated list of Bech32 Cardano Shelley addresses
   } deriving (Show)
-
--- | Should contain all the indexers required by Sidechain
-newtype IndexerWrapper = IndexerWrapper
-    { unWrapUtxoIndexer :: TMVar Utxo.UtxoIndexer     -- ^ for query thread to access in-memory utxos
-    }
-
-data IndexerEnv = IndexerEnv
-    { _uiIndexer    :: IndexerWrapper
-    , _uiQaddresses :: Maybe TargetAddresses        -- ^ user provided addresses to filter
-    }
-makeClassy ''IndexerEnv
 
 -- | JSON-RPC as well as the Query Indexer Env
 data SidechainEnv = SidechainEnv
-    { _httpSettings :: Settings               -- ^ HTTP server setting
-    , _queryEnv     :: IndexerEnv         -- ^ used for query sqlite
+    { _sidechainEnvHttpSettings :: !Settings -- ^ HTTP server setting
+    , _sidechainEnvIndexers     :: !SidechainIndexers -- ^ Used for query the indexers
     }
-makeClassy ''SidechainEnv
+
+-- | Should contain all the indexers required by Sidechain.
+data SidechainIndexers = SidechainIndexers
+    { _sidechainAddressUtxoIndexer              :: !AddressUtxoIndexerEnv
+    -- ^ For query thread to access in-memory utxos
+    , _sidechainEpochStakePoolDelegationIndexer :: !EpochSPDIndexerEnv
+    -- ^ For query thread to access in-memory epoch stake pool delegation
+    }
+
+data AddressUtxoIndexerEnv = AddressUtxoIndexerEnv
+    { _addressUtxoIndexerEnvTargetAddresses :: !(Maybe TargetAddresses)
+    , _addressUtxoIndexerEnvIndexer         :: !(TMVar (State UtxoHandle))
+    }
+
+newtype EpochSPDIndexerEnv = EpochSPDIndexerEnv
+    { _epochSpdIndexerEnvIndexer         :: TMVar (State EpochSPDHandle)
+    }
 
 data QueryExceptions
-    = AddressConversionError QueryExceptions
-    | QueryError String
+    = AddressConversionError !QueryExceptions
+    | QueryError !String
     deriving stock Show
     deriving anyclass  Exception
+
+makeLenses ''SidechainEnv
+makeLenses ''SidechainIndexers
+makeLenses ''AddressUtxoIndexerEnv
+makeLenses ''EpochSPDIndexerEnv

--- a/marconi-sidechain/src/Marconi/Sidechain/Bootstrap.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Bootstrap.hs
@@ -7,44 +7,60 @@ module Marconi.Sidechain.Bootstrap where
 import Cardano.Api qualified as C
 import Control.Concurrent.STM (atomically)
 import Control.Lens ((^.))
+import Marconi.ChainIndex.Indexers (epochStakepoolSizeWorker, runIndexers, utxoWorker)
+import Marconi.ChainIndex.Indexers.EpochStakepoolSize (EpochSPDHandle)
+import Marconi.ChainIndex.Indexers.Utxo (UtxoHandle)
+import Marconi.ChainIndex.Types (TargetAddresses, epochStakepoolSizeDbName, utxoDbName)
+import Marconi.Core.Storable (State, StorableEvent)
+import Marconi.Sidechain.Api.Query.Indexers.EpochSPD qualified as EpochSPD
+import Marconi.Sidechain.Api.Query.Indexers.Utxo qualified as AddressUtxo
+import Marconi.Sidechain.Api.Types (CliArgs (CliArgs), SidechainEnv (SidechainEnv),
+                                    SidechainIndexers (SidechainIndexers), epochSpdIndexerEnvIndexer,
+                                    sidechainAddressUtxoIndexer, sidechainEnvIndexers,
+                                    sidechainEpochStakePoolDelegationIndexer)
 import Network.Wai.Handler.Warp (Port, defaultSettings, setPort)
 import System.FilePath ((</>))
 
-import Marconi.ChainIndex.Indexers (runIndexers, utxoWorker)
-import Marconi.ChainIndex.Types (TargetAddresses, utxoDbName)
-import Marconi.Sidechain.Api.Query.Indexers.Utxo (UtxoIndexer, initializeEnv, writeTMVar')
-import Marconi.Sidechain.Api.Types (CliArgs (CliArgs), HasIndexerEnv (uiIndexer), HasSidechainEnv (queryEnv),
-                                    SidechainEnv (SidechainEnv, _httpSettings, _queryEnv))
-
-
 -- | Bootstraps the JSON-RPC  http server with appropriate settings and marconi cache
 -- this is just a wrapper for the bootstrapHttp in json-rpc package
-initializeIndexerEnv
+initializeSidechainEnv
     :: Maybe Port
     -> Maybe TargetAddresses
     -> IO SidechainEnv
-initializeIndexerEnv maybePort targetAddresses = do
-    queryenv <- initializeEnv targetAddresses
-    let httpsettings =  maybe defaultSettings (flip setPort defaultSettings ) maybePort
-    pure $ SidechainEnv
-        { _httpSettings = httpsettings
-        , _queryEnv = queryenv
-        }
+initializeSidechainEnv maybePort targetAddresses = do
+    let httpsettings = maybe defaultSettings (flip setPort defaultSettings ) maybePort
+    sidechainIndexers <-
+        SidechainIndexers
+            <$> AddressUtxo.initializeEnv targetAddresses
+            <*> EpochSPD.initializeEnv
+    pure $ SidechainEnv httpsettings sidechainIndexers
 
 -- |  Marconi cardano blockchain indexer
 bootstrapIndexers
     :: CliArgs
     -> SidechainEnv
     -> IO ()
-bootstrapIndexers (CliArgs socketPath dbPath _ networkId targetAddresses) env = do
-  let callbackIndexer :: UtxoIndexer -> IO ()
-      callbackIndexer = atomically . writeTMVar' (env ^. queryEnv . uiIndexer)
+bootstrapIndexers (CliArgs socketPath nodeConfigPath dbPath _ networkId targetAddresses) env = do
+  let addressUtxoCallback :: State UtxoHandle -> IO ()
+      addressUtxoCallback =
+          atomically
+        . AddressUtxo.updateEnvState (env ^. sidechainEnvIndexers . sidechainAddressUtxoIndexer)
+  let epochSPDCallback :: (State EpochSPDHandle, StorableEvent EpochSPDHandle) -> IO ()
+      epochSPDCallback =
+          atomically
+        . EpochSPD.updateEnvState (env ^. sidechainEnvIndexers . sidechainEpochStakePoolDelegationIndexer . epochSpdIndexerEnvIndexer)
+        . fst
+  let indexers =
+          [ ( utxoWorker addressUtxoCallback targetAddresses
+            , Just $ dbPath </> utxoDbName
+            )
+          , ( epochStakepoolSizeWorker nodeConfigPath epochSPDCallback
+            , Just $ dbPath </> epochStakepoolSizeDbName
+            )
+          ]
   runIndexers
     socketPath
     networkId
     C.ChainPointAtGenesis
     "marconi-sidechain"
-    [ ( utxoWorker callbackIndexer targetAddresses
-      , Just (dbPath </> utxoDbName)
-      )
-    ]
+    indexers

--- a/marconi-sidechain/src/Marconi/Sidechain/CLI.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/CLI.hs
@@ -15,6 +15,10 @@ programParser gitSha = Opt.info
 parserCliArgs :: Opt.Parser CliArgs
 parserCliArgs = CliArgs
   <$> Cli.commonSocketPath
+  <*> Opt.strOption
+        (  Opt.long "node-config-path"
+        <> Opt.help "Path to node configuration which you are connecting to."
+        )
   <*> Cli.commonDbDir
   <*> Cli.commonMaybePort
   <*> Cli.pNetworkId

--- a/marconi-sidechain/src/Marconi/Sidechain/Utils.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Utils.hs
@@ -1,0 +1,11 @@
+module Marconi.Sidechain.Utils where
+
+import Control.Concurrent.STM (STM, TMVar, putTMVar, tryTakeTMVar)
+
+-- | Non-blocking write of a new value to a 'TMVar'
+-- Puts if empty. Replaces if populated.
+--
+-- Only exists in GHC9, but we're on GHC8.
+-- TODO: Remove once we migrate to GHC9.
+writeTMVar :: TMVar a -> a -> STM ()
+writeTMVar t new = tryTakeTMVar t >> putTMVar t new

--- a/marconi-sidechain/test/Spec.hs
+++ b/marconi-sidechain/test/Spec.hs
@@ -12,7 +12,7 @@ main = defaultMain tests
 tests :: TestTree
 tests = localOption (HedgehogTestLimit $ Just 200) $
     testGroup "marconi-sidechain"
-        [ Api.Query.Indexers.Utxo.tests
-        , CLI.tests
+        [ CLI.tests
         , Routes.tests
+        , Api.Query.Indexers.Utxo.tests
         ]

--- a/marconi-sidechain/test/Spec/Golden/Cli/marconi-sidechain___help.help
+++ b/marconi-sidechain/test/Spec/Golden/Cli/marconi-sidechain___help.help
@@ -2,7 +2,8 @@ marconi-sidechain - a lightweight customizable solution for indexing and
 querying the Cardano blockchain
 
 Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
-                         (-d|--db-dir DIR) [--http-port HTTP-PORT] 
+                         --node-config-path ARG (-d|--db-dir DIR) 
+                         [--http-port HTTP-PORT] 
                          (--mainnet | --testnet-magic NATURAL) 
                          [(-a|--addresses-to-index BECH32-ADDRESS)]
 
@@ -13,6 +14,8 @@ Available options:
   --version                Show git SHA
   -s,--socket-path FILE-PATH
                            Path to node socket.
+  --node-config-path ARG   Path to node configuration which you are connecting
+                           to.
   -d,--db-dir DIR          Directory path where all SQLite databases are
                            located.
   --http-port HTTP-PORT    JSON-RPC http port number, default is port 3000.

--- a/marconi-sidechain/test/Spec/Golden/Cli/marconi-sidechain___socket.help
+++ b/marconi-sidechain/test/Spec/Golden/Cli/marconi-sidechain___socket.help
@@ -1,7 +1,8 @@
 Invalid option `--socket'
 
 Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
-                         (-d|--db-dir DIR) [--http-port HTTP-PORT] 
+                         --node-config-path ARG (-d|--db-dir DIR) 
+                         [--http-port HTTP-PORT] 
                          (--mainnet | --testnet-magic NATURAL) 
                          [(-a|--addresses-to-index BECH32-ADDRESS)]
 

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Routes/Golden/epoch-stakepooldelegation-response.json
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Routes/Golden/epoch-stakepooldelegation-response.json
@@ -1,0 +1,26 @@
+[
+    {
+        "blockHeaderHash": "578f3cb70f4153e1622db792fea9005c80ff80f83df028210c7a914fb780a6f6",
+        "blockNo": 64903,
+        "epochNo": 6,
+        "lovelace": 100000000000000,
+        "poolId": "pool1z22x50lqsrwent6en0llzzs9e577rx7n3mv9kfw7udwa2rf42fa",
+        "slotNo": 1382422
+    },
+    {
+        "blockHeaderHash": "578f3cb70f4153e1622db792fea9005c80ff80f83df028210c7a914fb780a6f6",
+        "blockNo": 64903,
+        "epochNo": 6,
+        "lovelace": 100000000000000,
+        "poolId": "pool1547tew8vmuj0g6vj3k5jfddudextcw6hsk2hwgg6pkhk7lwphe6",
+        "slotNo": 1382422
+    },
+    {
+        "blockHeaderHash": "578f3cb70f4153e1622db792fea9005c80ff80f83df028210c7a914fb780a6f6",
+        "blockNo": 64903,
+        "epochNo": 6,
+        "lovelace": 100000000000000,
+        "poolId": "pool174mw7e20768e8vj4fn8y6p536n8rkzswsapwtwn354dckpjqzr8",
+        "slotNo": 1382422
+    }
+]

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/Routes.hs
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/Routes.hs
@@ -5,16 +5,24 @@
 module Spec.Marconi.Sidechain.Routes (tests) where
 
 import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as C
+import Control.Monad (forM)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Encode.Pretty qualified as Aeson
 import Data.ByteString.Lazy (ByteString)
 import Data.Proxy (Proxy (Proxy))
+import Gen.Cardano.Api.Typed qualified as CGen
 import Gen.Marconi.ChainIndex.Types qualified as CGen
+import Gen.Marconi.ChainIndex.Types qualified as Gen
 import Hedgehog (Property, forAll, property, tripping)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Marconi.ChainIndex.Indexers.EpochStakepoolSize (EpochSPDRow (EpochSPDRow))
 import Marconi.ChainIndex.Indexers.MintBurn (TxMintRow (TxMintRow))
 import Marconi.ChainIndex.Indexers.Utxo (Utxo (Utxo), UtxoRow (UtxoRow))
 import Marconi.Sidechain.Api.Routes (AddressUtxoResult (AddressUtxoResult),
                                      CurrentSyncedPointResult (CurrentSyncedPointResult),
+                                     EpochStakePoolDelegationResult (EpochStakePoolDelegationResult),
                                      MintingPolicyHashTxResult (MintingPolicyHashTxResult))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Golden (goldenVsStringDiff)
@@ -27,6 +35,10 @@ tests = testGroup "Spec.Marconi.Sidechain.Routes"
             "CurrentSyncedPointResult"
             "propJSONRountripCurrentSyncedPointResult"
             propJSONRountripCurrentSyncedPointResult
+        , testPropertyNamed
+            "EpochStakePoolDelegationResult"
+            "propJSONRountripEpochStakePoolDelegationResult"
+            propJSONRountripEpochStakePoolDelegationResult
         ]
     , testGroup "Golden test for query results"
         [ goldenVsStringDiff
@@ -66,6 +78,18 @@ propJSONRountripCurrentSyncedPointResult :: Property
 propJSONRountripCurrentSyncedPointResult = property $ do
     cp <- CurrentSyncedPointResult <$> forAll CGen.genChainPoint
     tripping cp Aeson.encode Aeson.decode
+
+propJSONRountripEpochStakePoolDelegationResult :: Property
+propJSONRountripEpochStakePoolDelegationResult = property $ do
+    spds <- fmap EpochStakePoolDelegationResult $ forAll $ Gen.list (Range.linear 1 10) $ do
+        EpochSPDRow
+            <$> Gen.genEpochNo
+            <*> Gen.genPoolId
+            <*> CGen.genLovelace
+            <*> Gen.genSlotNo
+            <*> Gen.genHashBlockHeader
+            <*> Gen.genBlockNo
+    tripping spds Aeson.encode Aeson.decode
 
 goldenCurrentChainPointGenesisResult :: IO ByteString
 goldenCurrentChainPointGenesisResult = do
@@ -199,7 +223,33 @@ goldenMintingPolicyHashTxResult = do
     pure $ Aeson.encodePretty result
 
 goldenEpochStakePoolDelegationResult :: IO ByteString
-goldenEpochStakePoolDelegationResult = pure ""
+goldenEpochStakePoolDelegationResult = do
+    let blockHeaderHashRawBytes = "578f3cb70f4153e1622db792fea9005c80ff80f83df028210c7a914fb780a6f6"
+    blockHeaderHash <-
+        either
+            (error . show)
+            pure
+            $ C.deserialiseFromRawBytesHex (C.AsHash (C.proxyToAsType $ Proxy @C.BlockHeader)) blockHeaderHashRawBytes
+
+    let poolIdsBech32 =
+            [ "pool1z22x50lqsrwent6en0llzzs9e577rx7n3mv9kfw7udwa2rf42fa"
+            , "pool1547tew8vmuj0g6vj3k5jfddudextcw6hsk2hwgg6pkhk7lwphe6"
+            , "pool174mw7e20768e8vj4fn8y6p536n8rkzswsapwtwn354dckpjqzr8"
+            ]
+    poolIds <- forM poolIdsBech32 $ \poolIdBech32 -> do
+        either
+            (error . show)
+            pure
+            $ C.deserialiseFromBech32 (C.AsHash (C.proxyToAsType $ Proxy @C.StakePoolKey)) poolIdBech32
+
+    let lovelace = C.Lovelace 100000000000000
+        slotNo = C.SlotNo 1382422
+        epochNo = C.EpochNo 6
+        blockNo = C.BlockNo 64903
+
+    let spds = fmap (\poolId -> EpochSPDRow epochNo poolId lovelace slotNo blockHeaderHash blockNo) poolIds
+        result = EpochStakePoolDelegationResult spds
+    pure $ Aeson.encodePretty result
 
 goldenEpochNonceResult :: IO ByteString
 goldenEpochNonceResult = pure ""


### PR DESCRIPTION
Add JSON-RPC querying of the stake pool delegation (SPD) by epoch in `marconi-sidechain`.

* Add indexing and JSON-RPC querying of the SPD by epoch in `marconi-sidechain`.

* Added golden test for JSON response of stake pool delegation by epoch

* Fixed resuming of Utxo indexer to include *all* possible chain points, not only the latest ones.

* Updated README of `marconi-sidechain` to include an example of request and response for the JSON-RPC server on that specific endpoint.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [ ] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
