### PR TITLE
Update link to generated Haddock in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,7 +63,7 @@ Run `nix develop` to enter the development shell and you will be presented with 
 The main documentation is located https://plutus-apps.readthedocs.io/en/latest/[here].
 
 The generated Haskell API documentation (haddocks) are here:
-<https://input-output-hk.github.io/plutus-apps/main/>.
+<https://intersectmbo.github.io/plutus-apps/main/>.
 
 
 === Talks


### PR DESCRIPTION
This updates the link in the README to the generated Haddock documentation. The current link is dead.
