### PR TITLE
Restrict to aeson 2.0 or better

### DIFF
--- a/cardano-node-emulator/cardano-node-emulator.cabal
+++ b/cardano-node-emulator/cardano-node-emulator.cabal
@@ -70,7 +70,7 @@ library
   -- Non-IOG dependencies
   ------------------------
   build-depends:
-    , aeson               >=1.5.2
+    , aeson               >=2
     , array
     , base                >=4.9     && <5
     , bytestring

--- a/plutus-contract/plutus-contract.cabal
+++ b/plutus-contract/plutus-contract.cabal
@@ -148,7 +148,7 @@ library
   -- Non-IOG dependencies
   ------------------------
   build-depends:
-    , aeson                 >=1.5.2
+    , aeson                 >=2
     , aeson-pretty
     , base                  >=4.7     && <5
     , bytestring


### PR DESCRIPTION
This PR is response to Slack conversation on [#cardano-dev channel](https://input-output-rnd.slack.com/archives/CCZSDE005/p1679613693027109) in regards to upgrading aeson to 2.0 or better.
Note that plutus-apps cabal.project is configured for 2.0  and this change is more for readability.
[PLT-5442](https://input-output.atlassian.net/browse/PLT-5442)

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested


[PLT-5442]: https://input-output.atlassian.net/browse/PLT-5442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ