### PR TITLE
Marconi Utxo indexer return collateral

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -329,15 +329,13 @@ open dbPath (Depth k) isToVacuume = do
                       , inlineScript BLOB
                       , inlineScriptHash BLOB
                       , slotNo INT NOT NULL
-                      , blockHash BLOB NOT NULL
-                      , UNIQUE (txId, txIx))|]
+                      , blockHash BLOB NOT NULL)|]
 
   SQL.execute_ c [r|CREATE TABLE IF NOT EXISTS spent
                       ( txId TEXT NOT NULL
                       , txIx INT NOT NULL
                       , slotNo INT NOT NULL
-                      , blockHash BLOB NOT NULL
-                      , UNIQUE (txId, txIx))|]
+                      , blockHash BLOB NOT NULL)|]
 
   SQL.execute_ c [r|CREATE INDEX IF NOT EXISTS
                       spent_slotNo ON spent (slotNo)|]
@@ -371,7 +369,7 @@ instance Buffered UtxoHandle where
           (null rows)
           (SQL.executeMany c
             [r|INSERT
-               OR REPLACE INTO unspent_transactions (
+               INTO unspent_transactions (
                  address,
                  txId,
                  txIx,
@@ -388,7 +386,7 @@ instance Buffered UtxoHandle where
           (null spents)
           (SQL.executeMany c
            [r|INSERT
-              OR REPLACE INTO spent (
+              INTO spent (
                 txId,
                 txIx, slotNo, blockHash
               ) VALUES
@@ -589,8 +587,8 @@ utxoAtAddressQuery c es eventAtQuery filters params
                LEFT JOIN spent s ON u.txId = s.txId
                AND u.txIx = s.txIx
                WHERE
-                  s.txId IS NOT NULL
-                  AND s.txIx IS NOT NULL
+                  s.txId IS NULL
+                  AND s.txIx IS NULL
                AND |] <> SQL.Query (Text.intercalate " AND " $ SQL.fromQuery <$> filters) <>
             [r| ORDER BY
                 u.slotNo ASC |]

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
@@ -19,8 +19,7 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 
 import Cardano.Api qualified as C
-import Gen.Cardano.Api.Typed qualified as CGen
-import Gen.Marconi.ChainIndex.Indexers.Utxo (genShelleyEraUtxoEvents, genUtxoEvents)
+import Gen.Marconi.ChainIndex.Indexers.Utxo (genShelleyEraUtxoEvents, genTx, genUtxoEvents)
 import Gen.Marconi.ChainIndex.Indexers.Utxo qualified as UtxoGen
 import Gen.Marconi.ChainIndex.Mockchain (MockBlock (mockBlockChainPoint, mockBlockTxs))
 import Gen.Marconi.ChainIndex.Types (genChainPoint, genChainPoints)
@@ -195,9 +194,7 @@ allqueryUtxosShouldBeUnspent = property $ do
 --    * use the collateral TxOutsTxIns
 propTxInWhenPhase2ValidationFails :: Property
 propTxInWhenPhase2ValidationFails = property $ do
-  C.AnyCardanoEra (era :: C.CardanoEra era) <- forAll $
-    Gen.enum (C.AnyCardanoEra C.AlonzoEra) maxBound
-  tx@(C.Tx (C.TxBody C.TxBodyContent {..})_) <- forAll $ CGen.genTx era
+  tx@(C.Tx (C.TxBody C.TxBodyContent {..})_) <- forAll genTx
   cp <- forAll genChainPoint
   let event :: StorableEvent Utxo.UtxoHandle = Utxo.getUtxoEvents Nothing [tx] cp
       computedTxins :: [C.TxIn]
@@ -232,9 +229,7 @@ propTxInWhenPhase2ValidationFails = property $ do
 --    * failure in phase-2 validation, collateral used
 propTxOutWhenPhase2ValidationFails :: Property
 propTxOutWhenPhase2ValidationFails = property $ do
-  C.AnyCardanoEra (era :: C.CardanoEra era) <- forAll $
-    Gen.enum (C.AnyCardanoEra C.AlonzoEra) maxBound
-  (C.Tx (C.TxBody txBodyContent@C.TxBodyContent {..}) _) <- forAll $ CGen.genTx era
+  (C.Tx (C.TxBody txBodyContent@C.TxBodyContent {..}) _) <- forAll genTx
   let computedTxOuts = Utxo.getTxOutFromTxBodyContent txBodyContent
   case txReturnCollateral of
     C.TxReturnCollateralNone -> Hedgehog.success -- nothing to do here

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Marconi.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Marconi.hs
@@ -30,9 +30,8 @@ import Data.Map (elems)
 import Data.Set qualified as Set
 import Ledger.Address (CardanoAddress)
 import Ledger.Tx (CardanoTx (CardanoTx))
-import Marconi.ChainIndex.Indexers.Utxo (StorableEvent (UtxoEvent), StorableQuery (UtxoAddress, UtxoByAddress),
-                                         UtxoHandle, getInputs, getInputsFromTx, getUtxoResult, getUtxos, txId, txIx,
-                                         urUtxo)
+import Marconi.ChainIndex.Indexers.Utxo (StorableEvent (UtxoEvent), StorableQuery (UtxoByAddress), UtxoHandle,
+                                         getInputsFromTx, getUtxoResult, getUtxos, txId, txIx, urUtxo)
 import Marconi.Core.Storable (HasPoint, QueryInterval (QEverything), Queryable, State, StorableMonad, StorablePoint,
                               StorableResult, insertMany, query)
 import Plutus.ChainIndex.Api (UtxosResponse (UtxosResponse))

--- a/plutus-chain-index-core/src/Plutus/ChainIndex/Marconi.hs
+++ b/plutus-chain-index-core/src/Plutus/ChainIndex/Marconi.hs
@@ -30,8 +30,9 @@ import Data.Map (elems)
 import Data.Set qualified as Set
 import Ledger.Address (CardanoAddress)
 import Ledger.Tx (CardanoTx (CardanoTx))
-import Marconi.ChainIndex.Indexers.Utxo (StorableEvent (UtxoEvent), StorableQuery (UtxoByAddress), UtxoHandle,
-                                         getInputs, getUtxoResult, getUtxos, txId, txIx, urUtxo)
+import Marconi.ChainIndex.Indexers.Utxo (StorableEvent (UtxoEvent), StorableQuery (UtxoAddress, UtxoByAddress),
+                                         UtxoHandle, getInputs, getInputsFromTx, getUtxoResult, getUtxos, txId, txIx,
+                                         urUtxo)
 import Marconi.Core.Storable (HasPoint, QueryInterval (QEverything), Queryable, State, StorableMonad, StorablePoint,
                               StorableResult, insertMany, query)
 import Plutus.ChainIndex.Api (UtxosResponse (UtxosResponse))
@@ -140,7 +141,7 @@ getUtxoEvents
   -> StorableEvent UtxoHandle -- ^ UtxoEvents are stored in storage after conversion to UtxoRow
 getUtxoEvents txs cp =
   let utxosFromCardanoTx (CardanoTx c _) = elems $ getUtxos Nothing c
-      inputsFromCardanoTx (CardanoTx c _) = getInputs c
+      inputsFromCardanoTx (CardanoTx c _) = getInputsFromTx c
       utxos = Set.fromList $ concatMap utxosFromCardanoTx txs
       ins = foldl' Set.union Set.empty $ inputsFromCardanoTx <$> txs
   in UtxoEvent utxos ins cp


### PR DESCRIPTION
This PR is to fix the collateral processing of UTXO per [PLT-656].  There are three commits in the PR:

1. Commit-1 adds property tests for : 
    - return collateral
    - phase-2 validation failure  
    - minor refactoring of the Indexser.Utxo module to support TDD 
    We expect both these tests to fail in this commit

2.  Fixes to the Indexers.Utxo to get the above tests pass
3. Removes the SQL `Unique` constraint, and replace `INSERT OR REPLACE` with `INSERT` for the spent and unspent_transactions


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested


[PLT-656]: https://input-output.atlassian.net/browse/PLT-656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ