### PR TITLE
Deactive combined-haddock CI job in darwin

### DIFF
--- a/__std__/cells/automation/hydra-jobs.nix
+++ b/__std__/cells/automation/hydra-jobs.nix
@@ -31,7 +31,10 @@ let
     pkgs.lib.optionalAttrs (system == "x86_64-linux") { mingwW64 = windows-plutus-apps-jobs; } //
     # Devcontainer is only available on linux
     pkgs.lib.optionalAttrs (system == "x86_64-linux") inputs.cells.plutus-apps.devcontainer //
-    other-jobs;
+    # Because of lack of resources in our darwin CI cluster, the "combined-plutus-apps-haddock" job
+    # often gets timed out, which of course makes the required darwin CI checks fail. In the end, we
+    # just remove it from the required darwin jobs, but still keep it in the linux jobs.
+    pkgs.lib.filterAttrsRecursive (n: _: pkgs.system != "x86_64-darwin" || n != "combined-plutus-apps-haddock") other-jobs;
 
   # Hydra doesn't like these attributes hanging around in "jobsets": it thinks they're jobs!
   filtered-jobs = pkgs.lib.filterAttrsRecursive (n: _: n != "recurseForDerivations") jobs;


### PR DESCRIPTION
Remove the `combined-plutus-apps-haddock` in darwin CI jobs, but still keep it in the linux CI jobs. It often gets timed out in darwin because of how large this job is. Plus, it's not really necessary to check this in darwin (linux suffices).

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
