### PR TITLE
PLT-5459 Fix resuming on the MintBurn indexer

### DIFF
--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -173,6 +173,7 @@ library marconi-chain-index-test-lib
     Gen.Marconi.ChainIndex.Mockchain
     Gen.Marconi.ChainIndex.Types
     Helpers
+    Marconi.ChainIndex.TestLib.StorableProperties
 
   --------------------
   -- Local components

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/MintBurn.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/MintBurn.hs
@@ -329,15 +329,15 @@ instance RI.Buffered MintBurnHandle where
     sqliteInsert sqlCon (map coerce $ toList events)
     pure h
 
-  getStoredEvents (MintBurnHandle sqlCon k) =
-    map MintBurnEvent . fromRows <$> SQL.query sqlCon query (SQL.Only k)
+  getStoredEvents (MintBurnHandle sqlCon k) = do
+    fmap MintBurnEvent . fromRows <$> SQL.query sqlCon query (SQL.Only k)
     where
       query =
-        " SELECT slotNo, blockHeaderHash, txId, policyId, assetName, quantity  \
+        " SELECT slotNo, blockHeaderHash, txId, policyId, assetName, quantity, \
         \        redeemerIx, redeemerData                                      \
         \   FROM minting_policy_events                                         \
         \  WHERE slotNo >= (SELECT MAX(slotNo) - ? FROM minting_policy_events) \
-        \  ORDER BY slotNo, txId                                               "
+        \  ORDER BY slotNo DESC, txId                                          "
 
 instance RI.Resumable MintBurnHandle where
   resumeFromStorage h = do

--- a/marconi-chain-index/test-lib/Marconi/ChainIndex/TestLib/StorableProperties.hs
+++ b/marconi-chain-index/test-lib/Marconi/ChainIndex/TestLib/StorableProperties.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Marconi.ChainIndex.TestLib.StorableProperties where
+
+import Cardano.Api qualified as C
+import Control.Monad.IO.Class (liftIO)
+import Data.List qualified as List
+import Data.Ord (Down (Down))
+import Hedgehog ((===))
+import Hedgehog qualified as H
+import Marconi.ChainIndex.Orphans ()
+import Marconi.Core.Storable (Resumable, State, StorableMonad, StorablePoint, resume)
+
+-- | The property verifies that the 'Storable.resumeFromStorage' call returns at least the
+-- 'C.ChainPointAtGenesis' point.
+--
+-- TODO: ChainPointAtGenesis should always be returned by default. Don't need this property test.
+propResumingShouldReturnAtLeastTheGenesisPoint ::
+    ( Resumable h
+    , StorablePoint h ~ C.ChainPoint
+    , StorableMonad h ~ IO
+    )
+    => State h
+    -> H.PropertyT IO ()
+propResumingShouldReturnAtLeastTheGenesisPoint indexer = do
+    actualResumablePoints <- liftIO $ resume indexer
+    H.assert $ elem C.ChainPointAtGenesis actualResumablePoints
+
+-- | The property verifies that the 'Storable.resumeFromStorage' call returns a sorted list of chain
+-- points in descending order.
+propResumablePointsShouldBeSortedInDescOrder ::
+    ( Resumable h
+    , StorablePoint h ~ C.ChainPoint
+    , StorableMonad h ~ IO
+    )
+    => State h
+    -> H.PropertyT IO ()
+propResumablePointsShouldBeSortedInDescOrder indexer = do
+    actualResumablePoints <- liftIO $ resume indexer
+    actualResumablePoints === List.sortOn Down actualResumablePoints

--- a/marconi-chain-index/test/Spec.hs
+++ b/marconi-chain-index/test/Spec.hs
@@ -20,9 +20,9 @@ tests :: TestTree
 tests = testGroup "Marconi"
   [ Orphans.tests
   , Indexers.Utxo.tests
-  , Indexers.ScriptTx.tests
-  , Indexers.AddressDatum.tests
   , Indexers.MintBurn.tests
+  , Indexers.AddressDatum.tests
+  , Indexers.ScriptTx.tests
   , CLI.tests
   -- TODO Enable when test environemnt is reconfigured
   -- , EpochStakepoolSize.tests

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
@@ -25,6 +25,7 @@ import Gen.Marconi.ChainIndex.Types (genChainPoints)
 import Helpers (addressAnyToShelley)
 import Marconi.ChainIndex.Indexers.Utxo (StorableEvent (ueInputs, ueUtxos))
 import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
+import Marconi.ChainIndex.TestLib.StorableProperties qualified as StorableProperties
 import Marconi.ChainIndex.Types (TargetAddresses)
 import Marconi.Core.Storable (StorableQuery)
 import Marconi.Core.Storable qualified as Storable
@@ -74,14 +75,19 @@ tests = testGroup "Spec.Marconi.ChainIndex.Indexers.Utxo"
         propUtxoQueryByAddressAndQueryInterval
 
     , testPropertyNamed
+          "The points the indexer can be resumed from should return at least the genesis point"
+          "propResumingShouldReturnAtLeastTheGenesisPoint"
+          propResumingShouldReturnAtLeastTheGenesisPoint
+
+    , testPropertyNamed
           "The points that indexer can be resumed from should return at least non-genesis point when some data was indexed on disk"
           "propResumingShouldReturnAtLeastOneNonGenesisPointIfStoredOnDisk"
           propResumingShouldReturnAtLeastOneNonGenesisPointIfStoredOnDisk
 
     , testPropertyNamed
-          "The points that indexer can be resumed from should return an ordered set of points"
-          "propResumingShouldReturnOrderedListOfPoints"
-          propResumingShouldReturnOrderedListOfPoints
+          "The points that indexer can be resumed from should return an descending ordered list of points"
+          "propResumablePointsShouldBeSortedInDescOrder"
+          propResumablePointsShouldBeSortedInDescOrder
 
     , testPropertyNamed
           "ToJSON/FromJSON roundtrip for UtxoRow"
@@ -313,6 +319,16 @@ propUsingAllAddressesOfTxsAsTargetAddressesShouldReturnUtxosAsIfNoFilterWasAppli
     mkTargetAddressFromTxOuts txOuts =
         nonEmpty $ mapMaybe (\(C.TxOut addr _ _ _) -> addressAnyToShelley $ Utxo.toAddr addr) txOuts
 
+-- | The property verifies that the 'Storable.resumeFromStorage' call returns at least the
+-- 'C.ChainPointAtGenesis' point.
+propResumingShouldReturnAtLeastTheGenesisPoint :: Property
+propResumingShouldReturnAtLeastTheGenesisPoint = property $ do
+    events <- forAll UtxoGen.genUtxoEvents
+    depth <- forAll $ Gen.int (Range.linear 1 $ length events)
+    indexer <- liftIO $ Utxo.open ":memory:" (Utxo.Depth depth) False
+            >>= Storable.insertMany events
+    StorableProperties.propResumingShouldReturnAtLeastTheGenesisPoint indexer
+
 -- | The property verifies that the 'Storable.resumeFromStorage' call returns at least a point which
 -- is not 'C.ChainPointAtGenesis' when some events are inserted on disk.
 propResumingShouldReturnAtLeastOneNonGenesisPointIfStoredOnDisk :: Property
@@ -340,22 +356,20 @@ propResumingShouldReturnAtLeastOneNonGenesisPointIfStoredOnDisk = property $ do
     -- contain at least one UTXO. In the future, this should be changed to take into account
     Hedgehog.assert $ length actualResumablePoints >= 2
 
--- | The property verifies that the 'Storable.resumeFromStorage' returns an ordered list of points.
-propResumingShouldReturnOrderedListOfPoints :: Property
-propResumingShouldReturnOrderedListOfPoints = property $ do
-  events <- forAll UtxoGen.genUtxoEvents
-  let numOfEvents = length events
-  depth <- forAll $ Gen.int (Range.constantFrom (numOfEvents - 1) 1 (numOfEvents + 1))
-    -- We insert the events in the indexer, but for the test assertions, we discard the events in
-    -- memory.
-  indexer <- liftIO $ Utxo.open ":memory:" (Utxo.Depth depth) False -- don't vacuum sqlite
-    >>= Storable.insertMany events
-  resumablePoints <- liftIO $ Storable.resume indexer
+-- | The property verifies that the 'Storable.resumeFromStorage' call returns a sorted list of chain
+-- points in descending order.
+propResumablePointsShouldBeSortedInDescOrder :: Property
+propResumablePointsShouldBeSortedInDescOrder = property $ do
+    events <- forAll UtxoGen.genUtxoEvents
+    depth <- forAll $ Gen.int (Range.linear 1 $ length events)
 
-  Hedgehog.classify "Events on disk and memory" $ depth < numOfEvents
-  Hedgehog.classify "Events are in memory only" $ depth >= numOfEvents
+    Hedgehog.classify "Events are in memory only" $ depth >= length events
+    Hedgehog.classify "Events on disk and memory" $ depth < length events
 
-  List.reverse (List.sort resumablePoints) === resumablePoints
+    indexer <- liftIO $ Utxo.open ":memory:" (Utxo.Depth depth) False -- don't vaccum sqlite
+           >>= Storable.insertMany events
+
+    StorableProperties.propResumablePointsShouldBeSortedInDescOrder indexer
 
 propJsonRoundtripUtxoRow :: Property
 propJsonRoundtripUtxoRow = property $ do


### PR DESCRIPTION
* Fixed a syntax error of the `getStoredEvents` SQL query.

* Fixed the `getStoredEvents` SQL query so that the points returned are in descending order.

* Added a property test which verifies that the ChainPointAtGenesis is always returned by `resumablePoints`.

* Added a property test which verifies that the points returned by `resumablePoints` are sorted in descending order.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [x] Reviewer requested
