### PR TITLE
Temporarily move script-evaluation-dump to plutus-runner

### DIFF
--- a/.github/workflows/script-evaluation-dump.yml
+++ b/.github/workflows/script-evaluation-dump.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   script-evaluation-dump:
-    runs-on: [ubuntu-latest]
+    runs-on: [self-hosted, plutus-benchmark]
     timeout-minutes: 360
 
     steps:


### PR DESCRIPTION
The latest run of script-evaluation-dump.yaml halted after 4h48m with "no space left on device".
https://github.com/input-output-hk/plutus-apps/actions/runs/4888531941
We must have hit the disk space limit for free GH runners.
Let's see if the workflow completes on a dedicated runner (plutus-benchmark).