### PR TITLE
fix ex-units violation in contract-models tutorial

### DIFF
--- a/doc/plutus/tutorials/contract-models.rst
+++ b/doc/plutus/tutorials/contract-models.rst
@@ -325,7 +325,9 @@ Running tests and debugging the model
 
 We are finally ready to run some tests! We do still need to define a
 *property* that we can call QuickCheck with, but the :hsobj:`Plutus.Contract.Test.ContractModel.Interface.ContractModel`
-framework provides a standard one that we can just reuse. So we define
+framework provides a standard one that we can just reuse. To run the
+test successfully, we must increase the budget of the emulator, so
+we define
 
 .. literalinclude:: Escrow.hs
    :start-after: START prop_Escrow

--- a/plutus-use-cases/test/Spec/Tutorial/Escrow1.hs
+++ b/plutus-use-cases/test/Spec/Tutorial/Escrow1.hs
@@ -106,7 +106,9 @@ testWallets :: [Wallet]
 testWallets = [w1, w2, w3, w4, w5]
 
 prop_Escrow :: Actions EscrowModel -> Property
-prop_Escrow = propRunActions_
+prop_Escrow = propRunActionsWithOptions options defaultCoverageOptions (\ _ -> pure True)
+  where
+    options = defaultCheckOptionsContractModel & increaseTransactionLimits
 
 escrowParams :: EscrowParams d
 escrowParams =


### PR DESCRIPTION
Quick fix for the contract models tutorial. Prior to this, the property test would exceed ex-units and fail.

-----

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Important changes are reflected in changelog.d of the affected packages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reference the ADR in the PR and reference the PR in the ADR (if revelant)
    - [ ] Reviewer requested
